### PR TITLE
NTBS-378: Add functionality for linking to report page

### DIFF
--- a/ntbs-service/Pages/Reports/Index.cshtml
+++ b/ntbs-service/Pages/Reports/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@page "/Reports/{ReportType?}"
 @model ntbs_service.IndexModel
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "Reports";
     Layout = "~/Pages/Shared/_Layout.cshtml";
 }
 

--- a/ntbs-service/Pages/Reports/Index.cshtml
+++ b/ntbs-service/Pages/Reports/Index.cshtml
@@ -1,0 +1,21 @@
+﻿@page "/Reports/{ReportType?}"
+@model ntbs_service.IndexModel
+@{
+    ViewData["Title"] = "Index";
+    Layout = "~/Pages/Shared/_Layout.cshtml";
+}
+
+<nhs-width-container container-width="Standard">
+    <h1>Reports</h1>
+
+    <span>
+        @if (!string.IsNullOrEmpty(Model.ReportType))
+        {
+            @: Attempted to navigate to report type: <strong>@Model.ReportType </strong>
+        }
+        else
+        {
+            @: Attempted to navigate to reports home page.
+        }
+    </span>
+</nhs-width-container>

--- a/ntbs-service/Pages/Reports/Index.cshtml.cs
+++ b/ntbs-service/Pages/Reports/Index.cshtml.cs
@@ -4,6 +4,14 @@ using Microsoft.Extensions.Configuration;
 
 namespace ntbs_service
 {
+    /// <summary>
+    /// Route intended to be both a dummy location that's navigable for
+    /// when ExternalLinks__ReportingUri env variable is not set, and additional
+    /// a centralised location for logic when routing out to external reporting.
+    ///
+    /// Intended for all external links to reporting to route through here, to then be
+    /// redirected.
+    /// </summary>
     public class IndexModel : PageModel
     {
         [BindProperty(SupportsGet = true)]

--- a/ntbs-service/Pages/Reports/Index.cshtml.cs
+++ b/ntbs-service/Pages/Reports/Index.cshtml.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+
+namespace ntbs_service
+{
+    public class IndexModel : PageModel
+    {
+        [BindProperty(SupportsGet = true)]
+        public string ReportType { get; set; }
+
+        public string ReportingUri { get; }
+
+        public IndexModel(IConfiguration configuration)
+        {
+            ReportingUri = configuration.GetSection("ExternalLinks")?["ReportingUri"];
+        }
+
+        public IActionResult OnGet()
+        {
+            if (!string.IsNullOrEmpty(ReportingUri))
+            {
+                return Redirect(ReportingUri);
+                // TODO: Add logic for routing to difference report types directly.
+            }
+
+            return Page();
+        }
+    }
+}

--- a/ntbs-service/Pages/Shared/_Header.cshtml
+++ b/ntbs-service/Pages/Shared/_Header.cshtml
@@ -45,6 +45,11 @@
                         </a>
                     </li>
                     <li class="govuk-header__navigation-item" class="header-navigation-link">
+                        <a class="govuk-header__link header-navigation-list-item" href="/Reports">
+                            Reports
+                        </a>
+                    </li>
+                    <li class="govuk-header__navigation-item" class="header-navigation-link">
                         <a class="govuk-header__link header-navigation-list-item" href="/Logout">
                             @(User.Identity.Name) (Logout)
                         </a>

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -7,5 +7,8 @@
     "Wtrealm": "https://localhost:5001/",
     "DevGroup": "Global.NIS.NTBS.NTA",
     "UseDummyAuth": true
-  }
+  },
+  "ExternalLinks": {
+      "ReportingUri": "" 
+  } 
 }

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -48,6 +48,8 @@ spec:
               secretKeyRef:
                 name: development-ad-sync-credentials
                 key: password
+          - name: ExternalLinks__ReportingUri
+            value: ""
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -53,6 +53,8 @@ spec:
 #                secretKeyRef:
 #                  name: development-ad-sync-credentials
 #                  key: password
+            - name: ExternalLinks__ReportingUri
+              value: ""
       imagePullSecrets:
         - name: registery-password
 ---

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -48,6 +48,8 @@ spec:
               secretKeyRef:
                 name: development-ad-sync-credentials
                 key: password
+          - name: ExternalLinks__ReportingUri
+            value: ""
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -48,6 +48,8 @@ spec:
               secretKeyRef:
                 name: development-ad-sync-credentials
                 key: password
+          - name: ExternalLinks__ReportingUri
+            value: ""
       imagePullSecrets:
       - name: registery-password
 ---


### PR DESCRIPTION
## Description
Adds a new header in the top of the page for `/Reports`.

This navigates to a placeholder page if an env variables is not set. If it is set, then performs a redirect to that site.