### PR TITLE
Speed up jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ COPY ntbs-service/ntbs-service.csproj ./ntbs-service/
 RUN dotnet restore ntbs-service/ntbs-service.csproj
 
 # copy and build app
-COPY . ./
+COPY ntbs-service/ ./ntbs-service/
+COPY EFAuditer/ ./EFAuditer/
 RUN dotnet publish ntbs-service/*.csproj -c Release -o out
 
 FROM node AS build-frontend
@@ -22,7 +23,9 @@ COPY ntbs-service/package-lock.json .
 RUN npm install
 
 # copy everything else and build frontend app
-COPY ./ntbs-service/ .
+COPY ./ntbs-service/wwwroot ./wwwroot
+COPY ./ntbs-service/tsconfig.json ./
+COPY ./ntbs-service/webpack* ./
 RUN npm run build:prod
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,48 +4,52 @@ pipeline {
   }
   agent { label 'linux' }
   stages {
-    stage('run unit tests') {
-      steps {
-        script {
-          docker.image('mcr.microsoft.com/dotnet/core/sdk:2.2').inside {
-            sh(script: '''
-              # Workaround from https://stackoverflow.com/a/57212491/2363767
-              export DOTNET_CLI_HOME="/tmp/DOTNET_CLI_HOME"
-              cd ntbs-service-unit-tests
-              echo "Running service unit tests"
-              dotnet test
-              cd ../EFAuditer-tests
-              echo "Running EFAuditer unit tests"
-              dotnet test
-            ''')
+    stage('run automated tests') {
+      parallel {
+        stage('run unit tests') {
+          steps {
+            script {
+              docker.image('mcr.microsoft.com/dotnet/core/sdk:2.2').inside {
+                sh(script: '''
+                  # Workaround from https://stackoverflow.com/a/57212491/2363767
+                  export DOTNET_CLI_HOME="/tmp/DOTNET_CLI_HOME"
+                  cd ntbs-service-unit-tests
+                  echo "Running service unit tests"
+                  dotnet test
+                  cd ../EFAuditer-tests
+                  echo "Running EFAuditer unit tests"
+                  dotnet test
+                ''')
+              }
+            }
           }
         }
-      }
-    }
-    stage('run integration tests') {
-      steps {
-        script {
-          docker.image('mcr.microsoft.com/dotnet/core/sdk:2.2').inside {
-            sh(script: '''
-              # Workaround from https://stackoverflow.com/a/57212491/2363767
-              export DOTNET_CLI_HOME="/tmp/DOTNET_CLI_HOME"
-              cd ntbs-integration-tests
-              echo "Running integration tests"
-              dotnet test
-            ''')
+        stage('run integration tests') {
+          steps {
+            script {
+              docker.image('mcr.microsoft.com/dotnet/core/sdk:2.2').inside {
+                sh(script: '''
+                  # Workaround from https://stackoverflow.com/a/57212491/2363767
+                  export DOTNET_CLI_HOME="/tmp/DOTNET_CLI_HOME"
+                  cd ntbs-integration-tests
+                  echo "Running integration tests"
+                  dotnet test
+                ''')
+              }
+            }
           }
         }
-      }
-    }
-    stage('run ui tests') {
-      steps {
-        script {
-          docker.build("ntbs-service-ui-tests:${NTBS_BUILD}",  "-f Dockerfile-uitests --build-arg CACHEBUST=${NTBS_BUILD} .").inside {
-            sh(script: '''
-              # We would like to run the actual tests in here, but an issue with jenkins means we do that within the docker build
-              # See Dockerfile-uitests for details.
-              echo "ui tests complete"
-            ''')
+        stage('run ui tests') {
+          steps {
+            script {
+              docker.build("ntbs-service-ui-tests:${NTBS_BUILD}",  "-f Dockerfile-uitests --build-arg CACHEBUST=${NTBS_BUILD} .").inside {
+                sh(script: '''
+                  # We would like to run the actual tests in here, but an issue with jenkins means we do that within the docker build
+                  # See Dockerfile-uitests for details.
+                  echo "ui tests complete"
+                ''')
+              }
+            }
           }
         }
       }

--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -28,6 +28,7 @@ namespace ntbs_service
                 {
                     var logger = services.GetRequiredService<ILogger<Program>>();
                     logger.LogError(ex, "An error occurred migrating the DB.");
+                    throw ex;
                 }
 
                 try
@@ -39,6 +40,7 @@ namespace ntbs_service
                 {
                     var logger = services.GetRequiredService<ILogger<Program>>();
                     logger.LogError(ex, "An error occurred migrating the Audit DB.");
+                    throw ex;
                 }
             }
 

--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -1,13 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using EFAuditer;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using ntbs_service.Models;

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -15,6 +15,7 @@
   },
   "AdfsOptions": {
     "Wtrealm": "https://localhost:5001/",
-    "DevGroup": "Global.NIS.NTBS.NTA"
+    "DevGroup": "Global.NIS.NTBS.NTA",
+    "UseDummyAuth": true
   }
 }

--- a/ntbs-service/appsettings.Test.json
+++ b/ntbs-service/appsettings.Test.json
@@ -1,5 +1,8 @@
 {
-    "AppConfig" : {
-      "AuditingEnabled" : false
-    }
+  "AppConfig" : {
+    "AuditingEnabled" : false
+  },
+  "AdfsOptions": {
+    "UseDummyAuth": true
   }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
* Make docker build only copy the files it actually needs
* Run tests in parallel

I've tried out the change to parallel in https://jenkins2.softwire.com/job/phe-ntbs/job/master/414/, which took ages - seemingly the move to parallel has made all intermediate image caches invalid (as a result of running on different slaves perhaps??). I assume these will now be sourcable from the cache and will actually speed up once merged, but if not i'm ready to take the parallel bit out