### PR TITLE
NTBS-438: Display empty space on Overview page when value doesn't exist

### DIFF
--- a/ntbs-service/Models/ContactTracing.cs
+++ b/ntbs-service/Models/ContactTracing.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Validations;
 
@@ -43,5 +44,22 @@ namespace ntbs_service.Models
 
         [PositiveIntegerSmallerThanValue("ChildrenStartedTreatment", ErrorMessage = ValidationMessages.ContactTracingChildrenFinishedTreatment)]
         public int? ChildrenFinishedTreatment { get; set; }
+
+
+        public int TotalContactsIdentified => CalculateSum(AdultsIdentified, ChildrenIdentified);
+
+        public int TotalContactsScreened => CalculateSum(AdultsScreened, ChildrenScreened);
+
+        public int TotalContactsActiveTB => CalculateSum(AdultsActiveTB, ChildrenActiveTB);
+
+        public int TotalContactsLatentTB => CalculateSum(AdultsLatentTB, ChildrenLatentTB);
+
+        public int TotalContactsStartedTreatment => CalculateSum(AdultsStartedTreatment, ChildrenStartedTreatment);
+
+        public int TotalContactsFinishedTreatment => CalculateSum(AdultsFinishedTreatment, ChildrenFinishedTreatment);
+
+        private int CalculateSum(int? x, int? y) {
+            return (x ?? 0) + (y ?? 0);
+        }
     }
 }

--- a/ntbs-service/Models/Notification.cs
+++ b/ntbs-service/Models/Notification.cs
@@ -72,12 +72,6 @@ namespace ntbs_service.Models
         public string FormattedDob => FormatDate(PatientDetails.Dob);
         [Display(Name = "Date created")]
         public string FormattedCreationDate => FormatDate(CreationDate);
-        public int? TotalContactsIdentified => CalculateSum(ContactTracing.AdultsIdentified, ContactTracing.ChildrenIdentified);
-        public int? TotalContactsScreened => CalculateSum(ContactTracing.AdultsScreened, ContactTracing.ChildrenScreened);
-        public int? TotalContactsActiveTB => CalculateSum(ContactTracing.AdultsActiveTB, ContactTracing.ChildrenActiveTB);
-        public int? TotalContactsLatentTB => CalculateSum(ContactTracing.AdultsLatentTB, ContactTracing.ChildrenLatentTB);
-        public int? TotalContactsStartedTreatment => CalculateSum(ContactTracing.AdultsStartedTreatment, ContactTracing.ChildrenStartedTreatment);
-        public int? TotalContactsFinishedTreatment => CalculateSum(ContactTracing.AdultsFinishedTreatment, ContactTracing.ChildrenFinishedTreatment);
 
         private string GetNotificationStatusString()
         {
@@ -91,14 +85,6 @@ namespace ntbs_service.Models
             {
                 return "Denotified";
             }
-        }
-
-        private int? CalculateSum(int? x, int? y) {
-            if (x == null && y == null) 
-            {
-                return null;
-            }
-            return x ?? 0 + y ?? 0;
         }
 
         private string FormatDate(DateTime? date)

--- a/ntbs-service/Models/Notification.cs
+++ b/ntbs-service/Models/Notification.cs
@@ -94,7 +94,11 @@ namespace ntbs_service.Models
         }
 
         private int? CalculateSum(int? x, int? y) {
-            return x + y;
+            if (x == null && y == null) 
+            {
+                return null;
+            }
+            return x ?? 0 + y ?? 0;
         }
 
         private string FormatDate(DateTime? date)

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -24,10 +24,10 @@ namespace ntbs_service.Models.Validations
         public const string PositiveNumbersOnly = "Please enter a positive value";
         public const string ContactTracingAdultsScreened = "Must be smaller or equal to the number of adults identified";
         public const string ContactTracingChildrenScreened = "Must be smaller or equal to the number of children identified";
-        public const string ContactTracingAdultsLatentTB = "Must be smaller or equal to than number of adults screened minus those with latent TB";
-        public const string ContactTracingChildrenLatentTB = "Must be smaller or equal to than number of children screened minus those with latent TB";
-        public const string ContactTracingAdultsActiveTB = "Must be smaller or equal to than number of adults screened minus those with active TB";
-        public const string ContactTracingChildrenActiveTB = "Must be smaller or equal to than number of children screened minus those with active TB";
+        public const string ContactTracingAdultsLatentTB = "Must be smaller or equal to than number of adults screened minus those with active TB";
+        public const string ContactTracingChildrenLatentTB = "Must be smaller or equal to than number of children screened minus those with active TB";
+        public const string ContactTracingAdultsActiveTB = "Must be smaller or equal to than number of adults screened minus those with latent TB";
+        public const string ContactTracingChildrenActiveTB = "Must be smaller or equal to than number of children screened minus those with laten TB";
         public const string ContactTracingAdultStartedTreatment = "Must be smaller or equal to number of adults with latent TB";
         public const string ContactTracingChildrenStartedTreatment = "Must be smaller or equal to number of children with latent TB";
         public const string ContactTracingAdultsFinishedTreatment = "Must be smaller or equal to number of adults the started treatment";

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -27,7 +27,7 @@ namespace ntbs_service.Models.Validations
         public const string ContactTracingAdultsLatentTB = "Must be smaller or equal to than number of adults screened minus those with active TB";
         public const string ContactTracingChildrenLatentTB = "Must be smaller or equal to than number of children screened minus those with active TB";
         public const string ContactTracingAdultsActiveTB = "Must be smaller or equal to than number of adults screened minus those with latent TB";
