### PR TITLE
NTBS-208: Notification routing change

### DIFF
--- a/ntbs-integration-tests/Helpers/Constants.cs
+++ b/ntbs-integration-tests/Helpers/Constants.cs
@@ -1,4 +1,4 @@
-using ntbs_service.Helpers;
+﻿using ntbs_service.Helpers;
 
 namespace ntbs_integration_tests.Helpers
 {

--- a/ntbs-integration-tests/Helpers/Constants.cs
+++ b/ntbs-integration-tests/Helpers/Constants.cs
@@ -6,20 +6,5 @@ namespace ntbs_integration_tests.Helpers
     {
         public const string HomePage = "/";
         public const string SearchPage = "/Search";
-
-        public static string Patient = RouteHelper.GetNotificationEditBasePath("Patient");
-        public static string Episode = RouteHelper.GetNotificationEditBasePath("Episode");
-        public static string ClinicalDetails = RouteHelper.GetNotificationEditBasePath("ClinicalDetails");
-        public static string ContactTracing = RouteHelper.GetNotificationEditBasePath("ContactTracing");
-        public static string SocialRiskFactors = RouteHelper.GetNotificationEditBasePath("SocialRiskFactors");
-        public static string Travel = RouteHelper.GetNotificationEditBasePath("Travel");
-        public static string Comorbidities = RouteHelper.GetNotificationEditBasePath("Comorbidities");
-        public static string Immunosuppression = RouteHelper.GetNotificationEditBasePath("Immunosuppression");
-        public static string PreviousHistory = RouteHelper.GetNotificationEditBasePath("PreviousHistory");
-
-        public static string Overview = RouteHelper.GetNotificationBasePath("Overview");
-        public static string LinkedNotifications = RouteHelper.GetNotificationBasePath("LinkedNotifications");
-        public static string Denotify = RouteHelper.GetNotificationBasePath("Denotify");
-        public static string Delete = RouteHelper.GetNotificationBasePath("Delete");
     }
 }

--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using ntbs_integration_tests.NotificationPages;

--- a/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
@@ -1,30 +1,31 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
 using ntbs_integration_tests.TestServices;
 using ntbs_service;
+using ntbs_service.Helpers;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class BasicEditPageTests : TestRunnerBase
+    public class BasicEditPageTests : TestRunnerNotificationBase
     {
         public BasicEditPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
-        [Theory, MemberData(nameof(EditPageRoutes))]
-        public async Task Get_ReturnsNotFound_ForNewId(string route)
+        [Theory, MemberData(nameof(EditPageSubPaths))]
+        public async Task Get_ReturnsNotFound_ForNewId(string subPath)
         {
             // Act
-            var response = await Client.GetAsync($"{route}?id={Utilities.NEW_ID}");
+            var response = await Client.GetAsync(GetPathForId(subPath, Utilities.NEW_ID));
 
             // Assert
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
 
-        [Theory, MemberData(nameof(OkRouteToIdCombinations))]
-        public async Task Get_ReturnsOk_ForExistingIds(string route, int id)
+        [Theory, MemberData(nameof(OkEditPathToIdCombinations))]
+        public async Task Get_ReturnsOk_ForExistingIds(string subPath, int id)
         {
             //Act
             var response = await Client.GetAsync($"{route}?id={id}");
@@ -122,25 +123,12 @@ namespace ntbs_integration_tests.NotificationPages
                                         .CreateClientWithoutRedirects())
             {
                 //Act
-                var response = await client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
+                var response = await Client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             }
         }
-
-        private static readonly List<string> Routes = new List<string>()
-        {
-            Helpers.Routes.Patient,
-            Helpers.Routes.Episode,
-            Helpers.Routes.ClinicalDetails,
-            Helpers.Routes.ContactTracing,
-            Helpers.Routes.SocialRiskFactors,
-            Helpers.Routes.Travel,
-            Helpers.Routes.Comorbidities,
-            Helpers.Routes.Immunosuppression,
-            Helpers.Routes.PreviousHistory
-        };
 
         private static readonly List<int> OkNotificationIds = new List<int>()
         {
@@ -149,15 +137,15 @@ namespace ntbs_integration_tests.NotificationPages
             Utilities.DENOTIFIED_ID
         };
 
-        public static IEnumerable<object[]> EditPageRoutes()
+        public static IEnumerable<object[]> EditPageSubPaths()
         {
-            return Routes.Select(route => new object[] { route });
+            return EditSubPaths.Select(path => new object[] { path });
         }
 
-        public static IEnumerable<object[]> OkRouteToIdCombinations()
+        public static IEnumerable<object[]> OkEditPathToIdCombinations()
         {
-            return Routes.SelectMany(route =>
-                OkNotificationIds.Select(id => new object[] { route, id })
+            return EditSubPaths.SelectMany(path =>
+                OkNotificationIds.Select(id => new object[] { path, id })
             );
         }
     }

--- a/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
@@ -28,30 +28,30 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Get_ReturnsOk_ForExistingIds(string subPath, int id)
         {
             //Act
-            var response = await Client.GetAsync($"{route}?id={id}");
+            var response = await Client.GetAsync(GetPathForId(subPath, id));
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         }
 
-        [Theory, MemberData(nameof(EditPageRoutes))]
-        public async Task Get_ReturnsOk_ForNhsUserWithPermission(string route)
+        [Theory, MemberData(nameof(EditPageSubPaths))]
+        public async Task Get_ReturnsOk_ForNhsUserWithPermission(string subPath)
         {
             // Arrange
             using (var client = Factory.WithMockUserService<NhsUserService>()
                                         .WithNotificationAndTbServiceConnected(Utilities.DRAFT_ID, Utilities.PERMITTED_SERVICE_CODE)
                                         .CreateClientWithoutRedirects())
             {
-                 //Act
-                var response = await client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
+                //Act
+                var response = await client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
 
-        [Theory, MemberData(nameof(EditPageRoutes))]
-        public async Task Get_ReturnsRedirect_ForNhsUserWithoutPermission(string route)
+        [Theory, MemberData(nameof(EditPageSubPaths))]
+        public async Task Get_ReturnsRedirect_ForNhsUserWithoutPermission(string subPath)
         {
             // Arrange
             using (var client = Factory.WithMockUserService<NhsUserService>()
@@ -59,15 +59,15 @@ namespace ntbs_integration_tests.NotificationPages
                                         .CreateClientWithoutRedirects())
             {
                 //Act
-                var response = await client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
+                var response = await client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             }
         }
 
-        [Theory, MemberData(nameof(EditPageRoutes))]
-        public async Task Get_ReturnsOk_ForPheUserWithMatchingServicePermission(string route)
+        [Theory, MemberData(nameof(EditPageSubPaths))]
+        public async Task Get_ReturnsOk_ForPheUserWithMatchingServicePermission(string subPath)
         {
             // Arrange
             using (var client = Factory.WithMockUserService<PheUserService>()
@@ -75,15 +75,15 @@ namespace ntbs_integration_tests.NotificationPages
                                         .CreateClientWithoutRedirects())
             {
                 //Act
-                var response = await client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
+                var response = await client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
 
-        [Theory, MemberData(nameof(EditPageRoutes))]
-        public async Task Get_ReturnsOk_ForPheUserWithMatchingPostcodePermission(string route)
+        [Theory, MemberData(nameof(EditPageSubPaths))]
+        public async Task Get_ReturnsOk_ForPheUserWithMatchingPostcodePermission(string subPath)
         {
             // Arrange
             using (var client = Factory.WithMockUserService<PheUserService>()
@@ -91,15 +91,15 @@ namespace ntbs_integration_tests.NotificationPages
                                         .CreateClientWithoutRedirects())
             {
                 //Act
-                var response = await client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
+                var response = await client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             }
         }
 
-        [Theory, MemberData(nameof(EditPageRoutes))]
-        public async Task Get_ReturnsRedirect_ForPheUserWithoutMatchingServicePermission(string route)
+        [Theory, MemberData(nameof(EditPageSubPaths))]
+        public async Task Get_ReturnsRedirect_ForPheUserWithoutMatchingServicePermission(string subPath)
         {
             // Arrange
             using (var client = Factory.WithMockUserService<PheUserService>()
@@ -107,15 +107,15 @@ namespace ntbs_integration_tests.NotificationPages
                                         .CreateClientWithoutRedirects())
             {
                 //Act
-                var response = await client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
+                var response = await client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
             }
         }
 
-        [Theory, MemberData(nameof(EditPageRoutes))]
-        public async Task Get_ReturnsRedirect_ForPheUserWithoutMatchingPostcodePermission(string route)
+        [Theory, MemberData(nameof(EditPageSubPaths))]
+        public async Task Get_ReturnsRedirect_ForPheUserWithoutMatchingPostcodePermission(string subPath)
         {
             // Arrange
             using (var client = Factory.WithMockUserService<PheUserService>()
@@ -123,7 +123,7 @@ namespace ntbs_integration_tests.NotificationPages
                                         .CreateClientWithoutRedirects())
             {
                 //Act
-                var response = await Client.GetAsync($"{route}?id={Utilities.DRAFT_ID}");
+                var response = await client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
@@ -148,5 +148,21 @@ namespace ntbs_integration_tests.NotificationPages
                 OkNotificationIds.Select(id => new object[] { path, id })
             );
         }
+
+        private static readonly List<string> EditSubPaths = new List<string>()
+        {
+            NotificationSubPaths.EditPatient,
+            NotificationSubPaths.EditEpisode,
+            NotificationSubPaths.EditClinicalDetails,
+            NotificationSubPaths.EditContactTracing,
+            NotificationSubPaths.EditSocialRiskFactors,
+            NotificationSubPaths.EditTravel,
+            NotificationSubPaths.EditComorbidities,
+            NotificationSubPaths.EditImmunosuppression,
+            NotificationSubPaths.EditPreviousHistory
+        };
     }
 }
+
+
+

--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -1,17 +1,18 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Validations;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class ClinicalDetailsPageTests : TestRunnerBase
+    public class ClinicalDetailsPageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.ClinicalDetails;
+        protected override string NotificationSubPath => NotificationSubPaths.EditClinicalDetails;
 
         public ClinicalDetailsPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
 
@@ -19,7 +20,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostDraft_ReturnsPageWithAllModelErrors_IfModelNotValid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await client.GetAsync(initialUrl);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -47,7 +49,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(document, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -71,7 +73,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithAllModelErrors_IfModelNotValid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
+            var initialUrl = GetCurrentPathForId(Utilities.NOTIFIED_ID);
+            var initialPage = await client.GetAsync(initialUrl);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -83,7 +86,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(document, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -98,7 +101,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithDiseaseSiteRequiredError_IfDiseaseSiteNotSet()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
+            var initialUrl = GetCurrentPathForId(Utilities.NOTIFIED_ID);
+            var initialPage = await client.GetAsync(initialUrl);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -109,7 +113,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(document, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -122,7 +126,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithDiagnosisDateRequiredError_IfDiagnosisDateNotSet()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
+            var initialUrl = GetCurrentPathForId(Utilities.NOTIFIED_ID);
+            var initialPage = await client.GetAsync(initialUrl);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -136,7 +141,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(document, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -149,7 +154,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_RedirectsToNextPageAndSavesContent_IfModelValid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -182,13 +188,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildEditRoute(Routes.ContactTracing, Utilities.DRAFT_ID), GetRedirectLocation(result));
+            Assert.Contains(GetPathForId(NotificationSubPaths.EditContactTracing, Utilities.DRAFT_ID), GetRedirectLocation(result));
 
-            var reloadedPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var reloadedPage = await client.GetAsync(GetCurrentPathForId(Utilities.DRAFT_ID));
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("NotificationSiteMap_PULMONARY_")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("NotificationSiteMap_OTHER_")).IsChecked);
@@ -219,7 +225,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ClearsConditionalInputValues_IfRadiosSetToOtherValue()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -244,13 +251,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildEditRoute(Routes.ContactTracing, Utilities.DRAFT_ID), result.Headers.Location.OriginalString);
+            Assert.Contains(GetPathForId(NotificationSubPaths.EditContactTracing, Utilities.DRAFT_ID), GetRedirectLocation(result));
 
-            var reloadedPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var reloadedPage = await client.GetAsync(GetCurrentPathForId(Utilities.DRAFT_ID));
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.False(((IHtmlInputElement)reloadedDocument.GetElementById("NotificationSiteMap_OTHER_")).IsChecked);
             Assert.Equal("", ((IHtmlInputElement)reloadedDocument.GetElementById("OtherSite_SiteDescription")).Value);
@@ -283,7 +290,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateClinicalDetailsDate"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsDate"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -303,7 +310,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateClinicalDetailsDate"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsDate"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -322,7 +329,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateNotificationSites"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateNotificationSites"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -344,7 +351,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateNotificationSiteProperty"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateNotificationSiteProperty"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -363,7 +370,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateClinicalDetailsYearComparison"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsYearComparison"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -373,7 +380,7 @@ namespace ntbs_integration_tests.NotificationPages
         [Fact]
         public async Task ValidateClinicalDetailsProperties_ReturnsErrorIfBothTreatmentsSetToTrue()
         {
-             // Arrange
+            // Arrange
             var keyValuePairs = new string[]
             {
                 "keyValuePairs[0][key]=IsShortCourseTreatment",
@@ -383,7 +390,8 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync($"{PageRoute}/ValidateClinicalDetailsProperties?{string.Join("&", keyValuePairs)}");
+            var defaultUrl = GetCurrentPathForId(0);
+            var response = await client.GetAsync($"{defaultUrl}/ValidateClinicalDetailsProperties?{string.Join("&", keyValuePairs)}");
 
             // Assert check just response.Content
             var result = await response.Content.ReadAsStringAsync();

--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -20,8 +20,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostDraft_ReturnsPageWithAllModelErrors_IfModelNotValid()
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialPage = await client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await Client.GetAsync(url);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -49,7 +49,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData, initialUrl);
+            var result = await SendPostFormWithData(document, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -73,8 +73,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithAllModelErrors_IfModelNotValid()
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var initialPage = await client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
+            var initialPage = await Client.GetAsync(url);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -86,7 +86,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData, initialUrl);
+            var result = await SendPostFormWithData(document, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -101,8 +101,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithDiseaseSiteRequiredError_IfDiseaseSiteNotSet()
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var initialPage = await client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
+            var initialPage = await Client.GetAsync(url);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -113,7 +113,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData, initialUrl);
+            var result = await SendPostFormWithData(document, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -126,8 +126,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithDiagnosisDateRequiredError_IfDiagnosisDateNotSet()
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var initialPage = await client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
+            var initialPage = await Client.GetAsync(url);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -141,7 +141,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData, initialUrl);
+            var result = await SendPostFormWithData(document, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -154,8 +154,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_RedirectsToNextPageAndSavesContent_IfModelValid()
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialPage = await client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -188,13 +188,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditContactTracing, Utilities.DRAFT_ID), GetRedirectLocation(result));
 
-            var reloadedPage = await client.GetAsync(GetCurrentPathForId(Utilities.DRAFT_ID));
+            var reloadedPage = await Client.GetAsync(GetCurrentPathForId(Utilities.DRAFT_ID));
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("NotificationSiteMap_PULMONARY_")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("NotificationSiteMap_OTHER_")).IsChecked);
@@ -225,8 +225,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ClearsConditionalInputValues_IfRadiosSetToOtherValue()
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialPage = await client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -251,13 +251,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditContactTracing, Utilities.DRAFT_ID), GetRedirectLocation(result));
 
