### PR TITLE
NTBS-640 fix cached date range validation

### DIFF
--- a/ntbs-integration-tests/Helpers/TestDocumentExtensions.cs
+++ b/ntbs-integration-tests/Helpers/TestDocumentExtensions.cs
@@ -6,9 +6,14 @@ namespace ntbs_integration_tests.Helpers
 {
     public static class HtmlDocumentExtensions
     {
-        public static string GetError(this IHtmlDocument document, string input) => 
-            document?.QuerySelector($"span[id='{input}-error']")?.TextContent;
-            
+        public static string GetError(this IHtmlDocument document, string input)
+        {
+            var errorSpan = document?.QuerySelector($"span[id='{input}-error']");
+            if (errorSpan == null) return null;
+            if (errorSpan.ClassList.Contains("hidden")) return null;
+            return errorSpan.TextContent;
+        }
+
         public static void AssertErrorMessage(this IHtmlDocument document, string inputName, string expectedMessage)
         {
             var expected = HtmlDocumentHelpers.FullErrorMessage(expectedMessage);

--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -14,7 +14,7 @@ namespace ntbs_integration_tests.NotificationPages
     {
         protected override string NotificationSubPath => NotificationSubPaths.EditClinicalDetails;
 
-        public ClinicalDetailsPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
+        public ClinicalDetailsPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
         [Fact]
         public async Task PostDraft_ReturnsPageWithAllModelErrors_IfModelNotValid()
@@ -35,13 +35,13 @@ namespace ntbs_integration_tests.NotificationPages
                 ["FormattedSymptomDate.Day"] = "10",
                 ["FormattedFirstPresentationDate.Day"] = "1",
                 ["FormattedFirstPresentationDate.Month"] = "1",
-                ["FormattedFirstPresentationDate.Year"] = "2000",
+                ["FormattedFirstPresentationDate.Year"] = "2050",
                 ["FormattedTbServicePresentationDate.Day"] = "1",
                 ["FormattedTbServicePresentationDate.Month"] = "1",
-                ["FormattedTbServicePresentationDate.Year"] = "2000",
+                ["FormattedTbServicePresentationDate.Year"] = "2050",
                 ["FormattedDiagnosisDate.Day"] = "1",
                 ["FormattedDiagnosisDate.Month"] = "1",
-                ["FormattedDiagnosisDate.Year"] = "2000",
+                ["FormattedDiagnosisDate.Year"] = "2050",
                 ["ClinicalDetails.DidNotStartTreatment"] = "false",
                 ["FormattedTreatmentDate.Day"] = "1",
                 ["ClinicalDetails.IsShortCourseTreatment"] = "true",
@@ -58,11 +58,11 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat), resultDocument.GetError("other-site"));
             Assert.Equal(FullErrorMessage(ValidationMessages.ValidYear), resultDocument.GetError("bcg-vaccination"));
             Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate), resultDocument.GetError("symptom"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier),
+            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier("Presentation to any health service")),
                 resultDocument.GetError("first-presentation"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier),
+            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier("Presentation to TB service")),
                 resultDocument.GetError("tb-service-presentation"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier),
+            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier("Diagnosis Date")),
                 resultDocument.GetError("diagnosis"));
             Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate), resultDocument.GetError("treatment"));
             Assert.Equal(FullErrorMessage(ValidationMessages.ValidTreatmentOptions), resultDocument.GetError("short-course"));
@@ -314,7 +314,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
-            Assert.Equal(ValidationMessages.TodayOrEarlier, result);
+            Assert.Equal(ValidationMessages.DateValidityRangeStart("Diagnosis Date", "01/01/2010"), result);
         }
 
         [Theory]
