### PR TITLE
NTBS-781 Remove volatile case manager defaulting

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
@@ -89,19 +89,6 @@ namespace ntbs_service.Pages.Notifications.Edit
             Hospitals = new SelectList(hospitals, nameof(Hospital.HospitalId), nameof(Hospital.Name));
 
             var caseManagers = await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(tbServiceCodes);
-
-            // If case manager not yet set, and current user is an allowed case manager for
-            // the current tbServices then set currentUser as default case manager
-            if (Episode.CaseManagerEmail == null)
-            {
-                var userEmail = User.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Email)?.Value;
-                var upperUserEmail = userEmail?.ToUpperInvariant();
-                if (caseManagers.Any(c => c.Email.ToUpperInvariant() == upperUserEmail))
-                {
-                    Episode.CaseManagerEmail = userEmail;
-                }
-            };
-
             CaseManagers = new SelectList(caseManagers, nameof(CaseManager.Email), nameof(CaseManager.FullName));
         }
 


### PR DESCRIPTION
We were defaulting the case manager twice over - once at creation time,
and then again at render time. The latter is the more confusing behaviour,
as indicated by this bug, and as recorded on this comment:
https://github.com/PublicHealthEngland/ntbs_Beta/pull/150/files/8fff34895e70dfb2d97738d79ec3f6076ec2a769#r346286846

The case manager will still default correctly at creation:
https://github.com/PublicHealthEngland/ntbs_Beta/blob/50f219f154d7b912e2642b61a8261e122e95c774/ntbs-service/Services/NotificationService.cs#L334