-            var reloadedPage = await client.GetAsync(GetCurrentPathForId(Utilities.DRAFT_ID));
+            var reloadedPage = await Client.GetAsync(GetCurrentPathForId(Utilities.DRAFT_ID));
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.False(((IHtmlInputElement)reloadedDocument.GetElementById("NotificationSiteMap_OTHER_")).IsChecked);
             Assert.Equal("", ((IHtmlInputElement)reloadedDocument.GetElementById("OtherSite_SiteDescription")).Value);
@@ -290,7 +290,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsDate"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsDate"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -310,7 +310,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsDate"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsDate"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -329,7 +329,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateNotificationSites"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateNotificationSites"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -351,7 +351,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateNotificationSiteProperty"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateNotificationSiteProperty"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -370,7 +370,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsYearComparison"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateClinicalDetailsYearComparison"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -391,7 +391,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Act
             var defaultUrl = GetCurrentPathForId(0);
-            var response = await client.GetAsync($"{defaultUrl}/ValidateClinicalDetailsProperties?{string.Join("&", keyValuePairs)}");
+            var response = await Client.GetAsync($"{defaultUrl}/ValidateClinicalDetailsProperties?{string.Join("&", keyValuePairs)}");
 
             // Assert check just response.Content
             var result = await response.Content.ReadAsStringAsync();

--- a/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
@@ -1,24 +1,26 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
+using ntbs_service.Helpers;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class ComorbidityPageTests : TestRunnerBase
+    public class ComorbidityPageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.Comorbidities;
+        protected override string NotificationSubPath => NotificationSubPaths.EditComorbidities;
 
-        public ComorbidityPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
+        public ComorbidityPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
         [Fact]
         public async Task Post_RedirectsToNextPageAndSavesContent()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -31,13 +33,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildEditRoute(Routes.Immunosuppression, Utilities.DRAFT_ID), GetRedirectLocation(result));
+            Assert.Contains(GetPathForId(NotificationSubPaths.EditImmunosuppression, Utilities.DRAFT_ID), GetRedirectLocation(result));
 
-            var reloadedPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var reloadedPage = await client.GetAsync(initialUrl);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("diabetes-radio-button-Yes")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("hepatitis-b-radio-button-No")).IsChecked);

--- a/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
@@ -19,8 +19,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_RedirectsToNextPageAndSavesContent()
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -33,13 +33,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditImmunosuppression, Utilities.DRAFT_ID), GetRedirectLocation(result));
 
-            var reloadedPage = await Client.GetAsync(initialUrl);
+            var reloadedPage = await Client.GetAsync(url);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("diabetes-radio-button-Yes")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("hepatitis-b-radio-button-No")).IsChecked);

--- a/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
@@ -20,7 +20,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var initialUrl = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -39,7 +39,7 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditImmunosuppression, Utilities.DRAFT_ID), GetRedirectLocation(result));
 
-            var reloadedPage = await client.GetAsync(initialUrl);
+            var reloadedPage = await Client.GetAsync(initialUrl);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("diabetes-radio-button-Yes")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("hepatitis-b-radio-button-No")).IsChecked);

--- a/ntbs-integration-tests/NotificationPages/DeletePageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DeletePageTests.cs
@@ -1,19 +1,19 @@
-using ntbs_integration_tests.Helpers;
-using ntbs_service;
-using ntbs_service.Models.Validations;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_service;
+using ntbs_service.Helpers;
 using ntbs_service.Models;
 using ntbs_service.Models.Enums;
+using ntbs_service.Models.Validations;
 using Xunit;
-using System;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class DeletePageTests : TestRunnerBase
+    public class DeletePageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.Delete;
+        protected override string NotificationSubPath => NotificationSubPaths.Delete;
 
         public DeletePageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
@@ -38,14 +38,14 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetDeletePage_ReturnsCorrectStatusCode_DependentOnId(int id, HttpStatusCode code)
         {
             // Act
-            var response = await Client.GetAsync(GetPageRouteForId(id));
+            var response = await Client.GetAsync(GetCurrentPathForId(id));
 
             // Assert
             Assert.Equal(code, response.StatusCode);
 
             if (response.StatusCode == HttpStatusCode.Redirect)
             {
-                Assert.Equal(BuildRoute(Routes.Overview, id), GetRedirectLocation(response));
+                Assert.Contains(GetRedirectLocation(response), GetPathForId(NotificationSubPaths.Overview, id));
             }
         }
 
@@ -54,7 +54,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DELETE_NO_DESCRIPTION;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
 
@@ -64,9 +65,9 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
-            
+
             // Assert
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
@@ -79,7 +80,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DELETE_WITH_DESCRIPTION;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -89,9 +91,9 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
-            
+
             // Assert
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
 
@@ -104,7 +106,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DELETE_WITH_DESCRIPTION;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -114,7 +117,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);

--- a/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
@@ -61,8 +61,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DENOTIFY_NO_DESCRIPTION;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -80,7 +80,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
@@ -97,8 +97,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DENOTIFY_WITH_DESCRIPTION;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -118,7 +118,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
@@ -135,8 +135,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "0";
@@ -154,7 +154,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -168,8 +168,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -187,7 +187,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -201,8 +201,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -220,7 +220,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -233,8 +233,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -250,7 +250,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -264,8 +264,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -283,7 +283,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, url, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);

