### PR TITLE
Fix search ordering

### DIFF
--- a/ntbs-service-unit-tests/Pages/SearchPageTest.cs
+++ b/ntbs-service-unit-tests/Pages/SearchPageTest.cs
@@ -46,7 +46,7 @@ namespace ntbs_service_unit_tests.Pages
 
             mockNotificationService.Setup(s => s.GetBaseQueryableNotificationByStatus(It.IsAny<List<NotificationStatus>>())).Returns(new List<Notification> { new Notification() {NotificationId = 1}}.AsQueryable());
             
-            var unionAndPaginateResult = Task.FromResult(new Tuple<IList<int>, int>(new List<int>() {1, 2}, 1)); 
+            var unionAndPaginateResult = Task.FromResult(GetNotificationIdsAndCount()); 
             mockSearchService.Setup(s => s.OrderAndPaginateQueryables(It.IsAny<IQueryable<Notification>>(), It.IsAny<IQueryable<Notification>>(), 
                 It.IsAny<PaginationParameters>())).Returns(unionAndPaginateResult);
 
@@ -72,6 +72,11 @@ namespace ntbs_service_unit_tests.Pages
             Assert.True(results.Count == 2);
             Assert.Equal("Bob", results[0].Name);
             Assert.Equal("Ross", results[1].Name);
+        }
+
+        public (IList<int> notificationIds, int count) GetNotificationIdsAndCount()
+        {
+            return (notificationIds: new List<int>() {1, 2}, count: 1);
         }
 
         public IEnumerable<Notification> GetNotifications()

--- a/ntbs-service-unit-tests/Pages/SearchPageTest.cs
+++ b/ntbs-service-unit-tests/Pages/SearchPageTest.cs
@@ -46,7 +46,7 @@ namespace ntbs_service_unit_tests.Pages
 
             mockNotificationService.Setup(s => s.GetBaseQueryableNotificationByStatus(It.IsAny<List<NotificationStatus>>())).Returns(new List<Notification> { new Notification() {NotificationId = 1}}.AsQueryable());
             
-            var unionAndPaginateResult = Task.FromResult(new Tuple<IList<int>, int>(new List<int>() {1}, 1)); 
+            var unionAndPaginateResult = Task.FromResult(new Tuple<IList<int>, int>(new List<int>() {1, 2}, 1)); 
             mockSearchService.Setup(s => s.OrderAndPaginateQueryables(It.IsAny<IQueryable<Notification>>(), It.IsAny<IQueryable<Notification>>(), 
                 It.IsAny<PaginationParameters>())).Returns(unionAndPaginateResult);
 
@@ -59,7 +59,7 @@ namespace ntbs_service_unit_tests.Pages
             var pageContext = new PageContext(actionContext) {};
 
             var pageModel = new IndexModel(mockNotificationService.Object, mockSearchService.Object, mockContext.Object) {
-                SearchParameters = new SearchParameters() {IdFilter = "1"},
+                SearchParameters = new SearchParameters(),
                 PageContext = pageContext
             };
 
@@ -72,10 +72,6 @@ namespace ntbs_service_unit_tests.Pages
             Assert.True(results.Count == 2);
             Assert.Equal("Bob", results[0].Name);
             Assert.Equal("Ross", results[1].Name);
-        }
-
-        public IList<int> GetNotificationIds() {
-            return new List<int>() {1, 2};
         }
 
         public IEnumerable<Notification> GetNotifications()

--- a/ntbs-service-unit-tests/Pages/SearchPageTest.cs
+++ b/ntbs-service-unit-tests/Pages/SearchPageTest.cs
@@ -47,7 +47,7 @@ namespace ntbs_service_unit_tests.Pages
             mockNotificationService.Setup(s => s.GetBaseQueryableNotificationByStatus(It.IsAny<List<NotificationStatus>>())).Returns(new List<Notification> { new Notification() {NotificationId = 1}}.AsQueryable());
             
             var unionAndPaginateResult = Task.FromResult(new Tuple<IList<int>, int>(new List<int>() {1}, 1)); 