-        public const string ContactTracingChildrenActiveTB = "Must be smaller or equal to than number of children screened minus those with laten TB";
+        public const string ContactTracingChildrenActiveTB = "Must be smaller or equal to than number of children screened minus those with latent TB";
         public const string ContactTracingAdultStartedTreatment = "Must be smaller or equal to number of adults with latent TB";
         public const string ContactTracingChildrenStartedTreatment = "Must be smaller or equal to number of children with latent TB";
         public const string ContactTracingAdultsFinishedTreatment = "Must be smaller or equal to number of adults the started treatment";

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml
@@ -43,7 +43,7 @@ ViewData["Title"] = "Notification - Contact Tracing";
             <div class="double-fixed-width-separator"> </div>
             <div>
                 <div class="nhsuk-label"> Total </div> 
-                <div class="nhsuk-label top-margin-separator" ref="totalContactsIdentified"> 0 </div>
+                <div class="nhsuk-label top-margin-separator" ref="totalContactsIdentified"> @Model.ContactTracing.TotalContactsIdentified </div>
             </div>
             </div>
 
@@ -77,7 +77,7 @@ ViewData["Title"] = "Notification - Contact Tracing";
             <div class="double-fixed-width-separator"> </div>
             <div>
                 <div class="nhsuk-label"> Total </div> 
-                <div class="nhsuk-label top-margin-separator" ref="totalContactsScreened"> 0 </div>
+                <div class="nhsuk-label top-margin-separator" ref="totalContactsScreened"> @Model.ContactTracing.TotalContactsScreened </div>
             </div>
         </div>
 
@@ -111,7 +111,7 @@ ViewData["Title"] = "Notification - Contact Tracing";
             <div class="double-fixed-width-separator"> </div>
             <div>
                 <div class="nhsuk-label"> Total </div> 
-                <div class="nhsuk-label top-margin-separator" ref="totalContactsActiveTB"> 0 </div>
+                <div class="nhsuk-label top-margin-separator" ref="totalContactsActiveTB"> @Model.ContactTracing.TotalContactsActiveTB </div>
             </div>
         </div>
 
@@ -145,7 +145,7 @@ ViewData["Title"] = "Notification - Contact Tracing";
             <div class="double-fixed-width-separator"> </div>
             <div>
                 <div class="nhsuk-label"> Total </div> 
-                <div class="nhsuk-label top-margin-separator" ref="totalContactsLatentTB"> 0 </div>
+                <div class="nhsuk-label top-margin-separator" ref="totalContactsLatentTB"> @Model.ContactTracing.TotalContactsLatentTB </div>
             </div>
         </div>
 
@@ -179,7 +179,7 @@ ViewData["Title"] = "Notification - Contact Tracing";
             <div class="double-fixed-width-separator"> </div>
             <div>
                 <div class="nhsuk-label"> Total </div> 
-                <div class="nhsuk-label top-margin-separator" ref="totalContactsStartedTreatment"> 0 </div>
+                <div class="nhsuk-label top-margin-separator" ref="totalContactsStartedTreatment"> @Model.ContactTracing.TotalContactsStartedTreatment </div>
             </div>
         </div>
 
@@ -213,7 +213,7 @@ ViewData["Title"] = "Notification - Contact Tracing";
             <div class="double-fixed-width-separator"> </div>
             <div>
                 <div class="nhsuk-label"> Total </div> 
-                <div class="nhsuk-label top-margin-separator" ref="totalContactsFinishedTreatment"> 0 </div>
+                <div class="nhsuk-label top-margin-separator" ref="totalContactsFinishedTreatment"> @Model.ContactTracing.TotalContactsFinishedTreatment </div>
             </div>
         </div>
         </nhs-fieldset>

--- a/ntbs-service/Pages/Notifications/Overview.cshtml
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml
@@ -13,7 +13,7 @@
 
 <partial name="./OverviewPartials/_ClinicalDetailsOverviewPartial" model="@Model">
 