@@ -361,7 +361,7 @@ namespace ntbs_integration_tests.NotificationPages
         [Fact]
         public async Task ValidateClinicalDetailsYearComparison_ReturnsErrorIfNewYearEarlierThanExisting()
         {
-             // Arrange
+            // Arrange
             var existingYear = 1990;
             var formData = new Dictionary<string, string>
             {

--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -55,18 +55,15 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat), resultDocument.GetError("other-site"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidYear), resultDocument.GetError("bcg-vaccination"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate), resultDocument.GetError("symptom"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier("Presentation to any health service")),
-                resultDocument.GetError("first-presentation"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier("Presentation to TB service")),
-                resultDocument.GetError("tb-service-presentation"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.TodayOrEarlier("Diagnosis Date")),
-                resultDocument.GetError("diagnosis"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate), resultDocument.GetError("treatment"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidTreatmentOptions), resultDocument.GetError("short-course"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidTreatmentOptions), resultDocument.GetError("mdr"));
+            resultDocument.AssertErrorMessage("other-site", ValidationMessages.StandardStringFormat);
+            resultDocument.AssertErrorMessage("bcg-vaccination", ValidationMessages.ValidYear);
+            resultDocument.AssertErrorMessage("symptom", ValidationMessages.ValidDate);
+            resultDocument.AssertErrorMessage("first-presentation", ValidationMessages.TodayOrEarlier("Presentation to any health service"));
+            resultDocument.AssertErrorMessage("tb-service-presentation", ValidationMessages.TodayOrEarlier("Presentation to TB service"));
+            resultDocument.AssertErrorMessage("diagnosis", ValidationMessages.TodayOrEarlier("Diagnosis Date"));
+            resultDocument.AssertErrorMessage("treatment", ValidationMessages.ValidDate);
+            resultDocument.AssertErrorMessage("short-course", ValidationMessages.ValidTreatmentOptions);
+            resultDocument.AssertErrorMessage("mdr", ValidationMessages.ValidTreatmentOptions);
         }
 
         [Fact]
@@ -92,9 +89,9 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DiseaseSiteOtherIsRequired), resultDocument.GetError("other-site"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.BCGYearIsRequired), resultDocument.GetError("bcg-vaccination"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.DeathDateIsRequired), resultDocument.GetError("postmortem"));
+            resultDocument.AssertErrorMessage("other-site", ValidationMessages.DiseaseSiteOtherIsRequired);
+            resultDocument.AssertErrorMessage("bcg-vaccination", ValidationMessages.BCGYearIsRequired);
+            resultDocument.AssertErrorMessage("postmortem", ValidationMessages.DeathDateIsRequired);
         }
 
         [Fact]
@@ -147,7 +144,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DiagnosisDateIsRequired), resultDocument.GetError("diagnosis"));
+            resultDocument.AssertErrorMessage("diagnosis", ValidationMessages.DiagnosisDateIsRequired);
         }
 
         [Fact]

--- a/ntbs-integration-tests/NotificationPages/DeletePageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DeletePageTests.cs
@@ -123,7 +123,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.StringWithNumbersAndForwardSlashFormat), resultDocument.GetError("reason"));
+            resultDocument.AssertErrorMessage("reason", ValidationMessages.StringWithNumbersAndForwardSlashFormat);
         }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
@@ -160,7 +160,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate), resultDocument.GetError("date"));
+            resultDocument.AssertErrorMessage("date", ValidationMessages.ValidDate);
         }
 
         [Fact]
@@ -193,7 +193,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DenotificationDateLatestToday), resultDocument.GetError("date"));
+            resultDocument.AssertErrorMessage("date", ValidationMessages.DenotificationDateLatestToday);
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DenotificationDateAfterNotification), resultDocument.GetError("date"));
+            resultDocument.AssertErrorMessage("date", ValidationMessages.DenotificationDateAfterNotification);
         }
 
         [Fact]
@@ -256,7 +256,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DenotificationReasonRequired), resultDocument.GetError("reason"));
+            resultDocument.AssertErrorMessage("reason", ValidationMessages.DenotificationReasonRequired);
         }
 
         [Fact]
@@ -289,7 +289,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.DenotificationReasonOtherRequired), resultDocument.GetError("description"));
+            resultDocument.AssertErrorMessage("description", ValidationMessages.DenotificationReasonOtherRequired);
         }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
