### PR TITLE
NTBS-684 Order search results by notification date

### DIFF
--- a/ntbs-service/Services/SearchService.cs
+++ b/ntbs-service/Services/SearchService.cs
@@ -53,8 +53,7 @@ namespace ntbs_service.Services
 
         private IQueryable<Notification> OrderQueryableByNotificationDate(IQueryable<Notification> query) 
         {
-            return query.OrderByDescending(n => n.CreationDate)
-                .OrderByDescending(n => n.SubmissionDate);
+            return query.OrderByDescending(n => n.NotificationDate ?? n.CreationDate);
         }
 
         private async Task<IList<T>> GetPaginatedItemsAsync<T>(IQueryable<T> items, PaginationParameters paginationParameters)


### PR DESCRIPTION
Search by notification date (and if that is not available use creation date).

I have left a comment on the ticket to check that this is intended behaviour and that we don't want to separate out drafts that do and don't have a notification date (will update this PR with the result of that conversation).

Local tests pass [X]