### PR TITLE
NTBS-376: Fix notification routing

### DIFF
--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -84,13 +84,14 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
             var document = await GetDocumentForUrl(url);
-            var dismissPageRoute = "/Alerts/1/Dismiss";
+            var dismissPageRoute = "/Alerts/1/Dismiss?Page=Overview";
             Assert.NotNull(document.QuerySelector("#alert-1"));
 
             // Act
             var result = await SendPostFormWithData(document, null, dismissPageRoute);
 
             // Assert
+            Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetRedirectLocation(result), url);
             var reloadedDocument = await GetDocumentForUrl(GetRedirectLocation(result));
             Assert.Null(reloadedDocument.QuerySelector("#alert-1"));

--- a/ntbs-service/Pages/Alerts/Dismiss.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/Dismiss.cshtml.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.Pages.Alerts
             }
             if (Request.Query["page"] == "Overview")
             {
-                return RedirectToPage("/Notifications/Overview", new { id = alertToDismiss.NotificationId });
+                return RedirectToPage("/Notifications/Overview", new { alertToDismiss.NotificationId });
             }
             // TODO:NTBS-376 This will need to be changed to link to the correct place instead of just the home page
             return RedirectToPage("/Index");


### PR DESCRIPTION
## Description
Routing was providing `{ id = notificationId }` rather than the new autobound `{ notificationId }`

## Checklist:
- [X] Automated tests are passing locally.
