### PR TITLE
NTBS-328 add error summary back in 

### DIFF
--- a/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
@@ -160,6 +160,31 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
+        public async Task PostNotified_ReturnsPageWithErrorSummary_IfModelNotValid()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+            var initialDocument = await GetDocumentForUrl(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = Utilities.NOTIFIED_ID.ToString(),
+                ["PatientDetails.NhsNumber"] = "|a2"
+            };
+
+            // Act
+            var result = await SendPostFormWithData(initialDocument, formData, url);
+
+            // Assert
+            var resultDocument = await GetDocumentAsync(result);
+
+            result.EnsureSuccessStatusCode();
+
+            Assert.Equal("NHS number can only contain digits 0-9", resultDocument.QuerySelector("#error-summary-PatientDetails-NhsNumber").TextContent);
+        }
+
+        [Fact]
         public async Task Post_RedirectsToNextPageAndSavesContent_IfModelValid()
         {
             // Arrange

--- a/ntbs-service/Pages/Notifications/Edit/_SinglePageErrorSummaryPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_SinglePageErrorSummaryPartial.cshtml
@@ -10,7 +10,7 @@
         @foreach (var notifyError in EditPageErrorDictionary) 
         {
             <li>
-                <a href="#@notifyError.Key">@notifyError.Value</a>
+                <a href="#@notifyError.Key" id="error-summary-@notifyError.Key">@notifyError.Value</a>
             </li>
         }
     </nhs-error-summary>

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -26,6 +26,9 @@ namespace ntbs_service.Pages.Notifications
         [ViewData]
         public Dictionary<string, NotifyError> NotifyErrorDictionary { get; set; }
 
+        [ViewData]
+        public Dictionary<string, string> EditPageErrorDictionary { get; set; }
+
         /*
         Post method accepts name of action specified by button clicked.
         Using handler appends handler to the url and would require awkward javascript logic
@@ -69,6 +72,7 @@ namespace ntbs_service.Pages.Notifications
 
             if (!isValid)
             {
+                EditPageErrorDictionary = EditPageValidationErrorGenerator.MapToDictionary(ModelState);
                 return await PrepareAndDisplayPageAsync(isBeingSubmitted);
             }
 


### PR DESCRIPTION
Added test to check it renders on patient details page as well.
A code base clean up/merge had removed a couple of lines last week but this should fix it :)

- [X] Automated tests are passing locally.