### PR TITLE
NTBS-130 default notification service to its creating users service

### DIFF
--- a/ntbs-integration-tests/Helpers/TestDocumentExtensions.cs
+++ b/ntbs-integration-tests/Helpers/TestDocumentExtensions.cs
@@ -1,5 +1,6 @@
 using AngleSharp.Html.Dom;
 using ntbs_service.Helpers;
+using Xunit;
 
 namespace ntbs_integration_tests.Helpers
 {
@@ -7,5 +8,12 @@ namespace ntbs_integration_tests.Helpers
     {
         public static string GetError(this IHtmlDocument document, string input) => 
             document?.QuerySelector($"span[id='{input}-error']")?.TextContent;
+            
+        public static void AssertErrorMessage(this IHtmlDocument resultDocument, string inputName, string expectedMessage)
+        {
+            var expected = HtmlDocumentHelpers.FullErrorMessage(expectedMessage);
+            var actual = resultDocument.GetError(inputName);
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/ntbs-integration-tests/Helpers/TestDocumentHelpers.cs
+++ b/ntbs-integration-tests/Helpers/TestDocumentHelpers.cs
@@ -1,0 +1,14 @@
+using AngleSharp.Html.Dom;
+using ntbs_service.Helpers;
+using Xunit;
+
+namespace ntbs_integration_tests.Helpers
+{
+    public static class HtmlDocumentHelpers
+    {        
+        public static string FullErrorMessage(string validationMessage)
+        {
+            return $"Error:{validationMessage}";
+        }
+    }
+}

--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using ntbs_integration_tests.NotificationPages;
 using ntbs_service.Models;
@@ -16,10 +17,17 @@ namespace ntbs_integration_tests.Helpers
         public const int DENOTIFY_WITH_DESCRIPTION = 10;
         public const int DENOTIFY_NO_DESCRIPTION = 11;
 
+        // These IDs match actual reference data - see app db seeding 
+        public const string HOSPITAL_FLEETWOOD_HOSPITAL_ID = "1EE2B39A-428F-44C7-B4BB-000649636591";
+        public const string HOSPITAL_FLEET_HOSPITAL_ID = "f9454382-9fbd-4524-8b65-04c1b449469c";
+        public const string HOSPITAL_FAKE_ID = "f9454382-9fbd-4524-8b65-000000000000";
+        public const string TBSERVICE_ROYAL_DERBY_HOSPITAL_ID = "TBS0181";
+        public const string TBSERVICE_ROYAL_FREE_LONDON_TB_SERVICE_ID = "TBS0182";
+
         public static void SeedDatabase(NtbsContext context)
         {
             // General purpose entities extensively shared between tests
-            context.Notification.AddRange(GetSeedingNotifications(context));
+            context.Notification.AddRange(GetSeedingNotifications());
 
             // Entities required for specific test suites
             context.Notification.AddRange(DenotifyPageTests.GetSeedingNotifications());
@@ -27,7 +35,7 @@ namespace ntbs_integration_tests.Helpers
             context.SaveChanges();
         }
 
-        public static List<Notification> GetSeedingNotifications(NtbsContext context)
+        public static List<Notification> GetSeedingNotifications()
         {
             return new List<Notification>
             {

--- a/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
@@ -35,8 +35,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate),
-                        resultDocument.GetError("notification-date"));
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.ValidDate);
         }
 
         [Fact]
@@ -60,8 +59,8 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate)),
-                        resultDocument.GetError("notification-date"));
+            var expectedMessage = ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate);
+            resultDocument.AssertErrorMessage("notification-date", expectedMessage);
         }
 
         [Fact]
@@ -82,8 +81,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.NotificationDateIsRequired),
-                        resultDocument.GetError("notification-date"));
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.NotificationDateIsRequired);
         }
 
         [Fact]
@@ -107,8 +105,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate),
-                        resultDocument.GetError("notification-date"));
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.ValidDate);
         }
 
         [Fact]
@@ -132,8 +129,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate)),
-                        resultDocument.GetError("notification-date"));
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate));
         }
 
         [Fact]
