### PR TITLE
Use serilog for better request logs

### DIFF
--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -19,6 +19,7 @@ using ntbs_service.DataAccess;
 using ntbs_service.Middleware;
 using ntbs_service.Models;
 using ntbs_service.Services;
+using Serilog;
 
 namespace ntbs_service
 {
@@ -137,9 +138,15 @@ namespace ntbs_service
                 app.UseHsts();
             }
 
+            app.UseStaticFiles();
+
+            app.UseSerilogRequestLogging(options => // Needs to be before MVC handlers
+            {
+                options.MessageTemplate = "HTTP {RequestMethod} {RequestPath} responded {StatusCode} in {Elapsed:0.0000} ms ({RequestId})";
+            });
+
             app.UseHttpsRedirection();
             app.UseAuthentication();
-            app.UseStaticFiles();
             app.UseCookiePolicy();
             if (Configuration.GetValue<bool>(Constants.AUDIT_ENABLED_CONFIG_VALUE))
             {

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -1,17 +1,10 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  },
   "ConnectionStrings": {
     "ntbsContext": "data source=localhost;initial catalog=ntbsDev;trusted_connection=true",
     "auditContext": "data source=localhost;initial catalog=ntbsAudit;trusted_connection=true"
   },
-  "AppConfig" : {
-    "AuditingEnabled" : false
+  "AppConfig": {
+    "AuditingEnabled": false
   },
   "AdfsOptions": {
     "Wtrealm": "https://localhost:5001/",

--- a/ntbs-service/appsettings.Production.json
+++ b/ntbs-service/appsettings.Production.json
@@ -1,11 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
-    }
-  },
   "ConnectionStrings": {
     "ntbsContext": "<supplied through env variable>",
     "auditContext": "<supplied through env variable>"

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -1,9 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Warning"
-    }
-  },
   "AllowedHosts": "*",
   "AdfsOptions": {
     "AdfsUrl": "https://ntbs.uksouth.cloudapp.azure.com",

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="NHSUK.FrontEndLibrary.TagHelpers" Version="1.1.3-alpha" />
     <PackageReference Include="ExpressiveAnnotations" Version="2.9.6" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Models/SeedData/*.csv">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related Jira ticket -->

## Description
Logs should now have timestamps and request ids on them consistently.
Serilog seems more flexible then the default logger so we can tweak it further as needed.