-            mockSearchService.Setup(s => s.UnionAndPaginateQueryables(It.IsAny<IQueryable<Notification>>(), It.IsAny<IQueryable<Notification>>(), 
+            mockSearchService.Setup(s => s.OrderAndPaginateQueryables(It.IsAny<IQueryable<Notification>>(), It.IsAny<IQueryable<Notification>>(), 
                 It.IsAny<PaginationParameters>())).Returns(unionAndPaginateResult);
 
             var notifications = Task.FromResult(GetNotifications());

--- a/ntbs-service/Pages/Search/Index.cshtml.cs
+++ b/ntbs-service/Pages/Search/Index.cshtml.cs
@@ -90,9 +90,9 @@ namespace ntbs_service.Pages_Search
                 .FilterByTBService(SearchParameters.TBServiceCode)
                 .GetResult();
 
-            Tuple<IList<int>, int> notificationIdsAndCount = await searchService.OrderAndPaginateQueryables(filteredDrafts, filteredNonDrafts, PaginationParameters);
-            var orderedNotificationIds = notificationIdsAndCount.Item1;
-            var count = notificationIdsAndCount.Item2;
+            var notificationIdsAndCount = await searchService.OrderAndPaginateQueryables(filteredDrafts, filteredNonDrafts, PaginationParameters);
+            var orderedNotificationIds = notificationIdsAndCount.notificationIds;
+            var count = notificationIdsAndCount.count;
             
             IEnumerable<Notification> notifications = await notificationService.GetNotificationsByIdAsync(orderedNotificationIds);
             var orderedNotifications = notifications.OrderBy(d => orderedNotificationIds.IndexOf(d.NotificationId)).ToList();

--- a/ntbs-service/Pages/Search/Index.cshtml.cs
+++ b/ntbs-service/Pages/Search/Index.cshtml.cs
@@ -90,12 +90,13 @@ namespace ntbs_service.Pages_Search
                 .FilterByTBService(SearchParameters.TBServiceCode)
                 .GetResult();
 
-            Tuple<IList<int>, int> notificationIdsAndCount = await searchService.UnionAndPaginateQueryables(filteredDrafts, filteredNonDrafts, PaginationParameters);
-            var notificationIds = notificationIdsAndCount.Item1;
+            Tuple<IList<int>, int> notificationIdsAndCount = await searchService.OrderAndPaginateQueryables(filteredDrafts, filteredNonDrafts, PaginationParameters);
+            var orderedNotificationIds = notificationIdsAndCount.Item1;
             var count = notificationIdsAndCount.Item2;
             
-            IEnumerable<Notification> notifications = await notificationService.GetNotificationsByIdAsync(notificationIds);
-            var notificationBannerModels = notifications.Select(NotificationBannerModel.WithLink);
+            IEnumerable<Notification> notifications = await notificationService.GetNotificationsByIdAsync(orderedNotificationIds);
+            var orderedNotifications = notifications.OrderBy(d => orderedNotificationIds.IndexOf(d.NotificationId)).ToList();
+            var notificationBannerModels = orderedNotifications.Select(NotificationBannerModel.WithLink);
             SearchResults = new PaginatedList<NotificationBannerModel>(notificationBannerModels, count, PaginationParameters);
 
             SetPaginationDetails();

--- a/ntbs-service/Services/SearchService.cs
+++ b/ntbs-service/Services/SearchService.cs
@@ -15,7 +15,7 @@ namespace ntbs_service.Services
         IQueryable<Notification> FilterById(IQueryable<Notification> IQ, string IdFilter);
         IQueryable<Notification> FilterBySex(IQueryable<Notification> IQ, int sexId);
         IQueryable<Notification> FilterByPartialDate(IQueryable<Notification> IQ, PartialDate partialDate);
-        Task<Tuple<IList<int>, int>> UnionAndPaginateQueryables(IQueryable<Notification> firstQueryable, 
+        Task<Tuple<IList<int>, int>> OrderAndPaginateQueryables(IQueryable<Notification> firstQueryable, 
             IQueryable<Notification> secondQueryable, PaginationParameters paginationParameters);
     }
 
@@ -40,7 +40,7 @@ namespace ntbs_service.Services
             return notifications.Where(s => s.PatientDetails.SexId.Equals(sexId));
         }
 
-        public async Task<Tuple<IList<int>, int>> UnionAndPaginateQueryables(IQueryable<Notification> firstQueryable, IQueryable<Notification> secondQueryable, 
+        public async Task<Tuple<IList<int>, int>> OrderAndPaginateQueryables(IQueryable<Notification> firstQueryable, IQueryable<Notification> secondQueryable, 
             PaginationParameters paginationParameters)
         {
             IQueryable<Notification> notificationIdsQueryable = OrderQueryableByNotificationDate(firstQueryable)

--- a/ntbs-service/Services/SearchService.cs
+++ b/ntbs-service/Services/SearchService.cs
@@ -15,7 +15,7 @@ namespace ntbs_service.Services
         IQueryable<Notification> FilterById(IQueryable<Notification> IQ, string IdFilter);
         IQueryable<Notification> FilterBySex(IQueryable<Notification> IQ, int sexId);
         IQueryable<Notification> FilterByPartialDate(IQueryable<Notification> IQ, PartialDate partialDate);
-        Task<Tuple<IList<int>, int>> OrderAndPaginateQueryables(IQueryable<Notification> firstQueryable, 
+        Task<(IList<int> notificationIds, int count)> OrderAndPaginateQueryables(IQueryable<Notification> firstQueryable, 
             IQueryable<Notification> secondQueryable, PaginationParameters paginationParameters);
     }
 
@@ -40,7 +40,7 @@ namespace ntbs_service.Services
             return notifications.Where(s => s.PatientDetails.SexId.Equals(sexId));
         }
 
-        public async Task<Tuple<IList<int>, int>> OrderAndPaginateQueryables(IQueryable<Notification> firstQueryable, IQueryable<Notification> secondQueryable, 
+        public async Task<(IList<int> notificationIds, int count)> OrderAndPaginateQueryables(IQueryable<Notification> firstQueryable, IQueryable<Notification> secondQueryable, 
             PaginationParameters paginationParameters)
         {
             IQueryable<Notification> notificationIdsQueryable = OrderQueryableByNotificationDate(firstQueryable)
@@ -48,7 +48,7 @@ namespace ntbs_service.Services
 
             var notificationIds = await GetPaginatedItemsAsync(notificationIdsQueryable.Select(n => n.NotificationId), paginationParameters);
             var count = await notificationIdsQueryable.CountAsync();
-            return new Tuple<IList<int>, int> (notificationIds, count);
+            return (notificationIds, count);
         }
 
         private IQueryable<Notification> OrderQueryableByNotificationDate(IQueryable<Notification> query) 


### PR DESCRIPTION
Fix search ordering to show draft notifications ordered by date first then notified/denotified notifications ordered by date