@@ -154,10 +150,9 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.NotificationDateIsRequired),
-                        resultDocument.GetError("notification-date"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.TBServiceIsRequired), resultDocument.GetError("tb-service"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.HospitalIsRequired), resultDocument.GetError("hospital"));
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.NotificationDateIsRequired);
+            resultDocument.AssertErrorMessage("tb-service", ValidationMessages.TBServiceIsRequired);
+            resultDocument.AssertErrorMessage("hospital", ValidationMessages.HospitalIsRequired);
         }
 
         [Fact]
@@ -180,10 +175,8 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat),
-                        resultDocument.GetError("consultant"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat),
-                        resultDocument.GetError("case-manager"));
+            resultDocument.AssertErrorMessage("consultant", ValidationMessages.StandardStringFormat);
+            resultDocument.AssertErrorMessage("case-manager", ValidationMessages.StandardStringFormat);
         }
 
         [Fact]
@@ -233,9 +226,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            // TODO NTBS-130 Get error messages assertions commonised
-            Assert.Equal(FullErrorMessage(ValidationMessages.HospitalMustBelongToSelectedTbSerice),
-                        resultDocument.GetError("hospital"));
+            resultDocument.AssertErrorMessage("hospital", ValidationMessages.HospitalMustBelongToSelectedTbSerice);
         }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
-using AngleSharp.Html.Dom;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
 using ntbs_service.Models.Validations;
@@ -13,7 +12,7 @@ namespace ntbs_integration_tests.NotificationPages
     {
         protected override string PageRoute => Routes.Episode;
 
-        public EpisodesPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
+        public EpisodesPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
         [Fact]
         public async Task PostDraft_ReturnsWithNotificationDateInvalidError_IfNotificationDateIsNotDate()
@@ -36,7 +35,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate),
                         resultDocument.GetError("notification-date"));
         }
 
@@ -61,7 +60,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate)), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate)),
                         resultDocument.GetError("notification-date"));
         }
 
@@ -83,7 +82,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.NotificationDateIsRequired), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.NotificationDateIsRequired),
                         resultDocument.GetError("notification-date"));
         }
 
@@ -108,7 +107,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate),
                         resultDocument.GetError("notification-date"));
         }
 
@@ -133,7 +132,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate)), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.DateValidityRange(ValidDates.EarliestClinicalDate)),
                         resultDocument.GetError("notification-date"));
         }
 
@@ -155,11 +154,11 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.NotificationDateIsRequired), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.NotificationDateIsRequired),
                         resultDocument.GetError("notification-date"));
-            Assert.Equal(ValidationMessages.TBServiceIsRequired, resultDocument.GetError("tb-service"));
-            Assert.Equal(ValidationMessages.HospitalIsRequired, resultDocument.GetError("hospital"));
-        }        
+            Assert.Equal(FullErrorMessage(ValidationMessages.TBServiceIsRequired), resultDocument.GetError("tb-service"));
+            Assert.Equal(FullErrorMessage(ValidationMessages.HospitalIsRequired), resultDocument.GetError("hospital"));
+        }
 
         [Fact]
         public async Task PostNotified_ReturnsPageWithTextFieldInputError_IfTextIsInvalid()
@@ -181,9 +180,9 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat),
                         resultDocument.GetError("consultant"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat), 
+            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat),
                         resultDocument.GetError("case-manager"));
         }
 
@@ -197,8 +196,8 @@ namespace ntbs_integration_tests.NotificationPages
             var formData = new Dictionary<string, string>
             {
                 ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
-                ["Episode.HospitalId"] = "1EE2B39A-428F-44C7-B4BB-000649636591",
-                ["Episode.TBServiceCode"] = "TBS0181",
+                ["Episode.HospitalId"] = Utilities.HOSPITAL_FLEETWOOD_HOSPITAL_ID,
+                ["Episode.TBServiceCode"] = Utilities.TBSERVICE_ROYAL_DERBY_HOSPITAL_ID,
                 ["Episode.Consultant"] = "Consultant",
                 ["Episode.CaseManager"] = "CaseManager",
                 ["FormattedNotificationDate.Day"] = "1",
@@ -214,6 +213,29 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Equal(BuildEditRoute(Routes.ClinicalDetails, Utilities.DRAFT_ID), GetRedirectLocation(result));
         }
 