--- a/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
@@ -44,7 +44,7 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetDenotifyPage_ReturnsCorrectStatusCode_DependentOnId(int id, HttpStatusCode code)
         {
             // Act
-            var response = await client.GetAsync(GetCurrentPathForId(id));
+            var response = await Client.GetAsync(GetCurrentPathForId(id));
 
             // Assert
             Assert.Equal(code, response.StatusCode);
@@ -62,7 +62,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DENOTIFY_NO_DESCRIPTION;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -98,7 +98,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DENOTIFY_WITH_DESCRIPTION;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -136,7 +136,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "0";
@@ -169,7 +169,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -202,7 +202,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -234,7 +234,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -265,7 +265,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";

--- a/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
@@ -1,4 +1,4 @@
-using ntbs_integration_tests.Helpers;
+﻿using ntbs_integration_tests.Helpers;
 using ntbs_service;
 using ntbs_service.Models.Validations;
 using System.Collections.Generic;
@@ -8,12 +8,13 @@ using ntbs_service.Models;
 using ntbs_service.Models.Enums;
 using Xunit;
 using System;
+using ntbs_service.Helpers;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class DenotifyPageTests : TestRunnerBase
+    public class DenotifyPageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.Denotify;
+        protected override string NotificationSubPath => NotificationSubPaths.Denotify;
 
         public DenotifyPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
@@ -23,10 +24,10 @@ namespace ntbs_integration_tests.NotificationPages
             {
                 new Notification(){ NotificationId = Utilities.DENOTIFY_WITH_DESCRIPTION, NotificationStatus = NotificationStatus.Notified },
                 new Notification(){ NotificationId = Utilities.DENOTIFY_NO_DESCRIPTION, NotificationStatus = NotificationStatus.Notified },
-                new Notification(){ 
-                    NotificationId = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE, 
-                    NotificationStatus = NotificationStatus.Notified, 
-                    NotificationDate = new DateTime(2011, 1, 1) 
+                new Notification(){
+                    NotificationId = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE,
+                    NotificationStatus = NotificationStatus.Notified,
+                    NotificationDate = new DateTime(2011, 1, 1)
                 }
             };
         }
@@ -43,14 +44,15 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetDenotifyPage_ReturnsCorrectStatusCode_DependentOnId(int id, HttpStatusCode code)
         {
             // Act
-            var response = await Client.GetAsync(GetPageRouteForId(id));
+            var response = await client.GetAsync(GetCurrentPathForId(id));
 
             // Assert
             Assert.Equal(code, response.StatusCode);
 
             if (response.StatusCode == HttpStatusCode.Redirect)
             {
-                Assert.Equal(BuildRoute(Routes.Overview, id), GetRedirectLocation(response));
+                // Flipped expected/actual here to accomodate trailing slash
+                Assert.Contains(GetRedirectLocation(response), GetPathForId(NotificationSubPaths.Overview, id));
             }
         }
 
@@ -59,7 +61,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DENOTIFY_NO_DESCRIPTION;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -77,11 +80,12 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildRoute(Routes.Overview, id), GetRedirectLocation(result));
+            // Flipped expected/actual here to accomodate trailing slash
+            Assert.Contains(GetRedirectLocation(result), GetPathForId(NotificationSubPaths.Overview, id));
 
             var redirectPage = await Client.GetAsync(GetRedirectLocation(result));
             var redirectDocument = await GetDocumentAsync(redirectPage);
@@ -93,7 +97,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DENOTIFY_WITH_DESCRIPTION;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -113,11 +118,12 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildRoute(Routes.Overview, id), GetRedirectLocation(result));
+            // Flipped expected/actual here to accomodate trailing slash
+            Assert.Contains(GetRedirectLocation(result), GetPathForId(NotificationSubPaths.Overview, id));
 
             var redirectPage = await Client.GetAsync(GetRedirectLocation(result));
             var redirectDocument = await GetDocumentAsync(redirectPage);
@@ -129,7 +135,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "0";
@@ -147,7 +154,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -161,7 +168,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -179,7 +187,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -193,7 +201,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -211,7 +220,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -224,7 +233,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -240,7 +250,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -254,7 +264,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string denotifyDateDay = "1";
@@ -272,7 +283,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, "Confirm");
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl, "Confirm");
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);

--- a/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
@@ -20,8 +20,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -33,7 +33,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -47,8 +47,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -60,7 +60,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -74,8 +74,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -84,7 +84,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -97,8 +97,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -110,7 +110,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -123,8 +123,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -136,7 +136,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -149,8 +149,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -159,7 +159,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -174,8 +174,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -186,7 +186,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -200,8 +200,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
 
@@ -218,7 +218,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);

--- a/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
@@ -1,16 +1,17 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Validations;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class EpisodesPageTests : TestRunnerBase
+    public class EpisodesPageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.Episode;
+        protected override string NotificationSubPath => NotificationSubPaths.EditEpisode;
 
         public EpisodesPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
@@ -18,8 +19,10 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostDraft_ReturnsWithNotificationDateInvalidError_IfNotificationDateIsNotDate()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.DRAFT_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
@@ -30,20 +33,23 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.ValidDate);
+            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate),
+                        resultDocument.GetError("notification-date"));
         }
 
         [Fact]
         public async Task PostDraft_ReturnsWithNotificationDateRangeError_IfNotificationDateIsNotInRange()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.DRAFT_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
@@ -54,7 +60,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -67,8 +73,10 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsWithNotificationDateRequiredError_IfNotificationDateNotSet()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.NOTIFIED_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
@@ -76,7 +84,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -88,8 +96,10 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsWithNotificationDateInvalidError_IfNotificationDateIsNotDate()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.NOTIFIED_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
@@ -100,7 +110,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -112,8 +122,10 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsWithNotificationDateRangeError_IfNotificationDateIsNotInRange()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.NOTIFIED_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
@@ -124,7 +136,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -136,8 +148,10 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithAllRequiredErrors_IfModelNotValid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.NOTIFIED_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
@@ -145,7 +159,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -159,8 +173,10 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostNotified_ReturnsPageWithTextFieldInputError_IfTextIsInvalid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.NOTIFIED_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.NOTIFIED_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
@@ -170,7 +186,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -183,8 +199,11 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostDraft_RedirectToNextPage_IfModelIsValid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
-            var document = await GetDocumentAsync(initialPage);
+            const int id = Utilities.DRAFT_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
+            var initialDocument = await GetDocumentAsync(initialPage);
+
 
             var formData = new Dictionary<string, string>
             {
@@ -199,11 +218,11 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildEditRoute(Routes.ClinicalDetails, Utilities.DRAFT_ID), GetRedirectLocation(result));
+            Assert.Contains(GetPathForId(NotificationSubPaths.EditClinicalDetails, id), GetRedirectLocation(result));
         }
 
         [Fact]

--- a/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
@@ -21,7 +21,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -48,7 +48,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -75,7 +75,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -98,7 +98,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -124,7 +124,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -150,7 +150,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -175,7 +175,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -201,7 +201,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
 
@@ -229,7 +229,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task PostDraft_HospitalDoesNotMatchTbService_ReturnsValdationError()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialPage = await Client.GetAsync(url);
             var document = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -240,7 +241,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(document, formData);
+            var result = await SendPostFormWithData(document, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);

--- a/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
@@ -22,8 +22,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -33,7 +33,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -47,8 +47,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -59,7 +59,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -73,8 +73,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string description = "Other Therapy";
@@ -87,13 +87,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditPreviousHistory, id), GetRedirectLocation(result));
 
-            var reloadedPage = await Client.GetAsync(initialUrl);
+            var reloadedPage = await Client.GetAsync(url);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("immunosuppression-yes")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("ImmunosuppressionDetails_HasOther")).IsChecked);

--- a/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
@@ -1,36 +1,39 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
 using Newtonsoft.Json;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Validations;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class ImmunosuppressionPageTests : TestRunnerBase
+    public class ImmunosuppressionPageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.Immunosuppression;
+        protected override string NotificationSubPath => NotificationSubPaths.EditImmunosuppression;
 
-        public ImmunosuppressionPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
+        public ImmunosuppressionPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
         [Fact]
         public async Task Post_ReturnsTypeRequiredError_IfYesSelected()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            const int id = Utilities.DRAFT_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
-                ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
+                ["NotificationId"] = id.ToString(),
                 ["ImmunosuppressionDetails.Status"] = "Yes",
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -43,18 +46,20 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ReturnsDetailsRequiredError_IfOtherCheckedSelected()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            const int id = Utilities.DRAFT_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
             {
-                ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
+                ["NotificationId"] = id.ToString(),
                 ["ImmunosuppressionDetails.Status"] = "Yes",
                 ["ImmunosuppressionDetails.HasOther"] = "True",
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -67,30 +72,32 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_RedirectsToNextPageAndSavesContent()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            const int id = Utilities.DRAFT_ID;
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
-            const string Description = "Other Therapy";
+            const string description = "Other Therapy";
             var formData = new Dictionary<string, string>
             {
-                ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
+                ["NotificationId"] = id.ToString(),
                 ["ImmunosuppressionDetails.Status"] = "Yes",
                 ["ImmunosuppressionDetails.HasOther"] = "True",
-                ["ImmunosuppressionDetails.OtherDescription"] = Description,
+                ["ImmunosuppressionDetails.OtherDescription"] = description,
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildEditRoute(Routes.PreviousHistory, Utilities.DRAFT_ID), GetRedirectLocation(result));
+            Assert.Contains(GetPathForId(NotificationSubPaths.EditPreviousHistory, id), GetRedirectLocation(result));
 
-            var reloadedPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var reloadedPage = await client.GetAsync(initialUrl);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("immunosuppression-yes")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("ImmunosuppressionDetails_HasOther")).IsChecked);
-            Assert.Equal(Description, ((IHtmlInputElement)reloadedDocument.GetElementById("ImmunosuppressionDetails_OtherDescription")).Value);
+            Assert.Equal(description, ((IHtmlInputElement)reloadedDocument.GetElementById("ImmunosuppressionDetails_OtherDescription")).Value);
         }
 
         [Theory]
@@ -110,21 +117,14 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "Validate"));
+            var response = await client.GetAsync(GetValidationPath(formData, "Validate"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
             if (!string.IsNullOrEmpty(result))
             {
                 var mappedResult = JsonConvert.DeserializeObject<Dictionary<string, string>>(result);
-                if (result.Contains("Status"))
-                {
-                    result = mappedResult["ImmunosuppressionDetails.Status"];
-                }
-                else
-                {
-                    result = mappedResult["ImmunosuppressionDetails.OtherDescription"];
-                }
+                result = result.Contains("Status") ? mappedResult["ImmunosuppressionDetails.Status"] : mappedResult["ImmunosuppressionDetails.OtherDescription"];
             }
             Assert.Equal(validationResult, result);
         }

--- a/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
@@ -23,7 +23,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -48,7 +48,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -74,7 +74,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string description = "Other Therapy";
@@ -93,7 +93,7 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditPreviousHistory, id), GetRedirectLocation(result));
 
-            var reloadedPage = await client.GetAsync(initialUrl);
+            var reloadedPage = await Client.GetAsync(initialUrl);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("immunosuppression-yes")).IsChecked);
             Assert.True(((IHtmlInputElement)reloadedDocument.GetElementById("ImmunosuppressionDetails_HasOther")).IsChecked);
@@ -117,7 +117,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "Validate"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "Validate"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();

--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -1,20 +1,20 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
 using ntbs_integration_tests.TestServices;
 using ntbs_service;
