### PR TITLE
NTBS-190: Adjust validation approach for year of uk entry

### DIFF
--- a/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
@@ -100,9 +100,9 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Contains(ValidationMessages.BirthDateIsRequired, resultDocument.GetError("dob"));
             Assert.Equal(FullErrorMessage(ValidationMessages.NHSNumberIsRequired), resultDocument.GetError("nhs-number"));
             Assert.Equal(FullErrorMessage(ValidationMessages.PostcodeIsRequired), resultDocument.GetError("postcode"));
-            Assert.Equal(ValidationMessages.SexIsRequired, resultDocument.GetError("sex"));
-            Assert.Equal(ValidationMessages.EthnicGroupIsRequired, resultDocument.GetError("ethnicity"));
-            Assert.Equal(ValidationMessages.BirthCountryIsRequired, resultDocument.GetError("birth-country"));
+            Assert.Equal(FullErrorMessage(ValidationMessages.SexIsRequired), resultDocument.GetError("sex"));
+            Assert.Equal(FullErrorMessage(ValidationMessages.EthnicGroupIsRequired), resultDocument.GetError("ethnicity"));
+            Assert.Equal(FullErrorMessage(ValidationMessages.BirthCountryIsRequired), resultDocument.GetError("birth-country"));
         }
 
         [Fact]

--- a/ntbs-service/Models/PatientDetails.cs
+++ b/ntbs-service/Models/PatientDetails.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using ExpressiveAnnotations.Attributes;
 using Microsoft.EntityFrameworkCore;
@@ -53,12 +54,11 @@ namespace ntbs_service.Models
         public virtual Country Country { get; set; }
 
         [Range(1900, 2100, ErrorMessage = ValidationMessages.ValidYearRange)]
-        [AssertThat("ForeignBorn == true", ErrorMessage = ValidationMessages.YearOfUkEntryNotNeededIfDomesticOrUnknown)]
         [AssertThat("UkEntryAfterBirth == true", ErrorMessage = ValidationMessages.YearOfUkEntryMustBeAfterDob)]
         [AssertThat("UkEntryNotInFuture == true", ErrorMessage = ValidationMessages.YearOfUkEntryMustNotBeInFuture)]
+        [DisplayName("year of uk entry")]
         public int? YearOfUkEntry { get; set; }
 
-        public bool ForeignBorn => UkBorn == false;
         public bool UkEntryAfterBirth => !Dob.HasValue || YearOfUkEntry >= Dob.Value.Year;
         public bool UkEntryNotInFuture => YearOfUkEntry <= DateTime.Now.Year;
 

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -42,7 +42,6 @@ namespace ntbs_service.Models.Validations
         public const string BirthCountryIsRequired = "Country of Birth is a mandatory field";
         public const string PostcodeIsRequired = "Postcode is a mandatory field";
         public const string PostcodeIsNotValid = "Postcode is not valid";
-        public const string YearOfUkEntryNotNeededIfDomesticOrUnknown = "Year of entry to the uk is not required if birth country is the uk or unknown";
         public const string YearOfUkEntryMustBeAfterDob = "Year of entry to the uk must be after patient's date of birth.";
         public const string YearOfUkEntryMustNotBeInFuture = "Year of entry to the uk must be no later than this year.";
         #endregion

--- a/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
@@ -98,7 +98,7 @@
                 <nhs-fieldset-legend nhs-legend-size="Standard">
                     Sex (required)
                 </nhs-fieldset-legend>
-                <span class="nhsuk-error-message" id="sex-error" ref="errorField" asp-validation-for="Patient.SexId" has-error="@hasSexError"></span>
+                <span nhs-span-type="ErrorMessage" id="sex-error" ref="errorField" asp-validation-for="Patient.SexId" has-error="@hasSexError"></span>
                 <nhs-radios v-on:change="validate" nhs-radios-type="Standard">
                     @foreach (var sex in Model.Sexes)
                     {
@@ -123,7 +123,7 @@
             <label nhs-label-type="Standard" asp-for="Patient.EthnicityId">
                 Ethnic group (required)
             </label>
-            <span class="nhsuk-error-message" id="ethnicity-error" ref="errorField"
+            <span nhs-span-type="ErrorMessage" id="ethnicity-error" ref="errorField"
                   asp-validation-for="Patient.EthnicityId" has-error="@hasEthnicityError"></span>
             <select v-on:change="validate" ref="selectField" nhs-select-type="@ethnicitySelectErrorState"
                     asp-for="Patient.EthnicityId" asp-items="Model.Ethnicities">

--- a/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
@@ -206,7 +206,7 @@
                         <label nhs-label-type="Standard" asp-for="Patient.CountryId">
                             Birth country (required)
                         </label>
-                        <span class="nhsuk-error-message" id="birth-country-error"
+                        <span nhs-span-type="ErrorMessage" id="birth-country-error"
                               ref="errorField" asp-validation-for="Patient.CountryId" has-error="@hasCountryError"></span>
                         <select ref="selectField" v-on:change="validate" nhs-select-type="@countrySelectErrorState"
                                 asp-for="Patient.CountryId" asp-items="Model.Countries"

--- a/ntbs-service/Pages/Notifications/Edit/Patient.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Patient.cshtml.cs
@@ -71,7 +71,6 @@ namespace ntbs_service.Pages.Notifications.Edit
             // on changes made in UpdatePatientFlags
             ModelState.ClearValidationState("Patient.Postcode");
             ModelState.ClearValidationState("Patient.NHSNumber");
-            ModelState.ClearValidationState("Patient.YearOfUkEntry");
 
             Patient.SetFullValidation(Notification.NotificationStatus);
             await FindAndSetPostcodeAsync();


### PR DESCRIPTION
## Description
Issues in the intersection between having an `int?` field, and the field requiring data not available during post...

The thoroughly discussed workaround is to strip out values that don't match the validation requirement, thus rendering the validation moot. Added benefit of this option is to allow default validation to exist (no requirement to `clearValidationState`) so a 'fish' input can receive a validation message.

Sneaky change to add validation message tag-helper to some of the missing fields in Patient.cshtml.

## Checklist:
- [X] Automated tests are passing locally.
### Accessibility testing
- [X] Test functionality without javascript
- [X] Test in small window (immitating small screen)
- [X] Check the feature looks and works correctly in IE11
- [X] Zoom page to 400% - content still visible?
- [X] Test feature works with keyboard only operation
**Below not tested as this changeset is a superficial front-end change**
- [] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