+        [Fact]
+        public async Task PostDraft_HospitalDoesNotMatchTbService_ReturnsValdationError()
+        {
+            // Arrange
+            var initialPage = await client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var document = await GetDocumentAsync(initialPage);
 
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
+                ["Episode.HospitalId"] = Utilities.HOSPITAL_FLEETWOOD_HOSPITAL_ID,
+                ["Episode.TBServiceCode"] = Utilities.TBSERVICE_ROYAL_FREE_LONDON_TB_SERVICE_ID,
+            };
+
+            // Act
+            var result = await SendPostFormWithData(document, formData);
+
+            // Assert
+            var resultDocument = await GetDocumentAsync(result);
+            result.EnsureSuccessStatusCode();
+            // TODO NTBS-130 Get error messages assertions commonised
+            Assert.Equal(FullErrorMessage(ValidationMessages.HospitalMustBelongToSelectedTbSerice),
+                        resultDocument.GetError("hospital"));
+        }
     }
 }

--- a/ntbs-integration-tests/TestRunnerBase.cs
+++ b/ntbs-integration-tests/TestRunnerBase.cs
@@ -55,7 +55,7 @@ namespace ntbs_integration_tests
 
         protected string FullErrorMessage(string validationMessage)
         {
-            return $"Error:{validationMessage}";
+            return HtmlDocumentHelpers.FullErrorMessage(validationMessage);
         }
 
         protected async Task<HttpResponseMessage> SendPostFormWithData(

--- a/ntbs-service/Models/Episode.cs
+++ b/ntbs-service/Models/Episode.cs
@@ -5,10 +5,10 @@ using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Validations;
 
 namespace ntbs_service.Models
-{    
+{
     [Owned]
     public class Episode : ModelBase
-    {        
+    {
         [MaxLength(200)]
         [RegularExpression(ValidationRegexes.CharacterValidation, ErrorMessage = ValidationMessages.StandardStringFormat)]
         public string Consultant { get; set; }
@@ -23,7 +23,10 @@ namespace ntbs_service.Models
         public virtual TBService TBService { get; set; }
 
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.HospitalIsRequired)]
+        [AssertThat(@"HospitalBelongsToTbService", ErrorMessage = ValidationMessages.HospitalMustBelongToSelectedTbSerice)]
         public Guid? HospitalId { get; set; }
         public virtual Hospital Hospital { get; set; }
+
+        public bool HospitalBelongsToTbService => Hospital?.TBService == TBService;
     }
 }

--- a/ntbs-service/Models/NtbsContext.cs
+++ b/ntbs-service/Models/NtbsContext.cs
@@ -60,16 +60,11 @@ namespace ntbs_service.Models
             return await TbService.ToListAsync();
         }
 
