### PR TITLE
Ntbs 429 hide date warning if symptomatic false

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -227,7 +227,7 @@
                     <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                         <div class="nhsuk-radios__item">
                             <input ref="checkbox0" asp-for="ClinicalDetails.IsSymptomatic" id="symptomatic-yes" class="nhsuk-radios__input" 
-                                type="radio" value="true" data-aria-controls="conditional-symptomatic-conditional">
+                                type="radio" value="true" data-aria-controls="conditional-symptomatic-conditional" v-on:change="datechanged(0)">
                             <label class="nhsuk-label nhsuk-radios__label" for="symptomatic-yes">
                                 Yes
                             </label>
@@ -270,7 +270,7 @@
                                 </validate-date>
                             </div>
                         <div class="nhsuk-radios__item">
-                            <input asp-for="ClinicalDetails.IsSymptomatic" id="symptomatic-no" class="nhsuk-radios__input" type="radio" value="false">
+                            <input asp-for="ClinicalDetails.IsSymptomatic" id="symptomatic-no" class="nhsuk-radios__input" type="radio" value="false"  v-on:change="datechanged(0)">
                             <label class="nhsuk-label nhsuk-radios__label" for="symptomatic-no">
                                 No
                             </label>

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -212,6 +212,7 @@
     <br />
 
     <h2>Clinical Dates</h2>
+
     <date-comparison inline-template>
         <div>
             <ul class="text-warning" id="date-warnings">
@@ -225,7 +226,8 @@
                     <nhs-fieldset-legend nhs-legend-size="Standard">Patient is symptomatic</nhs-fieldset-legend>
                     <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                         <div class="nhsuk-radios__item">
-                            <input asp-for="ClinicalDetails.IsSymptomatic" id="symptomatic-yes" class="nhsuk-radios__input" type="radio" value="true" data-aria-controls="conditional-symptomatic-conditional">
+                            <input ref="checkbox0" asp-for="ClinicalDetails.IsSymptomatic" id="symptomatic-yes" class="nhsuk-radios__input" 
+                                type="radio" value="true" data-aria-controls="conditional-symptomatic-conditional">
                             <label class="nhsuk-label nhsuk-radios__label" for="symptomatic-yes">
                                 Yes
                             </label>

--- a/ntbs-service/wwwroot/source/Components/DateComparison.ts
+++ b/ntbs-service/wwwroot/source/Components/DateComparison.ts
@@ -20,6 +20,11 @@ const DateComparison = Vue.extend({
                 return;
             }
 
+            if(this.$refs[`checkbox${currentIndex}`] && !this.$refs[`checkbox${currentIndex}`].checked) {
+                this.clearWarning(currentIndex, numberOfDates);
+                return;
+            }
+
             var lowerDateIndex = currentIndex - 1;
             for (var i = 0; i <= lowerDateIndex; i++) {
                 // We clear this so the warning is shown with respect to current date
@@ -34,7 +39,9 @@ const DateComparison = Vue.extend({
 
                 if (this.dates[lowerDateIndex] > currentDate)
                 {
-                    this.dateWarnings[currentIndex] = { message: warningMessageEarlier(this.$refs[`date${currentIndex}`].name, this.$refs[`date${lowerDateIndex}`].name), comparedTo: lowerDateIndex };
+                    this.$set(this.dateWarnings, currentIndex, 
+                        { message: warningMessageEarlier(this.$refs[`date${currentIndex}`].name, this.$refs[`date${lowerDateIndex}`].name), 
+                        comparedTo: lowerDateIndex });
                     return;
                 }
                 lowerDateIndex--;
@@ -54,7 +61,9 @@ const DateComparison = Vue.extend({
 
                 if (this.dates[higherDateIndex] < currentDate)
                 {
-                    this.dateWarnings[currentIndex] = { message: warningMessageLater(this.$refs[`date${currentIndex}`].name, this.$refs[`date${higherDateIndex}`].name), comparedTo: higherDateIndex };
+                    this.$set(this.dateWarnings, currentIndex, 
+                        { message: warningMessageLater(this.$refs[`date${currentIndex}`].name, this.$refs[`date${higherDateIndex}`].name), 
+                        comparedTo: higherDateIndex });
                     return;
                 }
                 higherDateIndex++;
@@ -64,7 +73,7 @@ const DateComparison = Vue.extend({
         },
         clearWarning: function(currentIndex: number, numberOfDates: number) {
             if (this.dateWarnings[currentIndex]) {
-                this.dateWarnings[currentIndex] = null;
+                this.$set(this.dateWarnings, currentIndex, null);
             }
             for (var i = 0; i < numberOfDates; i++) {
                 if (i === currentIndex) {
@@ -75,7 +84,7 @@ const DateComparison = Vue.extend({
         },
         unsetMatchingWarning: function(i: number, currentIndex: number) {
             if (this.dateWarnings[i] && this.dateWarnings[i].comparedTo === currentIndex) {
-                this.dateWarnings[i] = null;
+                this.$set(this.dateWarnings, i, null);
             }
         }
     },

--- a/ntbs-service/wwwroot/source/Components/DateComparison.ts
+++ b/ntbs-service/wwwroot/source/Components/DateComparison.ts
@@ -27,7 +27,7 @@ const DateComparison = Vue.extend({
             }
             while (lowerDateIndex >= 0)
             {
-                if (!this.dates[lowerDateIndex]) {
+                if (!this.dates[lowerDateIndex] || (this.$refs[`checkbox${lowerDateIndex}`] && !this.$refs[`checkbox${lowerDateIndex}`].checked)) {
                     lowerDateIndex--;
                     continue;
                 }
@@ -47,7 +47,7 @@ const DateComparison = Vue.extend({
             }
             while (higherDateIndex < numberOfDates)
             {
-                if (!this.dates[higherDateIndex]) {
+                if (!this.dates[higherDateIndex] || (this.$refs[`checkbox${higherDateIndex}`] && !this.$refs[`checkbox${higherDateIndex}`].checked)) {
                     higherDateIndex++;
                     continue;
                 }


### PR DESCRIPTION
This bulk of this change involves using this.$set over manually setting the date warnings so that a new array is created and Vue can pick up the change and realise a rerender is needed. 
