### PR TITLE
NTBS-370 add alert creation date into alertService

### DIFF
--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -52,6 +52,7 @@ namespace ntbs_service.Services
             if(alert.NotificationId != null)
             {
                 var notification = await _notificationRepository.GetNotificationAsync(alert.NotificationId);
+                alert.CreationDate = DateTime.Now;
                 if(alert.CaseManagerEmail == null)
                 {
                     alert.CaseManagerEmail = notification?.Episode?.CaseManagerEmail;


### PR DESCRIPTION
Originally was going to provide it as part of the alert passed to the method but think this is unnecessary