-        public virtual async Task<IList<Hospital>> GetAllHospitalsAsync()
-        {
-            return await Hospital.ToListAsync();
-        }
-
-        public virtual async Task<List<Hospital>> GetHospitalsByTbService(string tbServiceCode)
+        public virtual async Task<IList<Hospital>> GetHospitalsByTbServiceCodesAsync(IEnumerable<string> tbServices)
         {
             return await Hospital
-                        .Where(x => x.TBServiceCode == tbServiceCode)
-                        .ToListAsync();
+                .Where(h => tbServices.Contains(h.TBServiceCode))
+                .ToListAsync();
         }
 
         public virtual async Task<IList<Sex>> GetAllSexesAsync()

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 
 namespace ntbs_service.Models.Validations
 {
@@ -76,8 +76,10 @@ namespace ntbs_service.Models.Validations
         #region Hospital Details
         public const string TBServiceIsRequired = "TB Service is a mandatory field";
         public const string HospitalIsRequired = "Hospital is a mandatory field";
+        public const string HospitalMustBelongToSelectedTbSerice = "Hospital must belong to selected TB Service";
         public const string NotificationDateIsRequired = "Notification Date is a mandatory field";
         public const string NotificationDateShouldBeLaterThanDob = "Notification date must be later than date of birth";
+
         #endregion
         
         #region Travel History

--- a/ntbs-service/Pages/Notifications/Create.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Create.cshtml.cs
@@ -7,19 +7,18 @@ namespace ntbs_service.Pages_Notifications
 {
     public class CreateModel : PageModel
     {
-        private readonly INotificationService service;
+        private readonly INotificationService notificationService;
 
-        public CreateModel(INotificationService service)
+        public CreateModel(INotificationService notificationService)
         {
-            this.service = service;
+            this.notificationService = notificationService;
         }
 
         public async Task<IActionResult> OnGetAsync()
         {
-            var notification = await service.CreateNewNotificationForUser(User);
+            var notification = await notificationService.CreateNewNotificationForUser(User);
 
             return RedirectToPage("./Edit/Patient", new { id = notification.NotificationId });
         }
-
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
@@ -62,7 +62,7 @@
                 <label nhs-label-type="Standard" asp-for="Episode.TBServiceCode">
                     Notifying TB service (required)
                 </label>
-                <span class="nhsuk-error-message" id="tb-service-error"
+                <span nhs-span-type="ErrorMessage" id="tb-service-error" has-error="@TBServiceCodeError"
                       ref="errorFieldTBServiceCode" asp-validation-for="Episode.TBServiceCode"></span>
                 <select ref="selectFieldTBServiceCode" nhs-select-type="@TBServiceCodeSelectErrorState" asp-for="Episode.TBServiceCode"
                         asp-items="Model.TBServices" v-on:change="function (ev) {fetchHospitalList(ev); validate('TBServiceCode')(ev);}">
@@ -79,7 +79,7 @@
                 <label nhs-label-type="Standard" asp-for="Episode.HospitalId">
                     Hospital (required)
                 </label>
-                <span class="nhsuk-error-message" id="hospital-error"
+                <span nhs-span-type="ErrorMessage" id="hospital-error" has-error="@HospitalError"
                       ref="errorFieldHospitalId" asp-validation-for="Episode.HospitalId"></span>
                 <select ref="selectFieldHospitalId" nhs-select-type="@HospitalSelectErrorState" asp-for="Episode.HospitalId"
                         asp-items="Model.Hospitals" v-on:change="function(ev) { validate('HospitalId')(ev); }">

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
@@ -66,7 +66,6 @@
                       ref="errorFieldTBServiceCode" asp-validation-for="Episode.TBServiceCode"></span>
                 <select ref="selectFieldTBServiceCode" nhs-select-type="@TBServiceCodeSelectErrorState" asp-for="Episode.TBServiceCode"
                         asp-items="Model.TBServices" v-on:change="function (ev) {fetchHospitalList(ev); validate('TBServiceCode')(ev);}">
-                    <option value="" selected>Select TB Service</option>
                 </select>
             </nhs-form-group>
             <br />

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
@@ -102,13 +102,13 @@ namespace ntbs_service.Pages.Notifications.Edit
             Notification notification = await service.GetNotificationAsync(notificationId);
             return validationService.ValidateDate(notification, key, day, month, year);
         }
-        
+
         private void SetValuesForValidation()
         {
             Episode.SetFullValidation(Notification.NotificationStatus);
             validationService.TrySetAndValidateDateOnModel(Notification, nameof(Notification.NotificationDate), FormattedNotificationDate);
             /*
-            Binding only sets the entity ids, but not the actual entitie.
+            Binding only sets the entity ids, but not the actual entities.
             There's a validation rule that needs to check the relationship between the entities,
             therefore we need fetch the reference data from the db before validating
             */

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
@@ -11,7 +11,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace ntbs_service.Pages.Notifications.Edit
 {
-    
+
     public class EpisodeModel : NotificationEditModelBase
     {
         private readonly NtbsContext context;
@@ -21,14 +21,14 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         [BindProperty]
         public FormattedDate FormattedNotificationDate { get; set; }
-        
+
         [BindProperty]
         public Episode Episode { get; set; }
 
         public EpisodeModel(INotificationService service, IAuthorizationService authorizationService, NtbsContext context) : base(service, authorizationService)
         {
             this.context = context;
-            
+
             TBServices = new SelectList(context.GetAllTbServicesAsync().Result,
                                         nameof(TBService.Code),
                                         nameof(TBService.Name));
@@ -70,7 +70,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return RedirectToPage("./ClinicalDetails", new { id = notificationId, isBeingSubmitted });
         }
 
-        protected override async Task ValidateAndSave() 
+        protected override async Task ValidateAndSave()
         {
             Episode.SetFullValidation(Notification.NotificationStatus);
             validationService.TrySetAndValidateDateOnModel(Notification, nameof(Notification.NotificationDate), FormattedNotificationDate);

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -48,7 +48,7 @@ namespace ntbs_service.Services
             this.userService = userService;
             this.context = context;
         }
-
+        
         public async Task<Notification> GetNotificationAsync(int? id)
         {
             return await repository.GetNotificationAsync(id);

--- a/ntbs-service/Services/UserService.cs
+++ b/ntbs-service/Services/UserService.cs
@@ -54,7 +54,7 @@ namespace ntbs_service.Services
             var type = GetUserType(user);
             var roles = GetRoles(user);
 
-            return await UserServicesQuery(type, roles).FirstAsync();
+            return await GetTbServicesQuery(type, roles).FirstAsync();
         }
 
         public async Task<IEnumerable<TBService>> GetTbServicesAsync(ClaimsPrincipal user)
@@ -62,10 +62,10 @@ namespace ntbs_service.Services
             var type = GetUserType(user);
             var roles = GetRoles(user);
 
-            return await UserServicesQuery(type, roles).ToListAsync();
+            return await GetTbServicesQuery(type, roles).ToListAsync();
         }
 
-        private IQueryable<TBService> UserServicesQuery(UserType type, IEnumerable<string> roles)
+        private IQueryable<TBService> GetTbServicesQuery(UserType type, IEnumerable<string> roles)
         {
             switch (type)
             {

--- a/ntbs-service/Services/UserService.cs
+++ b/ntbs-service/Services/UserService.cs
@@ -13,6 +13,7 @@ namespace ntbs_service.Services
     {
         Task<UserPermissionsFilter> GetUserPermissionsFilterAsync(ClaimsPrincipal user);
         Task<TBService> GetDefaultTBService(ClaimsPrincipal user);
+        Task<IEnumerable<TBService>> GetTbServicesAsync(ClaimsPrincipal user);
     }
 
     public class UserService : IUserService
@@ -53,18 +54,27 @@ namespace ntbs_service.Services
             var type = GetUserType(user);
             var roles = GetRoles(user);
 
-            if (type == UserType.NationalTeam)
-            {
-                return null;
-            }
+            return await UserServicesQuery(type, roles).FirstAsync();
+        }
 
-            if (type == UserType.NhsUser)
+        public async Task<IEnumerable<TBService>> GetTbServicesAsync(ClaimsPrincipal user)
+        {
+            var type = GetUserType(user);
+            var roles = GetRoles(user);
+
+            return await UserServicesQuery(type, roles).ToListAsync();
+        }
+
+        private IQueryable<TBService> UserServicesQuery(UserType type, IEnumerable<string> roles)
+        {
+            switch (type)
             {
-                return await context.TbService.FirstAsync(tb => roles.Contains(tb.ServiceAdGroup));
-            }
-            else
-            {
-                return await context.TbService.Include(tb => tb.PHEC).FirstAsync(tb => roles.Contains(tb.PHEC.AdGroup));
+                case UserType.NationalTeam:
+                    return context.TbService;
+                case UserType.NhsUser:
+                    return context.TbService.Where(tb => roles.Contains(tb.ServiceAdGroup));
+                default:
+                    return context.TbService.Include(tb => tb.PHEC).Where(tb => roles.Contains(tb.PHEC.AdGroup));
             }
         }
 


### PR DESCRIPTION
## Description
Validate the selected hospital is part of the tbservice. Also ensure notifications are created with default service (part of that was already implemented by @lbbethke's recent changes, but more rounding out).  General cleanup of the hospital page included, going commit by commit might be helpful to contain the noise.
## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
- [x] Test functionality without javascript
- [x] Test in small window (immitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
