### PR TITLE
Revert "Bump mini-css-extract-plugin from 0.8.2 to 0.9.0 in /ntbs-service"

### DIFF
--- a/ntbs-service/package-lock.json
+++ b/ntbs-service/package-lock.json
@@ -3302,9 +3302,9 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.9.0.tgz",
-      "integrity": "sha512-lp3GeY7ygcgAmVIcRPBVhIkf8Us7FZjA+ILpal44qLdSu11wmjKQ3d9k15lfD7pO4esu9eUIAW7qiYIBppv40A==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.2.tgz",
+      "integrity": "sha512-a3Y4of27Wz+mqK3qrcd3VhYz6cU0iW5x3Sgvqzbj+XmlrSizmvu8QQMl5oMYJjgHOC4iyt+w7l4umP+dQeW3bw==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",

--- a/ntbs-service/package.json
+++ b/ntbs-service/package.json
@@ -26,7 +26,7 @@
     "@types/webpack-env": "1.14.1",
     "aspnet-webpack": "3.0.0",
     "css-loader": "3.4.0",
-    "mini-css-extract-plugin": "0.9.0",
+    "mini-css-extract-plugin": "0.8.2",
     "node-sass": "4.13.0",
     "sass-loader": "7.2.0",
     "ts-loader": "6.2.1",


### PR DESCRIPTION
Reverts PublicHealthEngland/ntbs_Beta#259
Needs manual check: https://jenkins2.softwire.com/job/phe-ntbs/job/master/549/console