@@ -22,10 +22,10 @@ namespace ntbs_integration_tests.NotificationPages
             return new List<Notification>()
             {
                 new Notification()
-                { 
-                    NotificationId = Utilities.NOTIFIED_WITH_TBSERVICE, 
-                    NotificationStatus = NotificationStatus.Notified, 
-                    Episode = new Episode() 
+                {
+                    NotificationId = Utilities.NOTIFIED_WITH_TBSERVICE,
+                    NotificationStatus = NotificationStatus.Notified,
+                    Episode = new Episode()
                     {
                         TBServiceCode = "A code",
                         TBService = new TBService() { Name = "A name" }
@@ -84,7 +84,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            var expectedMessage = ValidationMessages.TodayOrEarlier;
+            var expectedMessage = ValidationMessages.DateValidityRangeStart("Notification date", "01/01/2010");
             resultDocument.AssertErrorMessage("notification-date", expectedMessage);
         }
 
@@ -160,7 +160,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.TodayOrEarlier);
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.DateValidityRangeStart("Notification date", "01/01/2010"));
         }
 
         [Fact]

--- a/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/EpisodesPageTests.cs
@@ -57,8 +57,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
-            Assert.Equal(FullErrorMessage(ValidationMessages.ValidDate),
-                        resultDocument.GetError("notification-date"));
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.ValidDate);
         }
 
         [Fact]

--- a/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ImmunosuppressionPageTests.cs
@@ -39,7 +39,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
 
-            Assert.Equal(FullErrorMessage(ValidationMessages.ImmunosuppressionTypeRequired), resultDocument.GetError("status"));
+            resultDocument.AssertErrorMessage("status", ValidationMessages.ImmunosuppressionTypeRequired);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
             result.EnsureSuccessStatusCode();
 
-            Assert.Equal(FullErrorMessage(ValidationMessages.ImmunosuppressionDetailRequired), resultDocument.GetError("description"));
+            resultDocument.AssertErrorMessage("description", ValidationMessages.ImmunosuppressionDetailRequired);
         }
 
         [Fact]

--- a/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
@@ -98,7 +98,7 @@ namespace ntbs_integration_tests.NotificationPages
             resultDocument.AssertErrorMessage("given-name", ValidationMessages.StandardStringFormat);
             resultDocument.AssertErrorMessage("family-name", ValidationMessages.StandardStringFormat);
             // Cannot easily check for equality with FullErrorMessage here as the error field is formatted oddly due to there being two fields in the error span.
-            Assert.Contains(ValidationMessages.TodayOrEarlier, resultDocument.GetError("dob"));
+            Assert.Contains(ValidationMessages.DateValidityRangeStart("Date of birth", "01/01/1900"), resultDocument.GetError("dob"));
             resultDocument.AssertErrorMessage("nhs-number", ValidationMessages.NhsNumberLength);
             resultDocument.AssertErrorMessage("address", ValidationMessages.StringWithNumbersAndForwardSlashFormat);
             resultDocument.AssertErrorMessage("local-patient-id", ValidationMessages.InvalidCharacter);
@@ -364,7 +364,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
-            Assert.Equal(ValidationMessages.TodayOrEarlier, result);
+            Assert.Equal(ValidationMessages.DateValidityRangeStart("Date of birth", "01/01/1900"), result);
         }
 
         [Theory]

