### PR TITLE
NTBS-712 Simplify notification query used for homepage lists

### DIFF
--- a/ntbs-service-unit-tests/Pages/SearchPageTest.cs
+++ b/ntbs-service-unit-tests/Pages/SearchPageTest.cs
@@ -46,7 +46,7 @@ namespace ntbs_service_unit_tests.Pages
             var tbServiceList = Task.FromResult(tbServices);
             _mockReferenceDataRepository.Setup(s => s.GetAllTbServicesAsync()).Returns(tbServiceList);
 
-            _mockNotificationRepository.Setup(s => s.GetBaseQueryableNotificationByStatus(It.IsAny<List<NotificationStatus>>())).Returns(new List<Notification> { new Notification() { NotificationId = 1 } }.AsQueryable());
+            _mockNotificationRepository.Setup(s => s.GetQueryableNotificationByStatus(It.IsAny<List<NotificationStatus>>())).Returns(new List<Notification> { new Notification() { NotificationId = 1 } }.AsQueryable());
 
             var unionAndPaginateResult = Task.FromResult(GetNotificationIdsAndCount());
             _mockSearchService.Setup(s => s.OrderAndPaginateQueryables(It.IsAny<IQueryable<Notification>>(), It.IsAny<IQueryable<Notification>>(),

--- a/ntbs-service/Pages/Search/Index.cshtml.cs
+++ b/ntbs-service/Pages/Search/Index.cshtml.cs
@@ -72,8 +72,8 @@ namespace ntbs_service.Pages.Search
 
             var draftStatusList = new List<NotificationStatus>() { NotificationStatus.Draft };
             var nonDraftStatusList = new List<NotificationStatus>() { NotificationStatus.Notified, NotificationStatus.Denotified };
-            var draftsQueryable = _notificationRepository.GetBaseQueryableNotificationByStatus(draftStatusList);
-            var nonDraftsQueryable = _notificationRepository.GetBaseQueryableNotificationByStatus(nonDraftStatusList);
+            var draftsQueryable = _notificationRepository.GetQueryableNotificationByStatus(draftStatusList);
+            var nonDraftsQueryable = _notificationRepository.GetQueryableNotificationByStatus(nonDraftStatusList);
 
             var draftSearchBuilder = new NotificationSearchBuilder(draftsQueryable);
             var nonDraftsSearchBuilder = new NotificationSearchBuilder(nonDraftsQueryable);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
This simplifies the query, which has a chance of improving the results. Unfortunately the timeout-inducing performance is not consistently reproducible (perhaps db spec influences this), but a comparison of the query plans reported for the before and after query can be found on the ticket.

In particular, it removes:
- an inter-query sort
- table spool
- preserves left join approach to the table joins, which got turned into outer right joins before

(also includes deleting some unused code in the repository)

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.