### PR TITLE
NTBS-527 fix renaming for new names of clinicalDetails fields

### DIFF
--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -177,8 +177,8 @@ namespace ntbs_integration_tests.NotificationPages
                 ["ClinicalDetails.IsPostMortem"] = "false",
                 ["ClinicalDetails.IsShortCourseTreatment"] = "true",
                 ["ClinicalDetails.IsMDRTreatment"] = "false",
-                ["ClinicalDetails.IsDOT"] = "Yes",
-                ["ClinicalDetails.IsEnhancedCaseManagement"] = "No"
+                ["ClinicalDetails.DotStatus"] = "Yes",
+                ["ClinicalDetails.EnhancedCaseManagementStatus"] = "No"
             };
 
             // Act

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
@@ -98,11 +98,11 @@
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Directly observed treatment </div>
-            <div class="cell-min-height"> @Model.Notification.ClinicalDetails?.IsDOT </div>
+            <div class="cell-min-height"> @Model.Notification.ClinicalDetails?.DotStatus </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneThird">
             <div class="notification-details-label"> Enhanced Case Management </div>
-            <div class="cell-min-height"> @Model.Notification.ClinicalDetails?.IsEnhancedCaseManagement </div>
+            <div class="cell-min-height"> @Model.Notification.ClinicalDetails?.EnhancedCaseManagementStatus </div>
         </nhs-grid-column>
     </nhs-grid-row>
     <nhs-grid-row classes="notification-overview-details">


### PR DESCRIPTION
Renamed variables in tests and on overview page to the new names (IsDOT -> DotStatus and IsEnhancedCaseManagement -> EnhancedCaseManagementStatus)