--- a/ntbs-integration-tests/SearchPage/SearchPageTests.cs
+++ b/ntbs-integration-tests/SearchPage/SearchPageTests.cs
@@ -9,7 +9,7 @@ namespace ntbs_integration_tests.SearchPage
 {
     public class SearchPageTests : TestRunnerBase
     {
-        public SearchPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) {}
+        public SearchPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
 
         public const string PageRoute = "/Search";
 
@@ -39,12 +39,12 @@ namespace ntbs_integration_tests.SearchPage
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
-            Assert.Equal(FullErrorMessage(ValidationMessages.NumberFormat), resultDocument.GetError("id"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat), resultDocument.GetError("family-name"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringFormat), resultDocument.GetError("given-name"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.StandardStringWithNumbersFormat), resultDocument.GetError("postcode"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.InvalidDate), resultDocument.GetError("dob"));
-            Assert.Equal(FullErrorMessage(ValidationMessages.InvalidDate), resultDocument.GetError("notification-date"));
+            resultDocument.AssertErrorMessage("id", ValidationMessages.NumberFormat);
+            resultDocument.AssertErrorMessage("family-name", ValidationMessages.StandardStringFormat);
+            resultDocument.AssertErrorMessage("given-name", ValidationMessages.StandardStringFormat);
+            resultDocument.AssertErrorMessage("postcode", ValidationMessages.StandardStringWithNumbersFormat);
+            resultDocument.AssertErrorMessage("dob", ValidationMessages.InvalidDate);
+            resultDocument.AssertErrorMessage("notification-date", ValidationMessages.InvalidDate);
         }
 
 
@@ -64,7 +64,7 @@ namespace ntbs_integration_tests.SearchPage
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
-            
+
             Assert.Equal(" #1 ", resultDocument.QuerySelector("a[id='notification-banner-id']").TextContent);
         }
     }

--- a/ntbs-service/Models/ClinicalDetails.cs
+++ b/ntbs-service/Models/ClinicalDetails.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using ExpressiveAnnotations.Attributes;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Enums;
@@ -11,24 +12,30 @@ namespace ntbs_service.Models
     {
         public bool? IsSymptomatic { get; set; }
          
-        [ValidDate(ValidDates.EarliestClinicalDate)]
+        [Display(Name = "Symptoms start date")]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? SymptomStartDate { get; set; }
 
-        [ValidDate(ValidDates.EarliestClinicalDate)]
+        [Display(Name = "Presentation to any health service")]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? FirstPresentationDate { get; set; }
         
-        [ValidDate(ValidDates.EarliestClinicalDate)]
+        [Display(Name = "Presentation to TB service")]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? TBServicePresentationDate { get; set; }
 
+        [Display(Name = "Diagnosis Date")]
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.DiagnosisDateIsRequired)]
-        [ValidDate(ValidDates.EarliestClinicalDate)]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? DiagnosisDate { get; set; }
 
-        [ValidDate(ValidDates.EarliestClinicalDate)]
+        [Display(Name = "Treatment start date")]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? TreatmentStartDate { get; set; }
 
+        [Display(Name = "Date of death")]
         [RequiredIf(@"ShouldValidateFull && IsPostMortem == true", ErrorMessage = ValidationMessages.DeathDateIsRequired)]
-        [ValidDate(ValidDates.EarliestClinicalDate)]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? DeathDate { get; set; }
 
         public bool? DidNotStartTreatment { get; set; }
@@ -46,8 +53,9 @@ namespace ntbs_service.Models
 
         [OnlyOneTrue("IsShortCourseTreatment", ErrorMessage = ValidationMessages.ValidTreatmentOptions)]
         public bool? IsMDRTreatment { get; set; }
-        [ValidDate(ValidDates.EarliestClinicalDate)]
 
+        [Display(Name = "MDR treatment date")]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? MDRTreatmentStartDate { get; set; }
         public Status? DotStatus { get; set; }
         public Status? EnhancedCaseManagementStatus { get; set; }