-using ntbs_service.Pages;
+using ntbs_service.Helpers;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
 {
     // TODO: Complete tests for this page
-    public class OverviewPageTests : TestRunnerBase
+    public class OverviewPageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.Overview;
+        protected override string NotificationSubPath => NotificationSubPaths.Overview;
 
-        public OverviewPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
+        public OverviewPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
         public static IEnumerable<object[]> OverviewRoutes()
         {
@@ -28,14 +28,14 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetOverviewPage_ReturnsCorrectStatusCode_DependentOnId(int id, HttpStatusCode code)
         {
             // Act
-            var response = await Client.GetAsync(GetPageRouteForId(id));
+            var response = await client.GetAsync(GetCurrentPathForId(id));
 
             // Assert
             Assert.Equal(code, response.StatusCode);
 
             if (response.StatusCode == HttpStatusCode.Redirect)
             {
-                Assert.Equal(BuildRoute(Routes.Patient, id), GetRedirectLocation(response));
+                Assert.Contains(GetPathForId(NotificationSubPaths.EditPatient, id), GetRedirectLocation(response));
             }
         }
 

--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -5,6 +5,7 @@ using ntbs_integration_tests.Helpers;
 using ntbs_integration_tests.TestServices;
 using ntbs_service;
 using ntbs_service.Helpers;
+using ntbs_service.Pages;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
@@ -28,7 +29,7 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetOverviewPage_ReturnsCorrectStatusCode_DependentOnId(int id, HttpStatusCode code)
         {
             // Act
-            var response = await client.GetAsync(GetCurrentPathForId(id));
+            var response = await Client.GetAsync(GetCurrentPathForId(id));
 
             // Assert
             Assert.Equal(code, response.StatusCode);
@@ -49,7 +50,7 @@ namespace ntbs_integration_tests.NotificationPages
             {
 
                 //Act
-                var response = await client.GetAsync($"{GetPageRouteForId(Utilities.NOTIFIED_ID)}");
+                var response = await client.GetAsync(GetCurrentPathForId(Utilities.NOTIFIED_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -68,7 +69,7 @@ namespace ntbs_integration_tests.NotificationPages
             {
 
                 //Act
-                var response = await client.GetAsync($"{GetPageRouteForId(Utilities.NOTIFIED_ID)}");
+                var response = await client.GetAsync(GetCurrentPathForId(Utilities.NOTIFIED_ID));
 
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);

--- a/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
@@ -22,7 +22,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -58,7 +58,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -85,7 +85,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -118,7 +118,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string givenName = "Test";
@@ -157,7 +157,7 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditEpisode, id), GetRedirectLocation(result));
 
-            var reloadedPage = await client.GetAsync(initialUrl);
+            var reloadedPage = await Client.GetAsync(initialUrl);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.Equal(givenName, ((IHtmlInputElement)reloadedDocument.GetElementById("Patient_GivenName")).Value);
             Assert.Equal(familyName, ((IHtmlInputElement)reloadedDocument.GetElementById("Patient_FamilyName")).Value);
@@ -186,7 +186,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidatePatientDate"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidatePatientDate"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -206,7 +206,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidatePatientProperty"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidatePatientProperty"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -226,7 +226,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidatePatientProperty"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidatePatientProperty"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -242,7 +242,7 @@ namespace ntbs_integration_tests.NotificationPages
             var formData = new Dictionary<string, string> { [""] = year };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateYearOfUkEntry"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateYearOfUkEntry"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -259,7 +259,7 @@ namespace ntbs_integration_tests.NotificationPages
             var formData = new Dictionary<string, string> { [""] = year };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateYearOfUkEntry"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateYearOfUkEntry"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();

--- a/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
@@ -21,8 +21,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -39,7 +39,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -57,8 +57,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -72,7 +72,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -84,8 +84,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -96,7 +96,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -117,8 +117,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             const string givenName = "Test";
@@ -151,13 +151,13 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetPathForId(NotificationSubPaths.EditEpisode, id), GetRedirectLocation(result));
 
-            var reloadedPage = await Client.GetAsync(initialUrl);
+            var reloadedPage = await Client.GetAsync(url);
             var reloadedDocument = await GetDocumentAsync(reloadedPage);
             Assert.Equal(givenName, ((IHtmlInputElement)reloadedDocument.GetElementById("Patient_GivenName")).Value);
             Assert.Equal(familyName, ((IHtmlInputElement)reloadedDocument.GetElementById("Patient_FamilyName")).Value);

--- a/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
@@ -21,7 +21,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -45,7 +45,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -71,7 +71,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -111,7 +111,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -171,7 +171,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -218,7 +218,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -262,7 +262,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -303,7 +303,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -346,7 +346,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await client.GetAsync(initialUrl);
+            var initialPage = await Client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -396,7 +396,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateTravel"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateTravel"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -416,7 +416,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateTravel"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateTravel"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -438,7 +438,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateVisitor"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateVisitor"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -458,7 +458,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await client.GetAsync(GetValidationPath(formData, "ValidateVisitor"));
+            var response = await Client.GetAsync(GetValidationPath(formData, "ValidateVisitor"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();

--- a/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
@@ -20,8 +20,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -32,7 +32,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
@@ -44,8 +44,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -56,7 +56,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
@@ -70,8 +70,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ReturnsPageWithModelErrors_IfTotalNumberIsLessThanInputCountries(int id)
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -89,7 +89,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -110,8 +110,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ReturnsPageWithModelErrors_IfTotalDurationIsMoreThan24(int id)
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -137,7 +137,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -170,8 +170,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ReturnsPageWithModelErrors_IfCountriesAreNonUnique(int id)
         {
             // Arrange
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -191,7 +191,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -217,8 +217,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -229,7 +229,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -261,8 +261,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -282,7 +282,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -302,8 +302,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -325,7 +325,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -345,8 +345,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialUrl = GetCurrentPathForId(id);
-            var initialPage = await Client.GetAsync(initialUrl);
+            var url = GetCurrentPathForId(id);
+            var initialPage = await Client.GetAsync(url);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -368,7 +368,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
+            var result = await SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);

--- a/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
@@ -1,16 +1,17 @@
-using ntbs_integration_tests.Helpers;
+﻿using ntbs_integration_tests.Helpers;
 using ntbs_service;
 using ntbs_service.Models.Validations;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using ntbs_service.Helpers;
 using Xunit;
 
 namespace ntbs_integration_tests.NotificationPages
 {
-    public class TravelPageTests : TestRunnerBase
+    public class TravelPageTests : TestRunnerNotificationBase
     {
-        protected override string PageRoute => Routes.Travel;
+        protected override string NotificationSubPath => NotificationSubPaths.EditTravel;
 
         public TravelPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
@@ -19,7 +20,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.DRAFT_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -30,11 +32,11 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildEditRoute(Routes.Comorbidities, id), GetRedirectLocation(result));
+            Assert.Contains(GetPathForId(NotificationSubPaths.EditComorbidities, id), GetRedirectLocation(result));
         }
 
         [Fact]
@@ -42,7 +44,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -53,11 +56,12 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
-            Assert.Equal(BuildRoute(Routes.Overview, id), GetRedirectLocation(result));
+            // Flipped expected/actual here to accomodate trailing slash
+            Assert.Contains(GetRedirectLocation(result), GetPathForId(NotificationSubPaths.Overview, id));
         }
 
         [Theory]
@@ -66,7 +70,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ReturnsPageWithModelErrors_IfTotalNumberIsLessThanInputCountries(int id)
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -84,7 +89,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -105,7 +110,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ReturnsPageWithModelErrors_IfTotalDurationIsMoreThan24(int id)
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -131,7 +137,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -164,7 +170,8 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Post_ReturnsPageWithModelErrors_IfCountriesAreNonUnique(int id)
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -184,7 +191,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -210,7 +217,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -221,7 +229,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -253,7 +261,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -273,7 +282,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -293,7 +302,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -315,7 +325,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -335,7 +345,8 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
-            var initialPage = await Client.GetAsync(GetPageRouteForId(id));
+            var initialUrl = GetCurrentPathForId(id);
+            var initialPage = await client.GetAsync(initialUrl);
             var initialDocument = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -357,7 +368,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendPostFormWithData(initialDocument, formData);
+            var result = await SendPostFormWithData(initialDocument, formData, initialUrl);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -385,7 +396,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateTravel"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateTravel"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -405,7 +416,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateTravel"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateTravel"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -427,7 +438,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateVisitor"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateVisitor"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
@@ -447,7 +458,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var response = await Client.GetAsync(BuildValidationPath(formData, "ValidateVisitor"));
+            var response = await client.GetAsync(GetValidationPath(formData, "ValidateVisitor"));
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();

--- a/ntbs-integration-tests/SearchPage/SearchPageTests.cs
+++ b/ntbs-integration-tests/SearchPage/SearchPageTests.cs
@@ -1,25 +1,23 @@
-using System.Collections.Generic;
-using System.Net;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
-using AngleSharp.Html.Dom;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
 using ntbs_service.Models.Validations;
 using Xunit;
 
-namespace ntbs_integration_tests.NotificationPages
+namespace ntbs_integration_tests.SearchPage
 {
     public class SearchPageTests : TestRunnerBase
     {
-        protected override string PageRoute => Routes.SearchPage;
-
         public SearchPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
+
+        public const string PageRoute = "/Search";
 
         [Fact]
         public async Task GetSearch_ReturnsPageWithModelErrors_IfSearchNotValid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var initialPage = await client.GetAsync(PageRoute);
             var pageContent = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -37,7 +35,7 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendGetFormWithData(pageContent, formData);
+            var result = await SendGetFormWithData(pageContent, formData, PageRoute);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
@@ -54,7 +52,7 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetSearch_ReturnsPageWithMatchingResult_IfSearchValid()
         {
             // Arrange
-            var initialPage = await Client.GetAsync(GetPageRouteForId(Utilities.DRAFT_ID));
+            var initialPage = await client.GetAsync(PageRoute);
             var pageContent = await GetDocumentAsync(initialPage);
             var formData = new Dictionary<string, string>
             {
@@ -62,14 +60,12 @@ namespace ntbs_integration_tests.NotificationPages
             };
 
             // Act
-            var result = await SendGetFormWithData(pageContent, formData);
+            var result = await SendGetFormWithData(pageContent, formData, PageRoute);
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             
             Assert.Equal(" #1 ", resultDocument.QuerySelector("a[id='notification-banner-id']").TextContent);
-            
         }
-
     }
 }

--- a/ntbs-integration-tests/SearchPage/SearchPageTests.cs
+++ b/ntbs-integration-tests/SearchPage/SearchPageTests.cs
@@ -17,7 +17,7 @@ namespace ntbs_integration_tests.SearchPage
         public async Task GetSearch_ReturnsPageWithModelErrors_IfSearchNotValid()
         {
             // Arrange
-            var initialPage = await client.GetAsync(PageRoute);
+            var initialPage = await Client.GetAsync(PageRoute);
             var pageContent = await GetDocumentAsync(initialPage);
 
             var formData = new Dictionary<string, string>
@@ -52,7 +52,7 @@ namespace ntbs_integration_tests.SearchPage
         public async Task GetSearch_ReturnsPageWithMatchingResult_IfSearchValid()
         {
             // Arrange
-            var initialPage = await client.GetAsync(PageRoute);
+            var initialPage = await Client.GetAsync(PageRoute);
             var pageContent = await GetDocumentAsync(initialPage);
             var formData = new Dictionary<string, string>
             {

--- a/ntbs-integration-tests/TestRunnerBase.cs
+++ b/ntbs-integration-tests/TestRunnerBase.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using AngleSharp.Html.Dom;
@@ -6,7 +6,6 @@ using ntbs_integration_tests.Helpers;
 using ntbs_service;
 using Xunit;
 using AngleSharp;
-using System.Linq;
 
 namespace ntbs_integration_tests
 {
@@ -14,7 +13,6 @@ namespace ntbs_integration_tests
     {
         protected readonly HttpClient Client;
         protected readonly NtbsWebApplicationFactory<Startup> Factory;
-        protected virtual string PageRoute { get; }
 
         protected TestRunnerBase(NtbsWebApplicationFactory<Startup> factory)
         {
@@ -29,21 +27,6 @@ namespace ntbs_integration_tests
             return (IHtmlDocument)document;
         }
 
-        protected string GetPageRouteForId(int id)
-        {
-            return $"{PageRoute}?id={id}";
-        }
-
-        protected string BuildRoute(string route, int id)
-        {
-            return $"{route}?id={id}";
-        }
-
-        protected string BuildEditRoute(string route, int id, bool isBeingSubmitted = false)
-        {
-            return $"{BuildRoute(route, id)}&isBeingSubmitted={isBeingSubmitted}";
-        }
-
         protected string GetRedirectLocation(HttpResponseMessage response)
         {
             return response.Headers.Location.OriginalString;
@@ -56,12 +39,13 @@ namespace ntbs_integration_tests
 
         protected async Task<HttpResponseMessage> SendPostFormWithData(
             IHtmlDocument document,
-            Dictionary<string, string> formData, 
+            Dictionary<string, string> formData,
+            string pageRoute,
             string postRoute = null)
         {
             var form = (IHtmlFormElement)document.QuerySelector("form");
 
-            var submissionRoute = PageRoute;
+            var submissionRoute = pageRoute;
             if (!string.IsNullOrEmpty(postRoute))
             {
                 submissionRoute += postRoute.StartsWith('/') ? postRoute : $"/{postRoute}";
@@ -72,24 +56,19 @@ namespace ntbs_integration_tests
 
         protected async Task<HttpResponseMessage> SendGetFormWithData(
             IHtmlDocument document, 
-            Dictionary<string, string> formData, 
+            Dictionary<string, string> formData,
+            string pageRoute,
             string postRoute = null)
         {
             var form = (IHtmlFormElement)document.QuerySelector("form");
 
-            var submissionRoute = PageRoute;
+            var submissionRoute = pageRoute;
             if (!string.IsNullOrEmpty(postRoute))
             {
                 submissionRoute += postRoute.StartsWith('/') ? postRoute : $"/{postRoute}";
             }
 
             return await Client.SendGetAsync(form, formData, submissionRoute);
-        }
-
-        protected string BuildValidationPath(Dictionary<string, string> formData, string subPath)
-        {
-            var queryString = string.Join("&", formData.Select(kvp => $"{kvp.Key}={kvp.Value}"));
-            return $"{PageRoute}/{subPath}?{queryString}";
         }
     }
 }

--- a/ntbs-integration-tests/TestRunnerNotificationBase.cs
+++ b/ntbs-integration-tests/TestRunnerNotificationBase.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using AngleSharp.Html.Dom;
+using ntbs_service;
+using ntbs_service.Helpers;
+
+namespace ntbs_integration_tests
+{
+    public abstract class TestRunnerNotificationBase : TestRunnerBase
+    {
+        protected virtual string NotificationSubPath { get; }
+
+        protected TestRunnerNotificationBase(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
+
+        protected string GetCurrentPathForId(int id)
+        {
+            return GetPathForId(NotificationSubPath, id);
+        }
+
+        protected string GetPathForId(string subPath, int id)
+        {
+            return RouteHelper.GetNotificationPath(subPath, id);
+        }
+
+        protected string GetValidationPath(Dictionary<string, string> formData, string validationPath, int id = 0)
+        {
+            var queryString = string.Join("&", formData.Select(kvp => $"{kvp.Key}={kvp.Value}"));
+            return GetPathForId($"{NotificationSubPath}/{validationPath}?{queryString}", id);
+        }
+    }
+}

--- a/ntbs-service/Helpers/NotificationErrorGenerator.cs
+++ b/ntbs-service/Helpers/NotificationErrorGenerator.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
 using ntbs_service.Pages_Notifications;
 using System;
 using System.Collections.Generic;
@@ -6,84 +6,86 @@ using System.Linq;
 
 namespace ntbs_service.Helpers
 {
-    public static class NotificationValidationErrorGenerator {
+    public static class NotificationValidationErrorGenerator
+    {
         private static Dictionary<string, NotifyError> NotifyErrorDictionary { get; set; }
 
         // This method converts Model State Errors to Dictionary of Errors to be used in view
-        public static Dictionary<string, NotifyError> MapToDictionary(ModelStateDictionary modelState, int? notificationId) 
+        public static Dictionary<string, NotifyError> MapToDictionary(ModelStateDictionary modelState, int notificationId)
         {
             NotifyErrorDictionary = new Dictionary<string, NotifyError>();
 
-            foreach (var key in modelState.Keys) 
+            foreach (var key in modelState.Keys)
             {
                 // Splitting on '[' as well due to List properties having index, ex. NotificationSites[0]
-                var propertyKey = key.Split(new Char[] {'.', '['})[0];
+                var propertyKey = key.Split(new Char[] { '.', '[' })[0];
 
-                string url;
                 string displayName;
-                switch (propertyKey) {
+                string subPath;
+                switch (propertyKey)
+                {
                     case "PatientDetails":
-                        url = GetUrl("Patient", notificationId);
+                        subPath = NotificationSubPaths.EditPatient;
                         displayName = "Patient Details";
                         break;
                     // NotificationSites is part of Clinical Details page despite being property of Notification
                     // Fall-through is intentional
                     case "NotificationSites":
                     case "ClinicalDetails":
-                        url = GetUrl("ClinicalDetails", notificationId);
+                        subPath = NotificationSubPaths.EditClinicalDetails;
                         displayName = "Clinical Details";
                         break;
                     case "NotificationDate":
                     case "Episode":
-                        url = GetUrl("Episode", notificationId);
+                        subPath = NotificationSubPaths.EditEpisode;
                         displayName = "Hospital Details";
                         break;
                     case "PatientTBHistory":
-                        url = GetUrl("PreviousHistory", notificationId);
+                        subPath = NotificationSubPaths.EditPreviousHistory;
                         displayName = "Previous History";
                         break;
                     case "ImmunosuppressionDetails":
-                        url = GetUrl("Immunosuppression", notificationId);
+                        subPath = NotificationSubPaths.EditImmunosuppression;
                         displayName = "Immunosuppression Details";
                         break;
                     // Travel Details and Visitor Details are editable on the Travel/visitor history screen
                     // Fall-through is intentional
                     case "TravelDetails":
                     case "VisitorDetails":
-                        url = GetUrl("Travel", notificationId);
-                        displayName = "Travel/visitor History";
+                        subPath = NotificationSubPaths.EditTravel;
+                        displayName = "Travel and visitor history";
                         break;
                     default:
                         continue;
                 }
 
-                AddErrorMessagesIntoDictionary(displayName, url, 
+                var url = RouteHelper.GetNotificationPath(subPath, notificationId, true);
+                AddErrorMessagesIntoDictionary(displayName, url,
                     modelState[key]?.Errors?.Select(e => e.ErrorMessage).ToList());
             }
 
             return NotifyErrorDictionary;
         }
 
-        private static void AddErrorMessagesIntoDictionary(string displayName, string url, List<string> errorMessages) {
-            if (errorMessages == null || errorMessages.Count == 0) {
+        private static void AddErrorMessagesIntoDictionary(string displayName, string url, List<string> errorMessages)
+        {
+            if (errorMessages == null || errorMessages.Count == 0)
+            {
                 return;
             }
 
             if (!NotifyErrorDictionary.ContainsKey(displayName))
             {
-                NotifyErrorDictionary.Add(displayName, new NotifyError {
+                NotifyErrorDictionary.Add(displayName, new NotifyError
+                {
                     Url = url,
                     ErrorMessages = errorMessages
                 });
             }
-            else 
+            else
             {
                 NotifyErrorDictionary[displayName].ErrorMessages.AddRange(errorMessages);
             }
         }
-
-
-        private static string GetUrl(string viewModelName, int? notificationId) => 
-            $"/Notifications/Edit/{viewModelName}?id={notificationId}&isBeingSubmitted=True";
     }
 }

--- a/ntbs-service/Helpers/RouteHelper.cs
+++ b/ntbs-service/Helpers/RouteHelper.cs
@@ -1,25 +1,29 @@
-namespace ntbs_service.Helpers
+﻿namespace ntbs_service.Helpers
 {
     public static class RouteHelper
     {
-        public static string GetFullNotificationEditPath(string subPath, int id, bool isBeingSubmitted)
-        {
-            return $"{GetNotificationEditBasePath(subPath)}?id={id}&isBeingSubmitted={isBeingSubmitted}";
-        }
+        public static string NotificationBasePath => "/Notifications/{0}/{1}";
 
-        public static string GetNotificationEditBasePath(string subPath)
+        public static string GetNotificationPath(string subPath, int id, bool isBeingSubmitted = false)
         {
-            return $"/Notifications/Edit/{subPath}";
+            var pathWithQueryString = string.Concat(subPath, isBeingSubmitted ? "?isBeingSubmitted=True" : string.Empty);
+            return string.Format(NotificationBasePath, id, pathWithQueryString);
         }
+    }
 
-        public static string GetFullNotificationPath(string subPath, int id)
-        {
-            return $"{GetNotificationBasePath(subPath)}?id={id}";
-        }
-
-        public static string GetNotificationBasePath(string subPath)
-        {
-            return $"/Notifications/{subPath}";
-        }
+    public static class NotificationSubPaths
+    {
+        public static string EditClinicalDetails => "Edit/ClinicalDetails";
+        public static string EditPatient => "Edit/Patient";
+        public static string EditEpisode => "Edit/Episode";
+        public static string EditContactTracing => "Edit/ContactTracing";
+        public static string EditSocialRiskFactors => "Edit/SocialRiskFactors";
+        public static string EditTravel => "Edit/Travel";
+        public static string EditComorbidities => "Edit/Comorbidities";
+        public static string EditImmunosuppression => "Edit/Immunosuppression";
+        public static string EditPreviousHistory => "Edit/PreviousHistory";
+        public static string Overview => string.Empty;
+        public static string LinkedNotifications => "LinkedNotifications";
+        public static string Denotify => "Denotify";
     }
 }

--- a/ntbs-service/Helpers/RouteHelper.cs
+++ b/ntbs-service/Helpers/RouteHelper.cs
@@ -25,5 +25,6 @@
         public static string Overview => string.Empty;
         public static string LinkedNotifications => "LinkedNotifications";
         public static string Denotify => "Denotify";
+        public static string Delete => "Delete";
     }
 }

--- a/ntbs-service/Helpers/RouteHelper.cs
+++ b/ntbs-service/Helpers/RouteHelper.cs
@@ -1,4 +1,6 @@
-﻿namespace ntbs_service.Helpers
+﻿using Microsoft.AspNetCore.WebUtilities;
+
+namespace ntbs_service.Helpers
 {
     public static class RouteHelper
     {
@@ -6,8 +8,13 @@
 
         public static string GetNotificationPath(string subPath, int id, bool isBeingSubmitted = false)
         {
-            var pathWithQueryString = string.Concat(subPath, isBeingSubmitted ? "?isBeingSubmitted=True" : string.Empty);
-            return string.Format(NotificationBasePath, id, pathWithQueryString);
+            var path = subPath;
+            if (isBeingSubmitted)
+            {
+                path = QueryHelpers.AddQueryString(path, "isBeingSubmitted", "True");
+            }
+
+            return string.Format(NotificationBasePath, id, path);
         }
     }
 

--- a/ntbs-service/Models/Notification.cs
+++ b/ntbs-service/Models/Notification.cs
@@ -103,35 +103,11 @@ namespace ntbs_service.Models
         public string FormattedNotificationDate => FormatDate(NotificationDate);
         public string HIVTestState => ClinicalDetails.HIVTestState?.GetDisplayName() ?? string.Empty;
 
-        public string PatientEditPath => GetNotificationEditPath("Patient");
-        public string EpisodeEditPath => GetNotificationEditPath("Episode");
-        public string ClinicalDetailsEditPath => GetNotificationEditPath("ClinicalDetails");
-        public string ContactTracingEditPath => GetNotificationEditPath("ContactTracing");
-        public string SocialRiskFactorsEditPath => GetNotificationEditPath("SocialRiskFactors");
-        public string TravelEditPath => GetNotificationEditPath("Travel");
-        public string ComorbiditiesEditPath => GetNotificationEditPath("Comorbidities");
-        public string ImmunosuppressionEditPath => GetNotificationEditPath("Immunosuppression");
-        public string PreviousHistoryEditPath => GetNotificationEditPath("PreviousHistory");
-        public string OverviewPath => GetNotificationPath("Overview");
-        public string LinkedNotificationsPath => GetNotificationPath("LinkedNotifications");
-        public string DenotifyPath => GetNotificationPath("Denotify");
-        public string DeletePath => GetNotificationPath("Delete");
-
         public string LocalAuthorityName => PatientDetails?.PostcodeLookup?.LocalAuthority?.Name;
         public string ResidencePHECName => PatientDetails?.PostcodeLookup?.LocalAuthority?.LocalAuthorityToPHEC?.PHEC?.Name;
         public string TreatmentPHECName => Episode.TBService?.PHEC?.Name;
 
         public int? AgeAtNotification => GetAgeAtTimeOfNotification();
-
-        private string GetNotificationEditPath(string subPath)
-        {
-            return RouteHelper.GetFullNotificationEditPath(subPath, NotificationId, ShouldValidateFull);
-        }
-
-        private string GetNotificationPath(string subPath)
-        {
-            return RouteHelper.GetFullNotificationPath(subPath, NotificationId);
-        }
 
         private string GetNotificationStatusString()
         {

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -1,5 +1,6 @@
-using ntbs_service.Models.Enums;
+﻿using ntbs_service.Models.Enums;
 using System.ComponentModel.DataAnnotations.Schema;
+using ntbs_service.Helpers;
 
 namespace ntbs_service.Models
 {
@@ -48,7 +49,7 @@ namespace ntbs_service.Models
             Origin = "ntbs";
             ShowLink = showLink;
             FullAccess = fullAccess;
-            RedirectPath = notification.OverviewPath;
+            RedirectPath = RouteHelper.GetNotificationPath(NotificationSubPaths.Overview, NotificationId);
         }
     }
 }

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using ntbs_service.Helpers
 @model IndexModel
 @{
     ViewData["Title"] = "Home page";
@@ -10,7 +11,7 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(Model => Model.DraftNotifications[0].NotificationId)
+                @Html.DisplayNameFor(model => model.DraftNotifications[0].NotificationId)
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.DraftNotifications[0].FormattedCreationDate)
@@ -27,18 +28,18 @@
 @foreach (var item in Model.DraftNotifications) {
         <tr>
             <th>
-                <a href="./Notifications/Overview?id=@item.NotificationId" class="govuk-link govuk-link--no-visited-state">
-                    @Html.DisplayFor(modelItem => item.NotificationId)
+                <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Overview, item.NotificationId)" class="govuk-link govuk-link--no-visited-state">
+                    @Html.DisplayFor(_ => item.NotificationId)
                 </a>
             </th>
             <td>
-                @Html.DisplayFor(modelItem => item.FormattedCreationDate)
+                @Html.DisplayFor(_ => item.FormattedCreationDate)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.TBServiceName)
+                @Html.DisplayFor(_ => item.TBServiceName)
             </td>
             <td>
-                @Html.DisplayFor(modelItem => item.Episode.CaseManager)
+                @Html.DisplayFor(_ => item.Episode.CaseManager)
             </td>
         </tr>
 }
@@ -50,7 +51,7 @@
     <thead>
         <tr>
             <th>
-                @Html.DisplayNameFor(Model => Model.RecentNotifications[0].NotificationId)
+                @Html.DisplayNameFor(model => model.RecentNotifications[0].NotificationId)
             </th>
             <th>
                 @Html.DisplayNameFor(model => model.RecentNotifications[0].FormattedSubmissionDate)
@@ -67,7 +68,7 @@
 @foreach (var item in Model.RecentNotifications) {
         <tr>
             <th>
-                <a href="./Notifications/Overview?id=@item.NotificationId" class="govuk-link--no-visited-state">
+                <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Overview, item.NotificationId)" class="govuk-link--no-visited-state">
                     @Html.DisplayFor(modelItem => item.NotificationId)
                 </a>
             </th>

--- a/ntbs-service/Pages/Notifications/Delete.cshtml
+++ b/ntbs-service/Pages/Notifications/Delete.cshtml
@@ -1,4 +1,5 @@
-@page "{handler?}"
+@page "/Notifications/{id:int?}/Delete/{handler?}"
+
 @using ntbs_service.Helpers
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 @model ntbs_service.Pages.Notifications.DeleteModel
@@ -32,13 +33,13 @@
                 </nhs-fieldset-legend>
 
                 <span id="reason-error" nhs-span-type="ErrorMessage" asp-validation-for="DeletionReason" has-error="@hasReasonError"></span>
-                <textarea asp-for="DeletionReason" nhs-textarea-type="Standard" is-error-input="@hasReasonError" 
-                    aria-describedby="reason-error" rows="2" classes="delete-reason-text-area-container"> </textarea>
+                <textarea asp-for="DeletionReason" nhs-textarea-type="Standard" is-error-input="@hasReasonError"
+                          aria-describedby="reason-error" rows="2" classes="delete-reason-text-area-container"> </textarea>
             </nhs-fieldset>
         </nhs-form-group>
 
         <button asp-page-handler="Confirm" class="nhsuk-button ntbsuk-button--warning">Confirm deletion</button>
 
-        <nhs-back-link href="@Model.Notification.OverviewPath">Cancel & go back</nhs-back-link>
+        <nhs-back-link href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Overview, Model.NotificationId)">Cancel & go back</nhs-back-link>
     </nhs-grid-column>
 </nhs-grid-row>

--- a/ntbs-service/Pages/Notifications/Denotify.cshtml
+++ b/ntbs-service/Pages/Notifications/Denotify.cshtml
@@ -1,4 +1,5 @@
-@page "{handler?}"
+@page "/Notifications/{id:int?}/Denotify/{handler?}"
+
 @using ntbs_service.Helpers
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 @model ntbs_service.Pages.Notifications.DenotifyModel
@@ -112,6 +113,6 @@
 
     <button nhs-button-type="Standard" asp-page-handler="Confirm">Confirm denotification</button>
 
-    <nhs-back-link href="@Model.Notification.OverviewPath">Cancel & go back</nhs-back-link>
+    <nhs-back-link href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Overview, Model.NotificationId)">Cancel & go back</nhs-back-link>
 
 </div>

--- a/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
@@ -1,4 +1,4 @@
-using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models;
 using ntbs_service.Models.Enums;
 using ntbs_service.Pages_Notifications;
@@ -42,14 +42,10 @@ namespace ntbs_service.Pages.Notifications
                 return NotFound();
             }
 
-            await AuthorizeAndSetBannerAsync();
-            if (!HasEditPermission)
-            {
-                return RedirectToPage("./Overview", new {id});
-            }
-
             NotificationId = Notification.NotificationId;
-            if (Notification.NotificationStatus != NotificationStatus.Notified)
+
+            await AuthorizeAndSetBannerAsync();
+            if (!HasEditPermission || Notification.NotificationStatus != NotificationStatus.Notified)
             {
                 return RedirectToPage("/Notifications/Overview", new { id = NotificationId });
             }

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/ClinicalDetails/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.ClinicalDetailsModel
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 @using ntbs_service.Models

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -39,11 +39,6 @@ namespace ntbs_service.Pages.Notifications.Edit
         public ClinicalDetailsModel(INotificationService service, IAuthorizationService authorizationService, NtbsContext context) : base(service, authorizationService)
         {
             this.context = context;
-        }
-
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
         }
 
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
@@ -94,7 +89,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             }
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./ContactTracing", new { id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml
@@ -1,6 +1,5 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/Comorbidities/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.ComorbiditiesModel
-@using ntbs_service.Models.Enums
 
 @{
     Layout = "../../Shared/_NotificationLayout.cshtml";
@@ -80,7 +79,7 @@
         </nhs-fieldset>
     </nhs-form-group>
 
-     <nhs-form-group nhs-form-group-type="Standard">
+    <nhs-form-group nhs-form-group-type="Standard">
         <nhs-fieldset>
             <nhs-fieldset-legend nhs-legend-size="Standard">
                 Chronic Renal Disease

--- a/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models;
 using ntbs_service.Pages_Notifications;
@@ -11,11 +11,6 @@ namespace ntbs_service.Pages.Notifications.Edit
         [BindProperty]
         public ComorbidityDetails ComorbidityDetails { get; set; }
         public ComorbiditiesModel(INotificationService service, IAuthorizationService authorizationService) : base(service, authorizationService) {}
-
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
 
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
@@ -30,7 +25,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return Page();
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./Immunosuppression", new { id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/ContactTracing/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.ContactTracingModel
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models;
 using ntbs_service.Pages_Notifications;
@@ -13,11 +13,6 @@ namespace ntbs_service.Pages.Notifications.Edit
         [BindProperty]
         public ContactTracing ContactTracing { get; set; }
 
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
-
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
             ContactTracing = Notification.ContactTracing;
@@ -26,7 +21,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return Page();
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./SocialRiskFactors", new {id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/Episode/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.EpisodeModel
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 @using NHSUK.FrontEndLibrary.TagHelpers

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
@@ -1,13 +1,13 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.EntityFrameworkCore;
+using ntbs_service.Helpers;
 using ntbs_service.Models;
 using ntbs_service.Pages_Notifications;
 using ntbs_service.Services;
-using ntbs_service.Helpers;
-using Microsoft.EntityFrameworkCore;
 
 namespace ntbs_service.Pages.Notifications.Edit
 {
@@ -35,10 +35,6 @@ namespace ntbs_service.Pages.Notifications.Edit
             this.userService = userService;
         }
 
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
             Episode = Notification.Episode;
@@ -70,7 +66,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return new JsonResult(tbServices);
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./ClinicalDetails", new { id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/Edit/Immunosuppression.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Immunosuppression.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/Immunosuppression/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.ImmunosuppressionModel
 @using ntbs_service.Models
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
@@ -31,7 +31,7 @@
 
                         @{
                             var hasStatusError = !Model.IsValid("ImmunosuppressionDetails.Status");
-                            var statusFormGroupType = hasStatusError ? Error : Standard;  
+                            var statusFormGroupType = hasStatusError ? Error : Standard;
                         }
 
                         <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-radio">
@@ -54,7 +54,7 @@
 
                                         @{
                                             var hasDescriptionError = !Model.IsValid("ImmunosuppressionDetails.OtherDescription");
-                                            var descriptionFormGroupType = hasDescriptionError ? Error: Standard;
+                                            var descriptionFormGroupType = hasDescriptionError ? Error : Standard;
                                         }
 
                                         <div class="govuk-checkboxes__conditional govuk-checkboxes__conditional--hidden" id="conditional-other-description">
@@ -64,8 +64,8 @@
                                                         Specify Details
                                                     </label>
                                                     <span ref="descriptionError" id="description-error" nhs-span-type="ErrorMessage" asp-validation-for="ImmunosuppressionDetails.OtherDescription"></span>
-                                                    <input ref="otherDescription" asp-for="ImmunosuppressionDetails.OtherDescription" 
-                                                           nhs-input-type="Standard" is-error-input="@hasDescriptionError" aria-describedby="description-error"  />
+                                                    <input ref="otherDescription" asp-for="ImmunosuppressionDetails.OtherDescription"
+                                                           nhs-input-type="Standard" is-error-input="@hasDescriptionError" aria-describedby="description-error" />
                                                 </nhs-fieldset>
                                             </nhs-form-group>
                                         </div>

--- a/ntbs-service/Pages/Notifications/Edit/Immunosuppression.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Immunosuppression.cshtml.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models;
@@ -17,12 +17,7 @@ namespace ntbs_service.Pages.Notifications.Edit
         {
         }
 
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
-
-       protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
+        protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
             ImmunosuppressionDetails = Notification.ImmunosuppressionDetails;
             await SetNotificationProperties(isBeingSubmitted, ImmunosuppressionDetails);
@@ -30,7 +25,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return Page();
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./PreviousHistory", new { id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/Patient/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.PatientModel
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 @using NHSUK.FrontEndLibrary.TagHelpers

--- a/ntbs-service/Pages/Notifications/Edit/Patient.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Patient.cshtml.cs
@@ -44,11 +44,6 @@ namespace ntbs_service.Pages.Notifications.Edit
             Sexes = context.GetAllSexesAsync().Result.ToList();
         }
 
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted = false)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
-
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
             Patient = Notification.PatientDetails;
@@ -105,7 +100,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return validationService.ValidateMultipleProperties<PatientDetails>(propertyValueTuples, shouldValidateFull);
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./Episode", new { id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/PreviousHistory/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.PreviousHistoryModel
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models;
 using ntbs_service.Pages_Notifications;
@@ -14,11 +14,6 @@ namespace ntbs_service.Pages.Notifications.Edit
         [BindProperty]
         public PatientTBHistory PatientTBHistory { get; set; }
 
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
-
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
             PatientTBHistory = Notification.PatientTBHistory;
@@ -32,7 +27,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return Page();
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             // This is the last page in the flow, so there's no next page to go to
             return RedirectToPage("./PreviousHistory", new { id = notificationId, isBeingSubmitted });

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/SocialRiskFactors/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.SocialRiskFactorsModel
 @using ntbs_service.Models.Enums
 

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models;
 using ntbs_service.Pages_Notifications;
@@ -12,11 +12,6 @@ namespace ntbs_service.Pages.Notifications.Edit
         public SocialRiskFactors SocialRiskFactors { get; set; }
 
         public SocialRiskFactorsModel(INotificationService service, IAuthorizationService authorizationService) : base(service, authorizationService) {}
-
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
 
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
@@ -35,7 +30,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             }
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./Travel", new { id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int}/Edit/Travel/{handler?}"
 @model ntbs_service.Pages.Notifications.Edit.TravelModel
 
 @{

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
@@ -1,9 +1,9 @@
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.Models;
 using ntbs_service.Pages_Notifications;
 using ntbs_service.Services;
-using System.Threading.Tasks;
 
 namespace ntbs_service.Pages.Notifications.Edit
 {
@@ -26,11 +26,6 @@ namespace ntbs_service.Pages.Notifications.Edit
                 nameof(Country.Name));
         }
 
-        public override async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted)
-        {
-            return await base.OnGetAsync(id, isBeingSubmitted);
-        }
-
         protected override async Task<IActionResult> PreparePageForGet(int id, bool isBeingSubmitted)
         {
             TravelDetails = Notification.TravelDetails;
@@ -46,7 +41,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             return Page();
         }
 
-        protected override IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted)
+        protected override IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted)
         {
             return RedirectToPage("./Comorbidities", new { id = notificationId, isBeingSubmitted });
         }

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id:int?}/LinkedNotifications/{handler?}"
 @model ntbs_service.Pages_Notifications.LinkedNotificationsModel
 
 @{
@@ -7,11 +7,11 @@
     ViewData["NotificationId"] = @Model.NotificationId;
 }
 
-<h2>Linked Notifications</h2>
+<h2 id="top">Linked Notifications</h2>
 
 @foreach (var notificationBannerModel in @Model.LinkedNotifications)
 {
     <partial name="./Shared/_NotificationBanner" model="notificationBannerModel" />
 }
 
-<a href='#top' class="govuk-link--no-visited-state"> Back to top </a>
+<a href="#top" class="govuk-link--no-visited-state"> Back to top </a>

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models.Enums;
@@ -26,22 +26,23 @@ namespace ntbs_service.Pages_Notifications
         [ViewData]
         public Dictionary<string, NotifyError> NotifyErrorDictionary { get; set; }
 
-        public virtual async Task<IActionResult> OnGetAsync(int notificationId, bool isBeingSubmitted = false)
+        public virtual async Task<IActionResult> OnGetAsync(int id, bool isBeingSubmitted = false)
         {
-            Notification = await GetNotification(notificationId);
-
+            Notification = await GetNotification(id);
             if (Notification == null)
             {
                 return NotFound();
             }
 
+            NotificationId = Notification.NotificationId;
+
             await AuthorizeAndSetBannerAsync();
             if (!HasEditPermission)
             {
-                return RedirectToOverview(notificationId);
+                return RedirectToOverview(NotificationId);
             }
 
-            return await PreparePageForGet(notificationId, isBeingSubmitted);
+            return await PreparePageForGet(NotificationId, isBeingSubmitted);
         }
 
         protected virtual async Task<Notification> GetNotification(int notificationId)
@@ -52,7 +53,7 @@ namespace ntbs_service.Pages_Notifications
         /*
         Post method accepts name of action specified by button clicked.
         Using handler adds handler onto url and therefore breaking javascript
-        validation hapening after form is submitted
+        validation happening after form is submitted
         */
         public async Task<IActionResult> OnPostAsync(string actionName, bool isBeingSubmitted)
         {
@@ -143,7 +144,6 @@ namespace ntbs_service.Pages_Notifications
 
         protected async Task SetNotificationProperties<T>(bool isBeingSubmitted, T ownedModel) where T : ModelBase
         {
-            NotificationId = Notification.NotificationId;
             Notification.SetFullValidation(Notification.NotificationStatus, isBeingSubmitted);
             ownedModel.ShouldValidateFull = Notification.ShouldValidateFull;
 
@@ -157,6 +157,6 @@ namespace ntbs_service.Pages_Notifications
 
         protected abstract Task ValidateAndSave();
         protected abstract Task<IActionResult> PreparePageForGet(int notificationId, bool isBeingSubmitted);
-        protected abstract IActionResult RedirectToNextPage(int? notificationId, bool isBeingSubmitted);
+        protected abstract IActionResult RedirectToNextPage(int notificationId, bool isBeingSubmitted);
     }
 }

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.Models;
 using ntbs_service.Services;
@@ -45,8 +45,11 @@ namespace ntbs_service.Pages_Notifications
 
         protected async Task GetLinkedNotifications()
         {
-            Group = await GetNotificationGroupAsync();
-            NumberOfLinkedNotifications = Group?.Notifications.Count - 1 ?? 0;
+            if (Group == null)
+            {
+                Group = await GetNotificationGroupAsync();
+                NumberOfLinkedNotifications = Group?.Notifications.Count - 1 ?? 0;
+            }
         }
 
         protected IActionResult ForbiddenResult()

--- a/ntbs-service/Pages/Notifications/Overview.cshtml
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml
@@ -1,4 +1,4 @@
-@page "{handler?}"
+@page "/Notifications/{id?}/{handler?}"
 @model OverviewModel
 
 @{

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -1,6 +1,5 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
-using ntbs_service.Models;
 using ntbs_service.Models.Enums;
 using ntbs_service.Pages_Notifications;
 using ntbs_service.Services;

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
@@ -1,11 +1,11 @@
-@{
-    var notificationId = ViewData["NotificationId"];
-}
+@using ntbs_service.Helpers
+@model OverviewModel
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Clinical details </h3>
-    <a href="./Edit/ClinicalDetails?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
-</div> 
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditClinicalDetails, Model.NotificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+</div>
 <div class="notification-overview-details-container">
     <nhs-grid-row classes="notification-overview-details">
         <nhs-grid-column grid-column-width="OneThird">

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ComorbiditiesAndImmunosuppresionOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ComorbiditiesAndImmunosuppresionOverviewPartial.cshtml
@@ -1,12 +1,10 @@
+@using ntbs_service.Helpers
 @model OverviewModel
-
-@{
-    var notificationId = ViewData["NotificationId"];
-}
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Co-morbidities and immunosuppression </h3>
-    <a href="./Edit/Comorbidities?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditComorbidities, Model.NotificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
 </div>
 <div class="notification-overview-details-container">
     <nhs-grid-row classes="notification-overview-details">

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
@@ -1,13 +1,15 @@
+@using ntbs_service.Helpers
 @model ntbs_service.Models.ContactTracing
 
 @{
-    var notificationId = ViewData["NotificationId"];
+    var notificationId = (int)ViewData["NotificationId"];
 }
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Contact tracing </h3>
-    <a href="./Edit/ContactTracing?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
-</div> 
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditContactTracing, notificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+</div>
 <div class="notification-overview-details-container">
     <nhs-grid-row classes="notification-overview-details">
         <nhs-grid-column grid-column-width="OneThird">

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_EpisodeOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_EpisodeOverviewPartial.cshtml
@@ -1,10 +1,10 @@
-@{
-    var notificationId = ViewData["NotificationId"];
-}
+@using ntbs_service.Helpers
+@model OverviewModel
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Hospital Details </h3>
-    <a href="./Edit/Episode?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditEpisode, Model.NotificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
 </div>
 <div class="notification-overview-details-container">
     <nhs-grid-row classes="notification-overview-details">
@@ -20,7 +20,7 @@
     <nhs-grid-row classes="notification-overview-details">
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> TB Service </div>
-            <div class="cell-min-height"> @Model.Notification.TBServiceName </div> 
+            <div class="cell-min-height"> @Model.Notification.TBServiceName </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Hospital </div>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_PatientOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_PatientOverviewPartial.cshtml
@@ -1,11 +1,10 @@
+@using ntbs_service.Helpers
 @model OverviewModel
-@{
-    var notificationId = ViewData["NotificationId"];
-}
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Personal details of patient </h3>
-    <a href="./Edit/Patient?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditPatient, Model.NotificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
 </div>
 <div class="notification-overview-details-container">
     <nhs-grid-row classes="notification-overview-details">

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_PreviousHistoryOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_PreviousHistoryOverviewPartial.cshtml
@@ -1,10 +1,10 @@
-@{
-    var notificationId = ViewData["NotificationId"];
-}
+@using ntbs_service.Helpers
+@model OverviewModel
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Previous history of TB (pre-2000) </h3>
-    <a href="./Edit/PreviousHistory?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditPreviousHistory, Model.NotificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
 </div>
 <div class="notification-overview-details-container">
     <nhs-grid-row classes="notification-overview-details">

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_SocialRiskFactorsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_SocialRiskFactorsOverviewPartial.cshtml
@@ -1,11 +1,11 @@
-@{
-    var notificationId = ViewData["NotificationId"];
-}
+@using ntbs_service.Helpers
+@model OverviewModel
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Social risk factors </h3>
-    <a href="./Edit/SocialRiskFactors?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
-</div> 
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditSocialRiskFactors, Model.NotificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+</div>
 <div class="notification-overview-details-container">
     <nhs-grid-row classes="notification-overview-details">
         <nhs-grid-column grid-column-width="OneThird">

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TravelOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TravelOverviewPartial.cshtml
@@ -1,12 +1,10 @@
+@using ntbs_service.Helpers
 @model OverviewModel
-
-@{
-    var notificationId = ViewData["NotificationId"];
-}
 
 <div class="notification-overview-type-and-edit-container">
     <h3 class="notification-details-type"> Travel/visitors </h3>
-    <a href="./Edit/Travel?id=@notificationId" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
+    <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditTravel, Model.NotificationId)"
+       class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
 </div>
 <div class="notification-overview-details-container">
 

--- a/ntbs-service/Pages/Shared/_NotificationLayout.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationLayout.cshtml
@@ -1,4 +1,5 @@
 @model ntbs_service.Pages_Notifications.NotificationModelBase
+@using ntbs_service.Helpers
 @using static NHSUK.FrontEndLibrary.TagHelpers.GridColumnWidth
 @{
     Layout = "./_Form_Layout.cshtml";
@@ -18,7 +19,7 @@
             break;
     }
 
-    ViewData["IsOverviewPage"] = currentPage == "Overview";
+    ViewData["IsOverviewPage"] = currentPage == string.Empty;
     ViewData["IsPatientPage"] = currentPage == "Patient";
     ViewData["IsEpisodePage"] = currentPage == "Episode";
     ViewData["IsClinicalDetailsPage"] = currentPage == "ClinicalDetails";
@@ -26,7 +27,7 @@
     ViewData["IsSocialRiskFactorsPage"] = currentPage == "SocialRiskFactors";
     ViewData["IsTravelPage"] = currentPage == "Travel";
     ViewData["IsComorbiditiesPage"] = currentPage == "Comorbidities";
-    ViewData["IsImmunosuppressionPage"] = currentPage == "Immunosupression";
+    ViewData["IsImmunosuppressionPage"] = currentPage == "Immunosuppression";
     ViewData["IsPreviousHistoryPage"] = currentPage == "PreviousHistory";
     ViewData["IsLinkedNotificationsPage"] = currentPage == "LinkedNotifications";
 
@@ -43,19 +44,25 @@
             @if (Model.Notification.NotificationStatus != NotificationStatus.Draft)
             {
                 <div class="@((bool) ViewData["IsOverviewPage"] ? "notification-banner-links--current" : "")">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.OverviewPath"> Notification details </a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Overview, Model.NotificationId)">
+                        Notification details
+                    </a>
                 </div>
                 <div class="notification-banner-link-separator"> </div>
             }
             @if (Model.NumberOfLinkedNotifications > 0)
             {
                 <div class="@((bool) ViewData["IsLinkedNotificationsPage"] ? "notification-banner-links--current" : "")">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.LinkedNotificationsPath"> Linked Notifications (@Model.NumberOfLinkedNotifications) </a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.LinkedNotifications, Model.NotificationId)">
+                        Linked Notifications (@Model.NumberOfLinkedNotifications)
+                    </a>
                 </div>
                 <div class="notification-banner-link-separator"> </div>
             }
             <div>
-                <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.OverviewPath"> Audit </a>
+                <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Overview, Model.NotificationId)">
+                    Audit
+                </a>
             </div>
         </div>
     </nhs-grid-column>
@@ -64,31 +71,49 @@
         <nhs-grid-column grid-column-width="OneQuarter">
             <ul class="sub-nav-left">
                 <li class="@("contents-list-item " + ((bool)ViewData["IsPatientPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.PatientEditPath">Personal details</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditPatient, Model.NotificationId)">
+                        Personal details
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsEpisodePage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.EpisodeEditPath">Hospital details</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditEpisode, Model.NotificationId)">
+                        Hospital details
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsClinicalDetailsPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.ClinicalDetailsEditPath">Clinical Details</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditClinicalDetails, Model.NotificationId)">
+                        Clinical Details
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsContactTracingPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.ContactTracingEditPath">Contact Tracing</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditContactTracing, Model.NotificationId)">
+                        Contact Tracing
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsSocialRiskFactorsPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.SocialRiskFactorsEditPath">Social Risk Factors</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditSocialRiskFactors, Model.NotificationId)">
+                        Social Risk Factors
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsTravelPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.TravelEditPath">Travel/visitor history</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditTravel, Model.NotificationId)">
+                        Travel/visitor history
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsComorbiditiesPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.ComorbiditiesEditPath">Co-morbidities</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditComorbidities, Model.NotificationId)">
+                        Co-morbidities
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsImmunosuppressionPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.ImmunosuppressionEditPath">Immunosuppression</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditImmunosuppression, Model.NotificationId)">
+                        Immunosuppression
+                    </a>
                 </li>
                 <li class="@("contents-list-item " + ((bool)ViewData["IsPreviousHistoryPage"] ? "contents-list-item--current" : ""))">
-                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@Model.Notification.PreviousHistoryEditPath">Previous History</a>
+                    <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(NotificationSubPaths.EditPreviousHistory, Model.NotificationId)">
+                        Previous History
+                    </a>
                 </li>
             </ul>
         </nhs-grid-column>
@@ -114,7 +139,7 @@
         <button nhs-button-type="Standard" asp-page-handler="CreateLink">New notification for this person</button>
         if (Model.Notification.NotificationStatus == NotificationStatus.Notified && Model.HasEditPermission)
         {
-            <a href="@Model.Notification.DenotifyPath" role="button" draggable="false" class="nhsuk-button ntbsuk-button--warning">Denotify</a>
+            <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Denotify, Model.NotificationId)" role="button" draggable="false" class="nhsuk-button ntbsuk-button--warning">Denotify</a>
         }
     }
 }