-<partial name="./OverviewPartials/_ContactTracingOverviewPartial" model="@Model">
+<partial name="./OverviewPartials/_ContactTracingOverviewPartial" for="Notification.ContactTracing">
 
 <partial name="./OverviewPartials/_SocialRiskFactorsOverviewPartial" model="@Model">
 

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
@@ -1,7 +1,9 @@
+@model ntbs_service.Models.ContactTracing
+
 @{
     var notificationId = ViewData["NotificationId"];
-    string emptySpace = "&nbsp;";
 }
+
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Contact tracing </h3>
     <a href="./Edit/ContactTracing?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
@@ -10,46 +12,55 @@
     <nhs-grid-row classes="notification-overview-details">
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Number of contacts identified for screening </div>
-            <div class="contact-tracing-values">
-                <div>
-                    <div> Adults  </div>
-                    <div> Children  </div>
-                    <div> Total  </div>
+            <div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Adults  </span>
+                    <span class="contact-tracing-value"> @(Model.AdultsIdentified)</span>
                 </div>
-                <div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsIdentified ?? Html.Raw(emptySpace))</div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenIdentified ?? Html.Raw(emptySpace))</div>
-                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsIdentified ?? Html.Raw(emptySpace)) </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Children  </span>
+                    <span class="contact-tracing-value"> @(Model.ChildrenIdentified)</span>
+
+                </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Total  </span>
+                    <span class="contact-tracing-value"> @(Model.TotalContactsIdentified) </span>
                 </div>
             </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Number of contacts screened for TB </div>
-            <div class="contact-tracing-values">
-                <div>
-                    <div> Adults  </div>
-                    <div> Children  </div>
-                    <div> Total  </div>
+            <div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Adults  </span>
+                    <span class="contact-tracing-value"> @(Model.AdultsScreened)</span>
                 </div>
-                <div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsScreened ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenScreened ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsScreened ?? Html.Raw(emptySpace)) </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Children  </span>
+                    <span class="contact-tracing-value"> @(Model.ChildrenScreened)</span>
+
+                </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Total  </span>
+                    <span class="contact-tracing-value"> @(Model.TotalContactsScreened) </span>
                 </div>
             </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Number of contacts with active TB </div>
-            <div class="contact-tracing-values">
-                <div>
-                    <div> Adults  </div>
-                    <div> Children  </div>
-                    <div> Total  </div>
+            <div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Adults  </span>
+                    <span class="contact-tracing-value"> @(Model.AdultsActiveTB)</span>
                 </div>
-                <div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsActiveTB ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenActiveTB ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsActiveTB ?? Html.Raw(emptySpace)) </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Children  </span>
+                    <span class="contact-tracing-value"> @(Model.ChildrenActiveTB)</span>
+
+                </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Total  </span>
+                    <span class="contact-tracing-value"> @(Model.TotalContactsActiveTB) </span>
                 </div>
             </div>
         </nhs-grid-column>
@@ -57,46 +68,55 @@
     <nhs-grid-row classes="notification-overview-details">
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Number of contacts with latent TB </div>
-            <div class="contact-tracing-values">
-                <div>
-                    <div> Adults  </div>
-                    <div> Children  </div>
-                    <div> Total  </div>
+            <div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Adults  </span>
+                    <span class="contact-tracing-value"> @(Model.AdultsLatentTB)</span>
                 </div>
-                <div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsLatentTB ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenLatentTB ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsLatentTB ?? Html.Raw(emptySpace)) </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Children  </span>
+                    <span class="contact-tracing-value"> @(Model.ChildrenLatentTB)</span>
+
+                </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Total  </span>
+                    <span class="contact-tracing-value"> @(Model.TotalContactsLatentTB) </span>
                 </div>
             </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Number of contacts that have started treatment for latent TB </div>
-            <div class="contact-tracing-values">
-                <div>
-                    <div> Adults  </div>
-                    <div> Children  </div>
-                    <div> Total  </div>
+            <div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Adults  </span>
+                    <span class="contact-tracing-value"> @(Model.AdultsStartedTreatment)</span>
                 </div>
-                <div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsStartedTreatment ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenStartedTreatment ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsStartedTreatment ?? Html.Raw(emptySpace)) </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Children  </span>
+                    <span class="contact-tracing-value"> @(Model.ChildrenStartedTreatment)</span>
+
+                </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Total  </span>
+                    <span class="contact-tracing-value"> @(Model.TotalContactsStartedTreatment) </span>
                 </div>
             </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Number of contacts that have completed treatment for latent TB </div>
-            <div class="contact-tracing-values">
-                <div>
-                    <div> Adults  </div>
-                    <div> Children  </div>
-                    <div> Total  </div>
+            <div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Adults  </span>
+                    <span class="contact-tracing-value"> @(Model.AdultsFinishedTreatment)</span>
                 </div>