--- a/ntbs-service/Models/ClinicalDetails.cs
+++ b/ntbs-service/Models/ClinicalDetails.cs
@@ -11,7 +11,7 @@ namespace ntbs_service.Models
     public class ClinicalDetails : ModelBase
     {
         public bool? IsSymptomatic { get; set; }
-         
+
         [Display(Name = "Symptoms start date")]
         [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? SymptomStartDate { get; set; }
@@ -19,7 +19,7 @@ namespace ntbs_service.Models
         [Display(Name = "Presentation to any health service")]
         [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? FirstPresentationDate { get; set; }
-        
+
         [Display(Name = "Presentation to TB service")]
         [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? TBServicePresentationDate { get; set; }
@@ -54,7 +54,7 @@ namespace ntbs_service.Models
         [OnlyOneTrue("IsShortCourseTreatment", ErrorMessage = ValidationMessages.ValidTreatmentOptions)]
         public bool? IsMDRTreatment { get; set; }
 
-        [Display(Name = "MDR treatment date")]
+        [Display(Name = "RR/MDR/XDR treatment date")]
         [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? MDRTreatmentStartDate { get; set; }
         public Status? DotStatus { get; set; }

--- a/ntbs-service/Models/Notification.cs
+++ b/ntbs-service/Models/Notification.cs
@@ -37,9 +37,10 @@ namespace ntbs_service.Models
         [MaxLength(150)]
         public string DeletionReason { get; set; }
 
+        [Display(Name = "Notification date")]
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.NotificationDateIsRequired)]
         [AssertThat(@"PatientDetails.Dob == null || NotificationDate > PatientDetails.Dob", ErrorMessage = ValidationMessages.NotificationDateShouldBeLaterThanDob)]
-        [ValidDate(ValidDates.EarliestClinicalDate)]
+        [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? NotificationDate { get; set; }
         public NotificationStatus NotificationStatus { get; set; }
 
@@ -116,7 +117,7 @@ namespace ntbs_service.Models
             if (NotificationStatus == NotificationStatus.Draft)
             {
                 return "Draft";
-            } 
+            }
             else if (NotificationStatus == NotificationStatus.Notified)
             {
                 return "Notification";
@@ -188,7 +189,8 @@ namespace ntbs_service.Models
 
         private string FormatNhsNumberString()
         {
-            if (PatientDetails.NhsNumberNotKnown) {
+            if (PatientDetails.NhsNumberNotKnown)
+            {
                 return "Not known";
             }
             if (string.IsNullOrEmpty(PatientDetails.NhsNumber))
@@ -222,16 +224,16 @@ namespace ntbs_service.Models
 
         private int? GetAgeAtTimeOfNotification()
         {
-            if (NotificationDate == null || PatientDetails?.Dob == null) 
+            if (NotificationDate == null || PatientDetails?.Dob == null)
             {
                 return null;
             }
 
-            var notificationDate = (DateTime) NotificationDate;
-            var birthDate = (DateTime) PatientDetails.Dob;
+            var notificationDate = (DateTime)NotificationDate;
+            var birthDate = (DateTime)PatientDetails.Dob;
 
             var yearDiff = notificationDate.Year - birthDate.Year;
-            if ((birthDate.Month*100 + birthDate.Day) > (notificationDate.Month*100 + notificationDate.Day))
+            if ((birthDate.Month * 100 + birthDate.Day) > (notificationDate.Month * 100 + notificationDate.Day))
             {
                 yearDiff -= 1;
             }

--- a/ntbs-service/Models/PatientDetails.cs
+++ b/ntbs-service/Models/PatientDetails.cs
@@ -28,18 +28,19 @@ namespace ntbs_service.Models
 
         [MaxLength(50)]
         [RegularExpression(
-            ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtended, 
+            ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtended,
             ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string LocalPatientId { get; set; }
 
+        [Display(Name = "Date of birth")]
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.BirthDateIsRequired)]
-        [ValidDate(ValidDates.EarliestBirthDate)]
+        [ValidDateRange(ValidDates.EarliestBirthDate)]
         public DateTime? Dob { get; set; }
         public bool? UkBorn { get; set; }
 
         [MaxLength(150)]
         [RegularExpression(
-            ValidationRegexes.CharacterValidationWithNumbersForwardSlashAndNewLine, 
+            ValidationRegexes.CharacterValidationWithNumbersForwardSlashAndNewLine,
             ErrorMessage = ValidationMessages.StringWithNumbersAndForwardSlashFormat)]
         public string Address { get; set; }
 
@@ -51,7 +52,7 @@ namespace ntbs_service.Models
         public virtual PostcodeLookup PostcodeLookup { get; set; }
 
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.BirthCountryIsRequired)]
-        public int? CountryId { get; set;}
+        public int? CountryId { get; set; }
         public virtual Country Country { get; set; }
 
         [Range(1900, 2100, ErrorMessage = ValidationMessages.ValidYear)]
@@ -66,7 +67,7 @@ namespace ntbs_service.Models
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.EthnicGroupIsRequired)]
         public int? EthnicityId { get; set; }
         public virtual Ethnicity Ethnicity { get; set; }
-        
+
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.SexIsRequired)]
         public int? SexId { get; set; }
         public virtual Sex Sex { get; set; }

--- a/ntbs-service/Models/Validations/ValidationAttributes.cs
+++ b/ntbs-service/Models/Validations/ValidationAttributes.cs
@@ -1,20 +1,36 @@
 using System;
-using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
-using System.Reflection;
-using ntbs_service.Models;
-using ntbs_service.Models.Validations;
 
 namespace ntbs_service.Models.Validations
 {
-    public class ValidDateAttribute : RangeAttribute
+    public class ValidDateRangeAttribute : ValidationAttribute
     {
-        public ValidDateAttribute(string startDateString) : base(typeof(DateTime),
-            startDateString, DateTime.Now.ToShortDateString()) {}
+        private readonly DateTime StartDate;
+        public ValidDateRangeAttribute(string startDate) : base()
+        {
+            StartDate = DateTime.Parse(startDate);
+        }
+
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            if (value != null)
+            {
+                var date = (DateTime)value;
+                if (date < StartDate)
+                {
+                    return new ValidationResult(ErrorMessage);
+                }
+                if (date > DateTime.Today)
+                {
+                    return new ValidationResult(ValidationMessages.TodayOrEarlier(validationContext.DisplayName));
+                }
+            }
+            return null;
+        }
 
         public override string FormatErrorMessage(string name)
         {
-            return ValidationMessages.TodayOrEarlier;
+            return ValidationMessages.DateValidityRangeStart(name, StartDate.ToShortDateString());
         }
     }
 
@@ -33,7 +49,8 @@ namespace ntbs_service.Models.Validations
             var propertyToCompare = instance.GetType().GetProperty(ComparisonValue);
             object valueToCompare = propertyToCompare.GetValue(instance);
 
-            if (IsTruthy(valueToCompare) && IsTruthy(value)) {
+            if (IsTruthy(valueToCompare) && IsTruthy(value))
+            {
                 return new ValidationResult(ErrorMessage);
             }
             return null;
@@ -52,10 +69,10 @@ namespace ntbs_service.Models.Validations
 
         public AtLeastOnePropertyAttribute(params string[] propertyList)
         {
-            this.PropertyList  = propertyList;
+            this.PropertyList = propertyList;
         }
 
-        protected override ValidationResult IsValid(object value, ValidationContext validationContext) 
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
         {
             foreach (var propertyName in PropertyList)
             {
@@ -77,19 +94,24 @@ namespace ntbs_service.Models.Validations
             {
                 return null;
             }
-            if (!string.IsNullOrEmpty(partialDate.Day)) {
-                if(string.IsNullOrEmpty(partialDate.Month) || string.IsNullOrEmpty(partialDate.Year)) {
+            if (!string.IsNullOrEmpty(partialDate.Day))
+            {
+                if (string.IsNullOrEmpty(partialDate.Month) || string.IsNullOrEmpty(partialDate.Year))
+                {
                     return new ValidationResult(ValidationMessages.YearIfMonthRequired);
                 }
             }
-            if(!string.IsNullOrEmpty(partialDate.Month)) {
-                if(string.IsNullOrEmpty(partialDate.Year)) {
+            if (!string.IsNullOrEmpty(partialDate.Month))
+            {
+                if (string.IsNullOrEmpty(partialDate.Year))
+                {
                     return new ValidationResult(ValidationMessages.YearRequired);
                 }
             }
 
             bool canConvert = partialDate.TryConvertToDateTimeRange(out _, out _);
-            if (!canConvert) {
+            if (!canConvert)
+            {
                 return new ValidationResult(ErrorMessage);
             }
             return null;
@@ -107,7 +129,8 @@ namespace ntbs_service.Models.Validations
             }
 
             bool canConvert = formattedDate.TryConvertToDateTime(out _);
-            if (!canConvert) {
+            if (!canConvert)
+            {
                 return new ValidationResult(ErrorMessage);
             }
             return null;

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -6,11 +6,8 @@ namespace ntbs_service.Models.Validations
     {
         public const string ValidDate = "Please enter a valid date";
         public const string ValidYear = "Please enter a valid year";
-        public const string TodayOrEarlier = "Must be today or earlier";
-        public static string DateValidityRange(string startDate)
-        {
-            return $"Must be between {startDate} and {DateTime.Now.ToShortDateString()}";
-        }
+        public static string TodayOrEarlier(string name) => $"{name} must be today or earlier";
+        public static string DateValidityRangeStart(string name, string startDate) => $"{name} must not be before {startDate}";
 
         public static string ValidYearLaterThanBirthYear(int birthYear)
         {
@@ -27,9 +24,10 @@ namespace ntbs_service.Models.Validations
         public const string PositiveNumbersOnly = "Please enter a positive value";
         public const string InvalidDate = "Invalid date selection";
         public const string YearIfMonthRequired = "Year and month must be provided if a day has been provided";
-        public const string YearRequired = "A year must be provided";            
+        public const string YearRequired = "A year must be provided";
         public const string SupplyAParameter = "Please supply at least one of these fields";
         public const string ValidYearRange = "Year must be provided between {1} and {2}";
+
         #endregion
 
         #region Patient Details
@@ -84,7 +82,7 @@ namespace ntbs_service.Models.Validations
         public const string NotificationDateShouldBeLaterThanDob = "Notification date must be later than date of birth";
 
         #endregion
-        
+
         #region Travel History
         public const string TravelOrVisitTotalNumberOfCountriesRequired = "Please supply total number of countries";
         public const string TotalNumberOfCountriesVisitedFromGreaterThanInputNumber = "Number of countries entered exceeds total number of countries visited from";

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -56,7 +56,7 @@ namespace ntbs_service.Models.Validations
         public const string ValidTreatmentOptions = "Short course and MDR treatment cannot both be true";
         public const string ShortTreatmentIsRequired = "Short course treatment cannot be Yes if MDR treatment is Yes";
         public const string MDRIsRequired = "MDR treatment cannot be Yes if Short course treatment is Yes";
-        public const string MDRDateIsRequired = "MDR treatment date is a mandatory field";
+        public const string MDRDateIsRequired = "RR/MDR/XDR treatment date is a mandatory field";
         public const string BCGYearIsRequired = "BCG Year of vaccination is a mandatory field";
         #endregion
 

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -294,7 +294,7 @@
 
             <validate-date ref="date1" name="Presentation To Any Health Service Date" model="ClinicalDetails" property="FirstPresentationDate" rank="1" v-model="dates[1]" inline-template>
                 @{
-                    var hasPresentationAnyHealthServiceError = !Model.IsValid("ClinicalDetails.PresentationToAnyHealthServiceDate");
+                    var hasPresentationAnyHealthServiceError = !Model.IsValid("ClinicalDetails.FirstPresentationDate");
                     var presentationAnyHealthServiceGroupState = hasPresentationAnyHealthServiceError ? Error : Standard;
                 }
                 <nhs-form-group nhs-form-group-type=@presentationAnyHealthServiceGroupState>


### PR DESCRIPTION
## Description
Fix "today" getting cached in the date range validation to value from server startup

Separate commit bring the error message assertion helper to all places that need it.


## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
- [x] Test functionality without javascript
- [x] Test in small window (immitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