--- a/ntbs-service/Pages/Shared/_NotificationLayout.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationLayout.cshtml
@@ -132,7 +132,7 @@
     @if (Model.Notification.NotificationStatus == NotificationStatus.Draft && Model.HasEditPermission)
     {
         <button nhs-button-type="Standard" name="actionName" value="Submit">Submit</button>
-        <a href="@Model.Notification.DeletePath" role="button" draggable="false" class="nhsuk-button ntbsuk-button--warning delete-notification-button">Delete</a>
+        <a href="@RouteHelper.GetNotificationPath(NotificationSubPaths.Delete, Model.NotificationId)" role="button" draggable="false" class="nhsuk-button ntbsuk-button--warning delete-notification-button">Delete</a>
     }
     else if ((bool)ViewData["IsOverviewPage"])
     {

--- a/ntbs-service/wwwroot/source/Components/ValidatePostcode.ts
+++ b/ntbs-service/wwwroot/source/Components/ValidatePostcode.ts
@@ -1,13 +1,13 @@
-import Vue from 'vue';
-import { getHeaders } from '../helpers';
-import axios from 'axios';
+import Vue from "vue";
+import { getHeaders } from "../helpers";
+import axios from "axios";
 
 const ValidatePostcode = Vue.extend({
-    props: ['shouldvalidatefull'],
+    props: ["shouldvalidatefull"],
     methods: {
         validate: function (event: FocusEvent) {
             // Our onBlur validate events happen on input fields
-            const inputField = event.target as HTMLInputElement
+            const inputField = event.target as HTMLInputElement;
             const newValue = inputField.value;
 
             let requestConfig = {
@@ -23,17 +23,19 @@ const ValidatePostcode = Vue.extend({
                 .then((response: any) => {
                     var errorMessages = response.data;
                     if (errorMessages) {
-                        this.$refs["formGroup"].classList.add('nhsuk-form-group--error');
-                        this.$refs["inputField"].classList.add('nhsuk-input--error')
+                        this.$refs["formGroup"].classList.add("nhsuk-form-group--error");
+                        this.$refs["inputField"].classList.add("nhsuk-input--error");
+                        this.$refs["errorField"].classList.remove("hidden");
                         this.$refs["errorField"].textContent = errorMessages[0];
                     } else {
-                        this.$refs["formGroup"].classList.remove('nhsuk-form-group--error')
-                        this.$refs["inputField"].classList.remove('nhsuk-input--error')
+                        this.$refs["formGroup"].classList.remove("nhsuk-form-group--error");
+                        this.$refs["inputField"].classList.remove("nhsuk-input--error");
+                        this.$refs["errorField"].classList.add("hidden");
                         this.$refs["errorField"].textContent = "";
                     }
                 })
                 .catch((error: any) => {
-                    console.log(error.response)
+                    console.log(error.response);
                 });
         }
     }


### PR DESCRIPTION
## Description
Routing changes to allow notification screens to be navigable via `/Notifications/<id>/<subPath>` e.g. `Notifications/1/Edit/ClinicalDetails`.

Removed redundant OnGetAsync for EditNotification screens.

Added logic for validate postcode to work alongside has-error tag helper.

**There are a handful of other PRs up at the minute that will require further work here - will attempt to negotiate them as consistently as possible when this gets approved**

## Checklist:
- [X] Automated tests are passing locally.
- [X] Have navigated through all the links I could think of... but there might be some remaining (I'm pretty sure there aren't)
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (immitating small screen)
- [X] Check the feature looks and works correctly in IE11 (**Smoke test only**)
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
