### PR TITLE
NTBS-451: Post-qa markups

### DIFF
--- a/ntbs-service/Models/ClinicalDetails.cs
+++ b/ntbs-service/Models/ClinicalDetails.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel.DataAnnotations;
 using ExpressiveAnnotations.Attributes;
 using Microsoft.EntityFrameworkCore;
@@ -12,7 +12,7 @@ namespace ntbs_service.Models
     {
         public bool? IsSymptomatic { get; set; }
 
-        [Display(Name = "Symptoms start date")]
+        [Display(Name = "Symptom onset date")]
         [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? SymptomStartDate { get; set; }
 
@@ -33,7 +33,7 @@ namespace ntbs_service.Models
         [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? TreatmentStartDate { get; set; }
 
-        [Display(Name = "Date of death")]
+        [Display(Name = "Date of Death")]
         [RequiredIf(@"ShouldValidateFull && IsPostMortem == true", ErrorMessage = ValidationMessages.DeathDateIsRequired)]
         [ValidDateRange(ValidDates.EarliestClinicalDate)]
         public DateTime? DeathDate { get; set; }

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -222,10 +222,10 @@
 
     <date-comparison inline-template>
         <div>
-            <div v-if="dateWarnings.length > 0">
+            <div v-if="filteredDateWarnings.length > 0">
                 <govuk-warning-text id="nhs-number-warning" ref="nhs-number-warning">
                     <div class="warning-container">
-                        <p v-for="warning in dateWarnings" v-if="warning">
+                        <p v-for="warning in filteredDateWarnings">
                             <strong>{{ warning.message }}</strong>
                         </p>
                     </div>

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -5,8 +5,8 @@
 
 @{
     Layout = "../../Shared/_NotificationLayout.cshtml";
-    ViewData["Title"] = "Notification - Clinical Details";
-    var fullValidation = Model.ClinicalDetails.ShouldValidateFull ? "True" : "False";
+ViewData["Title"] = "Notification - Clinical Details";
+var fullValidation = Model.ClinicalDetails.ShouldValidateFull ? "True" : "False";
 }
 
 <!-- TODO: Split this into multiple partial pages for readability -->
@@ -248,11 +248,11 @@
                                 var hasSymptomError = !Model.IsValid("ClinicalDetails.SymptomStartDate");
                                 var symptomGroupState = hasSymptomError ? Error : Standard;
                             }
-                            <validate-date ref="date0" name="Symptom onset" model="ClinicalDetails" property="SymptomStartDate" rank="0" v-model="dates[0]" inline-template>
+                            <validate-date ref="date0" name="@Html.DisplayNameFor(model => model.ClinicalDetails.SymptomStartDate)" model="ClinicalDetails" property="SymptomStartDate" rank="0" v-model="dates[0]" inline-template>
                                 <nhs-form-group nhs-form-group-type=@symptomGroupState>
                                     <nhs-fieldset aria-describedby="symptom-error" role="group">
                                         <nhs-fieldset-legend nhs-legend-size="Standard" classes="govuk-visually-hidden">
-                                            Symptom onset date
+                                            @Html.DisplayNameFor(model => model.ClinicalDetails.SymptomStartDate)
                                         </nhs-fieldset-legend>
                                         <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="ClinicalDetails.SymptomStartDate"
                                               has-error="@hasSymptomError" id="symptom-error"></span>
@@ -294,14 +294,16 @@
             </nhs-form-group>
             <br />
 
-            <validate-date ref="date1" name="Presentation to health service" model="ClinicalDetails" property="FirstPresentationDate" rank="1" v-model="dates[1]" inline-template>
+            <validate-date ref="date1" name="@Html.DisplayNameFor(model => model.ClinicalDetails.FirstPresentationDate)" model="ClinicalDetails" property="FirstPresentationDate" rank="1" v-model="dates[1]" inline-template>
                 @{
                     var hasPresentationAnyHealthServiceError = !Model.IsValid("ClinicalDetails.FirstPresentationDate");
                     var presentationAnyHealthServiceGroupState = hasPresentationAnyHealthServiceError ? Error : Standard;
                 }
                 <nhs-form-group nhs-form-group-type=@presentationAnyHealthServiceGroupState>
                     <nhs-fieldset aria-describedby="first-presentation-error" role="group">
-                        <nhs-fieldset-legend nhs-legend-size="Standard">Presentation to any health service</nhs-fieldset-legend>
+                        <nhs-fieldset-legend nhs-legend-size="Standard">
+                            @Html.DisplayNameFor(model => model.ClinicalDetails.FirstPresentationDate)
+                        </nhs-fieldset-legend>
                         <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="ClinicalDetails.FirstPresentationDate"
                               has-error="@hasPresentationAnyHealthServiceError" id="first-presentation-error"></span>
                         <nhs-date-input id="presentation-to-any-health-service">
@@ -332,14 +334,16 @@
             </validate-date>
             <br />
 
-            <validate-date ref="date2" name="Presentation to TB service" model="ClinicalDetails" property="TBServicePresentationDate" rank="2" v-model="dates[2]" inline-template>
+            <validate-date ref="date2" name="@Html.DisplayNameFor(m => m.ClinicalDetails.TBServicePresentationDate)" model="ClinicalDetails" property="TBServicePresentationDate" rank="2" v-model="dates[2]" inline-template>
                 @{
                     var hasPresentationTbServiceError = !Model.IsValid("ClinicalDetails.TBServicePresentationDate");
                     var presentationTbServiceGroupState = hasPresentationTbServiceError ? Error : Standard;
                 }
                 <nhs-form-group nhs-form-group-type=@presentationTbServiceGroupState>
                     <nhs-fieldset aria-describedby="tb-service-presentation-error" role="group">
-                        <nhs-fieldset-legend nhs-legend-size="Standard">Presentation to TB service</nhs-fieldset-legend>
+                        <nhs-fieldset-legend nhs-legend-size="Standard">
+                            @Html.DisplayNameFor(m => m.ClinicalDetails.TBServicePresentationDate)
+                        </nhs-fieldset-legend>
                         <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="ClinicalDetails.TBServicePresentationDate"
                               has-error="@hasPresentationTbServiceError" id="tb-service-presentation-error"></span>
                         <nhs-date-input id="presentation-to-TB-service">
@@ -370,7 +374,7 @@
             </validate-date>
             <br />
 
-            <validate-date ref="date3" name="Diagnosis date" model="ClinicalDetails" property="DiagnosisDate" rank="3" v-model="dates[3]" inline-template>
+            <validate-date ref="date3" name="@Html.DisplayNameFor(m => m.ClinicalDetails.DiagnosisDate)" model="ClinicalDetails" property="DiagnosisDate" rank="3" v-model="dates[3]" inline-template>
                 @{
                     var hasDiagnosisError = !Model.IsValid("ClinicalDetails.DiagnosisDate");
                     var diagnosisGroupState = hasDiagnosisError ? Error : Standard;
@@ -378,7 +382,7 @@
                 <nhs-form-group nhs-form-group-type=@diagnosisGroupState>
                     <nhs-fieldset aria-describedby="diagnosis-error" role="group">
                         <nhs-fieldset-legend nhs-legend-size="Standard">
-                            Diagnosis Date (required)
+                            @Html.DisplayNameFor(m => m.ClinicalDetails.DiagnosisDate) (required)
                         </nhs-fieldset-legend>
                         <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="ClinicalDetails.DiagnosisDate"
                               has-error="@hasDiagnosisError" id="diagnosis-error"></span>
@@ -425,11 +429,11 @@
                                 var hasTreatmentError = !Model.IsValid("ClinicalDetails.TreatmentStartDate");
                                 var treatmentGroupState = hasTreatmentError ? Error : Standard;
                             }
-                            <validate-date ref="date4" name="Treatment start date" model="ClinicalDetails" property="TreatmentStartDate" rank="4" v-model="dates[4]" inline-template>
+                            <validate-date ref="date4" name="@Html.DisplayNameFor(m => m.ClinicalDetails.TreatmentStartDate)" model="ClinicalDetails" property="TreatmentStartDate" rank="4" v-model="dates[4]" inline-template>
                                 <nhs-form-group nhs-form-group-type=@treatmentGroupState>
                                     <nhs-fieldset aria-describedby="treatment-error" role="group">
                                         <nhs-fieldset-legend nhs-legend-size="Standard" classes="govuk-visually-hidden">
-                                            Treatment start date
+                                            @Html.DisplayNameFor(m => m.ClinicalDetails.TreatmentStartDate)
                                         </nhs-fieldset-legend>
                                         <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="ClinicalDetails.TreatmentStartDate"
                                               has-error="@hasTreatmentError" id="treatment-error"></span>
@@ -486,10 +490,12 @@
                                 var hasDeathDateError = !Model.IsValid("ClinicalDetails.DeathDate");
                                 var deathDateGroupState = hasDeathDateError ? Error : Standard;
                             }
-                            <validate-date ref="date5" name="Death Date" model="ClinicalDetails" property="DeathDate" rank="5" v-model="dates[5]" inline-template>
+                            <validate-date ref="date5" name="@Html.DisplayNameFor(m => m.ClinicalDetails.DeathDate)" model="ClinicalDetails" property="DeathDate" rank="5" v-model="dates[5]" inline-template>
                                 <nhs-form-group nhs-form-group-type=@deathDateGroupState>
                                     <nhs-fieldset aria-describedby="postmortem-error" role="group">
-                                        <nhs-fieldset-legend nhs-legend-size="Standard">Date of Death</nhs-fieldset-legend>
+                                        <nhs-fieldset-legend nhs-legend-size="Standard">
+                                            @Html.DisplayNameFor(m => m.ClinicalDetails.DeathDate)
+                                        </nhs-fieldset-legend>
                                         <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="ClinicalDetails.DeathDate"
                                               has-error="@hasDeathDateError" id="postmortem-error"></span>
                                         <nhs-date-input id="postmortem">

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -2,7 +2,6 @@
 @model ntbs_service.Pages.Notifications.Edit.ClinicalDetailsModel
 @using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 @using ntbs_service.Models
-@using ntbs_service.Models.Enums
 
 @{
     Layout = "../../Shared/_NotificationLayout.cshtml";
@@ -160,7 +159,7 @@
             </nhs-fieldset-legend>
             <nhs-checkboxes>
                 <nhs-checkboxes-item>
-                    <input nhs-input-type="Checkboxes" asp-for="ClinicalDetails.NoSampleTaken"/>
+                    <input nhs-input-type="Checkboxes" asp-for="ClinicalDetails.NoSampleTaken" />
                     <label nhs-label-type="Checkboxes" asp-for="ClinicalDetails.NoSampleTaken">No sample taken</label>
                 </nhs-checkboxes-item>
             </nhs-checkboxes>
@@ -223,12 +222,15 @@
 
     <date-comparison inline-template>
         <div>
-            @* TODO: Implement this as non-javascript friendly *@
-            <ul class="text-warning" id="date-warnings">
-                <li v-for="warning in dateWarnings" v-if="warning">
-                    <h4>{{ warning.message }}</h4>
-                </li>
-            </ul>
+            <div v-if="dateWarnings.length > 0">
+                <govuk-warning-text id="nhs-number-warning" ref="nhs-number-warning">
+                    <div class="warning-container">
+                        <p v-for="warning in dateWarnings" v-if="warning">
+                            <strong>{{ warning.message }}</strong>
+                        </p>
+                    </div>
+                </govuk-warning-text>
+            </div>
 
             <nhs-form-group nhs-form-group-type="Standard">
                 <nhs-fieldset>
@@ -246,7 +248,7 @@
                                 var hasSymptomError = !Model.IsValid("ClinicalDetails.SymptomStartDate");
                                 var symptomGroupState = hasSymptomError ? Error : Standard;
                             }
-                            <validate-date ref="date0" name="Symptom Onset Date" model="ClinicalDetails" property="SymptomStartDate" rank="0" v-model="dates[0]" inline-template>
+                            <validate-date ref="date0" name="Symptom onset" model="ClinicalDetails" property="SymptomStartDate" rank="0" v-model="dates[0]" inline-template>
                                 <nhs-form-group nhs-form-group-type=@symptomGroupState>
                                     <nhs-fieldset aria-describedby="symptom-error" role="group">
                                         <nhs-fieldset-legend nhs-legend-size="Standard" classes="govuk-visually-hidden">
@@ -259,21 +261,21 @@
                                                 <nhs-form-group nhs-form-group-type="Standard">
                                                     <label nhs-label-type="Date" asp-for="FormattedSymptomDate.Day">Day</label>
                                                     <input v-on:blur="validate" ref="dayInput" nhs-input-type="Date" fixed-width="Two"
-                                                           is-error-input=@hasSymptomError asp-for="FormattedSymptomDate.Day"/>
+                                                           is-error-input=@hasSymptomError asp-for="FormattedSymptomDate.Day" />
                                                 </nhs-form-group>
                                             </nhs-date-input-item>
                                             <nhs-date-input-item>
                                                 <nhs-form-group nhs-form-group-type="Standard">
                                                     <label nhs-label-type="Date" asp-for="FormattedSymptomDate.Month">Month</label>
                                                     <input v-on:blur="validate" ref="monthInput" nhs-input-type="Date" fixed-width="Two"
-                                                           is-error-input=@hasSymptomError asp-for="FormattedSymptomDate.Month"/>
+                                                           is-error-input=@hasSymptomError asp-for="FormattedSymptomDate.Month" />
                                                 </nhs-form-group>
                                             </nhs-date-input-item>
                                             <nhs-date-input-item>
                                                 <nhs-form-group nhs-form-group-type="Standard">
                                                     <label nhs-label-type="Date" asp-for="FormattedSymptomDate.Year">Year</label>
                                                     <input v-on:blur="validate" ref="yearInput" nhs-input-type="Date" fixed-width="Four"
-                                                           is-error-input=@hasSymptomError asp-for="FormattedSymptomDate.Year"/>
+                                                           is-error-input=@hasSymptomError asp-for="FormattedSymptomDate.Year" />
                                                 </nhs-form-group>
                                             </nhs-date-input-item>
                                         </nhs-date-input>
@@ -292,7 +294,7 @@
             </nhs-form-group>
             <br />
 
-            <validate-date ref="date1" name="Presentation To Any Health Service Date" model="ClinicalDetails" property="FirstPresentationDate" rank="1" v-model="dates[1]" inline-template>
+            <validate-date ref="date1" name="Presentation to health service" model="ClinicalDetails" property="FirstPresentationDate" rank="1" v-model="dates[1]" inline-template>
                 @{
                     var hasPresentationAnyHealthServiceError = !Model.IsValid("ClinicalDetails.FirstPresentationDate");
                     var presentationAnyHealthServiceGroupState = hasPresentationAnyHealthServiceError ? Error : Standard;
@@ -330,7 +332,7 @@
             </validate-date>
             <br />
 
-            <validate-date ref="date2" name="Presentation To TB Service Date" model="ClinicalDetails" property="TBServicePresentationDate" rank="2" v-model="dates[2]" inline-template>
+            <validate-date ref="date2" name="Presentation to TB service" model="ClinicalDetails" property="TBServicePresentationDate" rank="2" v-model="dates[2]" inline-template>
                 @{
                     var hasPresentationTbServiceError = !Model.IsValid("ClinicalDetails.TBServicePresentationDate");
                     var presentationTbServiceGroupState = hasPresentationTbServiceError ? Error : Standard;
@@ -368,7 +370,7 @@
             </validate-date>
             <br />
 
-            <validate-date ref="date3" name="Diagnosis Date" model="ClinicalDetails" property="DiagnosisDate" rank="3" v-model="dates[3]" inline-template>
+            <validate-date ref="date3" name="Diagnosis date" model="ClinicalDetails" property="DiagnosisDate" rank="3" v-model="dates[3]" inline-template>
                 @{
                     var hasDiagnosisError = !Model.IsValid("ClinicalDetails.DiagnosisDate");
                     var diagnosisGroupState = hasDiagnosisError ? Error : Standard;
@@ -423,7 +425,7 @@
                                 var hasTreatmentError = !Model.IsValid("ClinicalDetails.TreatmentStartDate");
                                 var treatmentGroupState = hasTreatmentError ? Error : Standard;
                             }
-                            <validate-date ref="date4" name="Treatment Start Date" model="ClinicalDetails" property="TreatmentStartDate" rank="4" v-model="dates[4]" inline-template>
+                            <validate-date ref="date4" name="Treatment start date" model="ClinicalDetails" property="TreatmentStartDate" rank="4" v-model="dates[4]" inline-template>
                                 <nhs-form-group nhs-form-group-type=@treatmentGroupState>
                                     <nhs-fieldset aria-describedby="treatment-error" role="group">
                                         <nhs-fieldset-legend nhs-legend-size="Standard" classes="govuk-visually-hidden">
@@ -436,21 +438,21 @@
                                                 <nhs-form-group nhs-form-group-type="Standard">
                                                     <label nhs-label-type="Date" asp-for="FormattedTreatmentDate.Day">Day</label>
                                                     <input v-on:blur="validate" ref="dayInput" nhs-input-type="Date" fixed-width="Two"
-                                                           is-error-input=@hasTreatmentError asp-for="FormattedTreatmentDate.Day"/>
+                                                           is-error-input=@hasTreatmentError asp-for="FormattedTreatmentDate.Day" />
                                                 </nhs-form-group>
                                             </nhs-date-input-item>
                                             <nhs-date-input-item>
                                                 <nhs-form-group nhs-form-group-type="Standard">
                                                     <label nhs-label-type="Date" asp-for="FormattedTreatmentDate.Month">Month</label>
                                                     <input v-on:blur="validate" ref="monthInput" nhs-input-type="Date" fixed-width="Two"
-                                                           is-error-input=@hasTreatmentError asp-for="FormattedTreatmentDate.Month"/>
+                                                           is-error-input=@hasTreatmentError asp-for="FormattedTreatmentDate.Month" />
                                                 </nhs-form-group>
                                             </nhs-date-input-item>
                                             <nhs-date-input-item>
                                                 <nhs-form-group nhs-form-group-type="Standard">
                                                     <label nhs-label-type="Date" asp-for="FormattedTreatmentDate.Year">Year</label>
                                                     <input v-on:blur="validate" ref="yearInput" nhs-input-type="Date" fixed-width="Four"
-                                                           is-error-input=@hasTreatmentError asp-for="FormattedTreatmentDate.Year"/>
+                                                           is-error-input=@hasTreatmentError asp-for="FormattedTreatmentDate.Year" />
                                                 </nhs-form-group>
                                             </nhs-date-input-item>
                                         </nhs-date-input>
@@ -602,7 +604,7 @@
             <nhs-form-group nhs-form-group-type="@mdrGroupState" v-bind:class="{ 'nhsuk-form-group--error': hasError}">
                 <nhs-fieldset>
                     <nhs-fieldset-legend nhs-legend-size="Standard">RR/MDR/XDR Treatment Planned?</nhs-fieldset-legend>
-                    <span ref="errorField[1]" nhs-span-type="ErrorMessage" asp-validation-for="ClinicalDetails.IsMDRTreatment" 
+                    <span ref="errorField[1]" nhs-span-type="ErrorMessage" asp-validation-for="ClinicalDetails.IsMDRTreatment"
                           has-error="@hasMdrError" id="mdr-error"></span>
                     <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                         <div class="nhsuk-radios__item">

--- a/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Patient.cshtml
@@ -21,7 +21,7 @@
     <nhs-number-duplicate-warning inline-template>
         <div>
             <govuk-warning-text id="nhs-number-warning" ref="nhs-number-warning" is-hidden="@isWarningHidden">
-                <strong>NHS number is associated with other notification(s), please confirm:</strong>
+                <strong>NHS number is already associated with the following notification(s), please review:</strong>
                 <div ref="warning-container" id="nhs-number-links">
                     @if (Model.DuplicateNhsNumberNotifications != null)
                     {

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -124,8 +124,24 @@ body {
 }
 
 /* Need to pin this to 38px to make icon circular */
-.govuk-warning-text__icon {
-    width: 38px;
+.govuk-warning-text {
+    color: orangered;
+
+    .govuk-warning-text__icon {
+        width: 38px;
+        border: 3px solid orangered;
+        background: orangered;
+    }
+
+    .warning-container {
+        p {
+            margin-bottom: 12px;
+        }
+
+        p:last-child {
+            margin-bottom: 0px;
+        }
+    }
 }
 
 .flex-container {

--- a/ntbs-service/wwwroot/source/Components/DateComparison.ts
+++ b/ntbs-service/wwwroot/source/Components/DateComparison.ts
@@ -3,11 +3,17 @@ import Vue from 'vue';
 // Component to validate date order. Compares the members of the "dates" array, in ascending index order.
 // Bind dates using v-model, and have bound component emit a datechanged event when date changes.
 const DateComparison = Vue.extend({
-    data: function() {
-      return {
-        dates: [],
-        dateWarnings: []
-      }
+    data: function () {
+        return {
+            dates: [],
+            dateWarnings: []
+        }
+    },
+    computed: {
+        filteredDateWarnings: function () {
+            return this.dateWarnings.filter((i: any) => i);
+        }
+
     },
     methods: {
         datechanged: function (rank: any) {
@@ -20,7 +26,7 @@ const DateComparison = Vue.extend({
                 return;
             }
 
-            if(this.$refs[`checkbox${currentIndex}`] && !this.$refs[`checkbox${currentIndex}`].checked) {
+            if (this.$refs[`checkbox${currentIndex}`] && !this.$refs[`checkbox${currentIndex}`].checked) {
                 this.clearWarning(currentIndex, numberOfDates);
                 return;
             }
@@ -30,18 +36,18 @@ const DateComparison = Vue.extend({
                 // We clear this so the warning is shown with respect to current date
                 this.unsetMatchingWarning(i, currentIndex);
             }
-            while (lowerDateIndex >= 0)
-            {
+            while (lowerDateIndex >= 0) {
                 if (!this.dates[lowerDateIndex] || (this.$refs[`checkbox${lowerDateIndex}`] && !this.$refs[`checkbox${lowerDateIndex}`].checked)) {
                     lowerDateIndex--;
                     continue;
                 }
 
-                if (this.dates[lowerDateIndex] > currentDate)
-                {
-                    this.$set(this.dateWarnings, currentIndex, 
-                        { message: warningMessageEarlier(this.$refs[`date${currentIndex}`].name, this.$refs[`date${lowerDateIndex}`].name), 
-                        comparedTo: lowerDateIndex });
+                if (this.dates[lowerDateIndex] > currentDate) {
+                    this.$set(this.dateWarnings, currentIndex,
+                        {
+                            message: warningMessageEarlier(this.$refs[`date${currentIndex}`].name, this.$refs[`date${lowerDateIndex}`].name),
+                            comparedTo: lowerDateIndex
+                        });
                     return;
                 }
                 lowerDateIndex--;
@@ -52,18 +58,18 @@ const DateComparison = Vue.extend({
                 // We clear this so the warning is shown with respect to current date
                 this.unsetMatchingWarning(i, currentIndex);
             }
-            while (higherDateIndex < numberOfDates)
-            {
+            while (higherDateIndex < numberOfDates) {
                 if (!this.dates[higherDateIndex] || (this.$refs[`checkbox${higherDateIndex}`] && !this.$refs[`checkbox${higherDateIndex}`].checked)) {
                     higherDateIndex++;
                     continue;
                 }
 
-                if (this.dates[higherDateIndex] < currentDate)
-                {
-                    this.$set(this.dateWarnings, currentIndex, 
-                        { message: warningMessageLater(this.$refs[`date${currentIndex}`].name, this.$refs[`date${higherDateIndex}`].name), 
-                        comparedTo: higherDateIndex });
+                if (this.dates[higherDateIndex] < currentDate) {
+                    this.$set(this.dateWarnings, currentIndex,
+                        {
+                            message: warningMessageLater(this.$refs[`date${currentIndex}`].name, this.$refs[`date${higherDateIndex}`].name),
+                            comparedTo: higherDateIndex
+                        });
                     return;
                 }
                 higherDateIndex++;
@@ -71,7 +77,7 @@ const DateComparison = Vue.extend({
 
             this.clearWarning(currentIndex, numberOfDates);
         },
-        clearWarning: function(currentIndex: number, numberOfDates: number) {
+        clearWarning: function (currentIndex: number, numberOfDates: number) {
             if (this.dateWarnings[currentIndex]) {
                 this.$set(this.dateWarnings, currentIndex, null);
             }
@@ -82,7 +88,7 @@ const DateComparison = Vue.extend({
                 this.unsetMatchingWarning(i, currentIndex);
             }
         },
-        unsetMatchingWarning: function(i: number, currentIndex: number) {
+        unsetMatchingWarning: function (i: number, currentIndex: number) {
             if (this.dateWarnings[i] && this.dateWarnings[i].comparedTo === currentIndex) {
                 this.$set(this.dateWarnings, i, null);
             }

--- a/ntbs-service/wwwroot/source/Components/DateComparison.ts
+++ b/ntbs-service/wwwroot/source/Components/DateComparison.ts
@@ -95,9 +95,9 @@ export {
 };
 
 function warningMessageEarlier(first: string, second: string) {
-    return `Warning: ${first} is earlier than ${second}`;
+    return `${first} is earlier than ${second}`;
 };
 
 function warningMessageLater(first: string, second: string) {
-    return `Warning: ${first} is later than ${second}`;
+    return `${first} is later than ${second}`;
 };

--- a/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
+++ b/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
@@ -17,7 +17,7 @@ const NhsNumberDuplicateWarning = Vue.extend({
 
             axios.request(requestConfig)
                 .then((response: any) => {
-                    if (response.data) {
+                    if (response.data && Object.keys(response.data).length !== 0) {
                         this.displayWarnings(response.data);
                     } else {
                         this.hideWarnings();

--- a/ntbs-service/wwwroot/source/Components/ValidateDate.ts
+++ b/ntbs-service/wwwroot/source/Components/ValidateDate.ts
@@ -40,7 +40,6 @@ const ValidateDate = Vue.extend({
 
             axios.request(requestConfig)
                 .then((response: any) => {
-                    console.log(response);
                     var errorMessage = response.data;
 
                     this.$refs["errorField"].textContent = errorMessage;


### PR DESCRIPTION
## Description
Fix issue with nhs-duplicate component
Additionally roll out warning component to other warnings (clinical dates) and recolour to `orangered`.

## Checklist:
- [X] Automated tests are passing locally.
### Accessibility testing
- [X] Test functionality without javascript (Clinical dates still doesn't work without JS)
- [X] Test in small window (immitating small screen)
- [X] Check the feature looks and works correctly in IE11
- [X] Zoom page to 400% - content still visible?
- [X] Test feature works with keyboard only operation
- [X] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
