### PR TITLE
NTBS-723: Audit qa markups

### DIFF
--- a/EFAuditer/AuditDatabaseContext.cs
+++ b/EFAuditer/AuditDatabaseContext.cs
@@ -11,37 +11,45 @@ namespace EFAuditer
         public virtual DbSet<AuditLog> AuditLogs { get; set; }
 
         public async Task AuditOperationAsync(
-            int primaryKeyId,
+            string key,
             string entity,
             string details,
             string eventType,
-            string userName)
+            string userName,
+            string rootEntity = null,
+            string rootId = null)
         {
             var log = CreateAuditLog(
-                primaryKeyId,
+                key,
                 entity,
                 details,
                 eventType,
-                userName);
+                userName,
+                rootEntity,
+                rootId);
             AuditLogs.Add(log);
             await SaveChangesAsync();
         }
 
         private static AuditLog CreateAuditLog(
-            int primaryKeyId,
+            string key,
             string entity,
             string details,
             string eventType,
-            string userName)
+            string userName,
+            string rootEntity,
+            string rootId)
         {
-            return new AuditLog()
+            return new AuditLog
             {
-                OriginalId = primaryKeyId.ToString(),
+                OriginalId = key,
                 EntityType = entity,
                 EventType = eventType,
                 AuditDateTime = DateTime.Now,
                 AuditUser = userName,
-                AuditDetails = details
+                AuditDetails = details,
+                RootEntity = rootEntity,
+                RootId = rootId
             };
         }
     }

--- a/ntbs-service/Middleware/AuditGetRequestMiddleware.cs
+++ b/ntbs-service/Middleware/AuditGetRequestMiddleware.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Linq;
+﻿using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -8,10 +7,10 @@ using ntbs_service.Services;
 
 namespace ntbs_service.Middleware
 {
-/*
-    This class is used to audit all page reads of the system.
-    It hooks into the middleware pipeline, and audits all successful (status 200) GET requests of particular records (no search pages/lists of records).
- */
+    /*
+        This class is used to audit all page reads of the system.
+        It hooks into the middleware pipeline, and audits all successful (status 200) GET requests of particular records (no search pages/lists of records).
+     */
     public class AuditGetRequestMiddleWare
     {
         private readonly RequestDelegate _next;
@@ -41,10 +40,14 @@ namespace ntbs_service.Middleware
                 if (shouldAudit && int.TryParse(pathArray[notificationIndex + 1], out var id))
                 {
                     var userName = context.User.FindFirstValue(ClaimTypes.Email);
-                    // Fallbacks if user doesn't have an email associated with them - as is the case with our test users
-                    if (string.IsNullOrEmpty(userName)) userName = context.User.Identity.Name;
+                    // Fallback if user doesn't have an email associated with them - as is the case with our test users
+                    if (string.IsNullOrEmpty(userName))
+                    {
+                        userName = context.User.Identity.Name;
+                    }
+
                     // TODO: Differentiate between Cluster and Full view.
-                    await auditService.OnGetAuditAsync(id, model: "Notification", auditDetails: NotificationAuditType.Full, userName: userName);
+                    await auditService.AuditNotificationReadAsync(id, NotificationAuditType.Full, userName);
                 };
             }
         }

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -32,7 +32,6 @@ namespace ntbs_service.Pages.Notifications
                 return NotFound();
             }
             NotificationId = Notification.NotificationId;
-            CultureAndResistance = await _cultureAndResistanceService.GetCultureAndResistanceDetailsAsync(NotificationId);
 
             await GetLinkedNotifications();
             await GetAlertsAsync();
@@ -48,6 +47,7 @@ namespace ntbs_service.Pages.Notifications
                 return RedirectToPage("./Edit/PatientDetails", new { NotificationId });
             }
 
+            CultureAndResistance = await _cultureAndResistanceService.GetCultureAndResistanceDetailsAsync(NotificationId);
             return Page();
         }
 

--- a/ntbs-service/Services/AuditService.cs
+++ b/ntbs-service/Services/AuditService.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using EFAuditer;
 using ntbs_service.Models.Enums;
 
@@ -6,23 +6,31 @@ namespace ntbs_service.Services
 {
     public interface IAuditService
     {
-        Task OnGetAuditAsync(int notificationId, string model, NotificationAuditType auditDetails, string userName);
+        Task AuditNotificationReadAsync(int notificationId, NotificationAuditType auditDetails, string userName);
     }
 
     public class AuditService : IAuditService
     {
-        private readonly AuditDatabaseContext auditContext;
+        private readonly AuditDatabaseContext _auditContext;
 
         private const string READ_EVENT = "Read";
 
         public AuditService(AuditDatabaseContext auditContext)
         {
-            this.auditContext = auditContext;
+            _auditContext = auditContext;
         }
-        
-        public async Task OnGetAuditAsync(int notificationId, string model, NotificationAuditType auditDetails, string userName)
+
+        public async Task AuditNotificationReadAsync(int notificationId, NotificationAuditType auditDetails, string userName)
         {
-            await auditContext.AuditOperationAsync(notificationId, model, auditDetails.ToString(), READ_EVENT, userName);
+            var notificationIdString = notificationId.ToString();
+            await _auditContext.AuditOperationAsync(
+                notificationIdString,
+                RootEntities.Notification,
+                auditDetails.ToString(),
+                READ_EVENT,
+                userName,
+                RootEntities.Notification,
+                notificationIdString);
         }
     }
 }


### PR DESCRIPTION
## Description
Add logic for nicely auditing inserts and reads.

Additional sneaky change to move call to `ufn.GetNotificationCulture...` on overview to after the redirect to `PatientDetails` for draft notifications.

## Checklist:
- [X] Automated tests are passing locally.