### PR TITLE
NTBS-210 use disabled dropdown to show locked TB service

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
@@ -78,7 +78,10 @@
                 else
                 {
                     <input asp-for="Episode.TBServiceCode" class="hidden"/>
-                    <p class="no-bottom-margin"> Notifying TB Service: @Model.Notification.Episode?.TBService?.Name </p>
+                    <p class="no-bottom-margin"> Notifying TB Service </p>
+                    <select nhs-select-type="Standard" disabled>
+                            <option value="@Model.Notification.Episode?.TBService?.Code" selected="selected"> @Model.Notification.Episode?.TBService?.Name </option>
+                    </select>
                 }
                 </nhs-form-group>
             


### PR DESCRIPTION
Simple change to add disabled dropdown to show locked TB service - the hidden input is kept in as a disabled select won't send it's information in the form (which is needed for validation). Another approach would be to make the select component "readonly" and style it as if it is disabled (give it grey text instead of black).