-                <div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsFinishedTreatment ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenFinishedTreatment ?? Html.Raw(emptySpace)) </div>
-                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsFinishedTreatment ?? Html.Raw(emptySpace)) </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Children  </span>
+                    <span class="contact-tracing-value"> @(Model.ChildrenFinishedTreatment)</span>
+
+                </div>
+                <div class="contact-tracing-row">
+                    <span class="contact-tracing-label"> Total  </span>
+                    <span class="contact-tracing-value"> @(Model.TotalContactsStartedTreatment) </span>
                 </div>
             </div>
         </nhs-grid-column>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
@@ -1,7 +1,7 @@
 @{
     var notificationId = ViewData["NotificationId"];
+    string emptySpace = "&nbsp;";
 }
-
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Contact tracing </h3>
     <a href="./Edit/ContactTracing?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
@@ -17,9 +17,9 @@
                     <div> Total  </div>
                 </div>
                 <div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.AdultsIdentified </div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.ChildrenIdentified </div>
-                    <div class="contact-tracing-value"> @Model.Notification.TotalContactsIdentified </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsIdentified ?? Html.Raw(emptySpace))</div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenIdentified ?? Html.Raw(emptySpace))</div>
+                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsIdentified ?? Html.Raw(emptySpace)) </div>
                 </div>
             </div>
         </nhs-grid-column>
@@ -32,9 +32,9 @@
                     <div> Total  </div>
                 </div>
                 <div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.AdultsScreened </div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.ChildrenScreened </div>
-                    <div class="contact-tracing-value"> @Model.Notification.TotalContactsScreened </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsScreened ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenScreened ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsScreened ?? Html.Raw(emptySpace)) </div>
                 </div>
             </div>
         </nhs-grid-column>
@@ -47,9 +47,9 @@
                     <div> Total  </div>
                 </div>
                 <div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.AdultsActiveTB </div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.ChildrenActiveTB </div>
-                    <div class="contact-tracing-value"> @Model.Notification.TotalContactsActiveTB </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsActiveTB ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenActiveTB ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsActiveTB ?? Html.Raw(emptySpace)) </div>
                 </div>
             </div>
         </nhs-grid-column>
@@ -64,9 +64,9 @@
                     <div> Total  </div>
                 </div>
                 <div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.AdultsLatentTB </div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.ChildrenLatentTB </div>
-                    <div class="contact-tracing-value"> @Model.Notification.TotalContactsLatentTB </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsLatentTB ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenLatentTB ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsLatentTB ?? Html.Raw(emptySpace)) </div>
                 </div>
             </div>
         </nhs-grid-column>
@@ -79,9 +79,9 @@
                     <div> Total  </div>
                 </div>
                 <div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.AdultsStartedTreatment </div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.ChildrenStartedTreatment </div>
-                    <div class="contact-tracing-value"> @Model.Notification.TotalContactsStartedTreatment </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsStartedTreatment ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenStartedTreatment ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsStartedTreatment ?? Html.Raw(emptySpace)) </div>
                 </div>
             </div>
         </nhs-grid-column>
@@ -94,9 +94,9 @@
                     <div> Total  </div>
                 </div>
                 <div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.AdultsFinishedTreatment </div>
-                    <div class="contact-tracing-value"> @Model.Notification.ContactTracing.ChildrenFinishedTreatment </div>
-                    <div class="contact-tracing-value"> @Model.Notification.TotalContactsFinishedTreatment </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.AdultsFinishedTreatment ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.ContactTracing.ChildrenFinishedTreatment ?? Html.Raw(emptySpace)) </div>
+                    <div class="contact-tracing-value"> @(Model.Notification.TotalContactsFinishedTreatment ?? Html.Raw(emptySpace)) </div>
                 </div>
             </div>
         </nhs-grid-column>

--- a/ntbs-service/wwwroot/css/notificationView.scss
+++ b/ntbs-service/wwwroot/css/notificationView.scss
@@ -19,12 +19,17 @@
     padding-bottom: 10px;
 }
 
-.contact-tracing-values {
-    display: flex;
+.contact-tracing-row {
+    display: table-row
 }
 
 .contact-tracing-value {
     padding-left: 20px;
+    display: table-cell
+}
+
+.contact-tracing-label {
+    display: table-cell
 }
 
 .notification-details-label {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

Display empty space on Overview page when value doesn't exist

## Description
<!--- High level changes overview -->
Overview page was omitting empty values and therefore shifting some values. Fixed the bug by displaying empty space.
Also overview page was not displaying Total when one of the values is missing

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
- [x] Test functionality without javascript
- [x] Test in small window (immitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader - logical flow, no unexpected content
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
