### PR TITLE
NTBS-793: Use environment name as a prefix for imported notifications table

### DIFF
--- a/ntbs-service/DataMigration/MigrationRepository.cs
+++ b/ntbs-service/DataMigration/MigrationRepository.cs
@@ -20,7 +20,7 @@ namespace ntbs_service.DataMigration
     public class MigrationRepository : IMigrationRepository
     {
         const string InsertImportedNotificationsQuery = @"
-            INSERT INTO ImportedNotifications (LegacyId, ImportedAt)
+            INSERT INTO {0} (LegacyId, ImportedAt)
             VALUES (@LegacyId, @ImportedAt);
         ";
 
@@ -63,10 +63,12 @@ namespace ntbs_service.DataMigration
             WHERE OldNotificationId IN @Ids
         ";
         private readonly string connectionString;
+        private readonly INotificationImportHelper _notificationHelper;
 
-        public MigrationRepository(IConfiguration _configuration)
+        public MigrationRepository(IConfiguration _configuration, INotificationImportHelper notificationHelper)
         {
             connectionString = _configuration.GetConnectionString("migration");
+            _notificationHelper = notificationHelper;
         }
 
         public async Task MarkNotificiationsAsImportedAsync(IEnumerable<Notification> notifications)
@@ -77,9 +79,10 @@ namespace ntbs_service.DataMigration
 
                 var importedAt = DateTime.Now.ToString("s");
 
+                var query = string.Format(InsertImportedNotificationsQuery, _notificationHelper.GetImportedNotificationsTableName());
                 foreach (var notification in notifications)
                 {
-                    await connection.QueryAsync(InsertImportedNotificationsQuery, new { notification.LegacyId, ImportedAt = importedAt });
+                    await connection.QueryAsync(query, new { notification.LegacyId, ImportedAt = importedAt });
                 }
             }
         }

--- a/ntbs-service/DataMigration/MigrationRepository.cs
+++ b/ntbs-service/DataMigration/MigrationRepository.cs
@@ -19,11 +19,6 @@ namespace ntbs_service.DataMigration
 
     public class MigrationRepository : IMigrationRepository
     {
-        const string InsertImportedNotificationsQuery = @"
-            INSERT INTO {0} (LegacyId, ImportedAt)
-            VALUES (@LegacyId, @ImportedAt);
-        ";
-
         const string NotificationsQuery = @"
             SELECT *,
             	trvl.Country1 AS travel_Country1,
@@ -63,12 +58,12 @@ namespace ntbs_service.DataMigration
             WHERE OldNotificationId IN @Ids
         ";
         private readonly string connectionString;
-        private readonly INotificationImportHelper _notificationHelper;
+        private readonly INotificationImportHelper _importHelper;
 
-        public MigrationRepository(IConfiguration _configuration, INotificationImportHelper notificationHelper)
+        public MigrationRepository(IConfiguration _configuration, INotificationImportHelper importHelper)
         {
             connectionString = _configuration.GetConnectionString("migration");
-            _notificationHelper = notificationHelper;
+            _importHelper = importHelper;
         }
 
         public async Task MarkNotificiationsAsImportedAsync(IEnumerable<Notification> notifications)
@@ -79,7 +74,7 @@ namespace ntbs_service.DataMigration
 
                 var importedAt = DateTime.Now.ToString("s");
 
-                var query = string.Format(InsertImportedNotificationsQuery, _notificationHelper.GetImportedNotificationsTableName());
+                var query = _importHelper.GetInsertImportedNotificationQuery();
                 foreach (var notification in notifications)
                 {
                     await connection.QueryAsync(query, new { notification.LegacyId, ImportedAt = importedAt });

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -18,6 +18,9 @@ namespace ntbs_service.DataMigration
     {
         private readonly string connectionString;
         private readonly string importedNotificationsTableName;
+
+        // Dapper does not support dynamic table names as parameters therefore we are using string format
+        // This is relatively safe as the parameter is passed from environment variable rather that user input
         private readonly string createImportedNotificationsTableQuery = @"
             IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{0}'))
             CREATE TABLE {0} (

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -1,0 +1,44 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using System.Data.SqlClient;
+using Dapper;
+using System.Threading.Tasks;
+
+namespace ntbs_service.DataMigration
+{
+    public interface INotificationImportHelper
+    {
+        Task CreateTableIfNotExists();
+        string GetImportedNotificationsTableName();
+    }
+
+    public class NotificationImportHelper : INotificationImportHelper
+    {
+        private readonly string connectionString;
+        private readonly string importedNotificationsTableName;
+        private readonly string createImportedNotificationsTableQuery = @"
+            IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{0}'))
+            CREATE TABLE {0} (
+                LegacyId varchar(255) NOT NULL PRIMARY KEY,
+                ImportedAt datetime NOT NULL
+            )";
+
+        public NotificationImportHelper(IConfiguration configuration)
+        {
+            connectionString = configuration.GetConnectionString("migration");
+            importedNotificationsTableName = $"{configuration.GetSection("Environment")?["Name"]}ImportedNotifications";
+        }
+
+        public async Task CreateTableIfNotExists()
+        {
+            using (var connection = new SqlConnection(connectionString))
+            {
+                connection.Open();
+                string query = String.Format(createImportedNotificationsTableQuery, importedNotificationsTableName);
+                await connection.QueryAsync(query);
+            }
+        }
+
+        public string GetImportedNotificationsTableName() => importedNotificationsTableName;
+    }
+}

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -9,7 +9,6 @@ namespace ntbs_service.DataMigration
     public interface INotificationImportHelper
     {
         Task CreateTableIfNotExists();
-        string GetImportedNotificationsTableName();
         string GetInsertImportedNotificationQuery();
         string GetSelectImportedNotificationByIdQuery();
     }
@@ -56,9 +55,6 @@ namespace ntbs_service.DataMigration
         }
 
         public string GetInsertImportedNotificationQuery() => string.Format(InsertImportedNotificationsQuery, importedNotificationsTableName);
-
-        public string GetImportedNotificationsTableName() => importedNotificationsTableName;
-
         public string GetSelectImportedNotificationByIdQuery() => string.Format(SelectImportedNotificationByIdQuery, importedNotificationsTableName);
     }
 }

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -10,6 +10,8 @@ namespace ntbs_service.DataMigration
     {
         Task CreateTableIfNotExists();
         string GetImportedNotificationsTableName();
+        string GetInsertImportedNotificationQuery();
+        string GetSelectImportedNotificationByIdQuery();
     }
 
     public class NotificationImportHelper : INotificationImportHelper
@@ -23,10 +25,21 @@ namespace ntbs_service.DataMigration
                 ImportedAt datetime NOT NULL
             )";
 
+        private const string InsertImportedNotificationsQuery = @"
+            INSERT INTO {0} (LegacyId, ImportedAt)
+            VALUES (@LegacyId, @ImportedAt);
+        ";
+
+        private const string SelectImportedNotificationByIdQuery = @"
+            SELECT *
+            FROM {0} impNtfc
+            WHERE impNtfc.LegacyId = n.OldNotificationId";
+
         public NotificationImportHelper(IConfiguration configuration)
         {
             connectionString = configuration.GetConnectionString("migration");
-            importedNotificationsTableName = $"{configuration.GetSection("Environment")?["Name"]}ImportedNotifications";
+            var tablePrefix = configuration.GetSection("Migration")?["TablePrefix"];
+            importedNotificationsTableName = $"{tablePrefix}ImportedNotifications";
         }
 
         public async Task CreateTableIfNotExists()
@@ -39,6 +52,10 @@ namespace ntbs_service.DataMigration
             }
         }
 
+        public string GetInsertImportedNotificationQuery() => string.Format(InsertImportedNotificationsQuery, importedNotificationsTableName);
+
         public string GetImportedNotificationsTableName() => importedNotificationsTableName;
+
+        public string GetSelectImportedNotificationByIdQuery() => string.Format(SelectImportedNotificationByIdQuery, importedNotificationsTableName);
     }
 }

--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Threading.Tasks;
 using EFAuditer;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ntbs_service.DataAccess;
+using ntbs_service.DataMigration;
 using Serilog;
 using Serilog.Events;
 
@@ -12,7 +14,7 @@ namespace ntbs_service
 {
     public class Program
     {
-        public static int Main(string[] args)
+        public static async Task<int> Main(string[] args)
         {
             SetUpLogger();
             try
@@ -25,6 +27,7 @@ namespace ntbs_service
                     var services = scope.ServiceProvider;
                     MigrateAppDb(services);
                     MigrateAuditDb(services);
+                    await CreateMigrationDbTablesAsync(services);
                 }
 
                 Log.Information("Starting web host");
@@ -40,6 +43,12 @@ namespace ntbs_service
             {
                 Log.CloseAndFlush();
             }
+        }
+
+        private static async Task CreateMigrationDbTablesAsync(IServiceProvider services)
+        {
+            var _notificationImportHelper = services.GetRequiredService<INotificationImportHelper>();
+            await _notificationImportHelper.CreateTableIfNotExists();
         }
 
         private static void SetUpLogger()

--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -45,12 +45,6 @@ namespace ntbs_service
             }
         }
 
-        private static async Task CreateMigrationDbTablesAsync(IServiceProvider services)
-        {
-            var _notificationImportHelper = services.GetRequiredService<INotificationImportHelper>();
-            await _notificationImportHelper.CreateTableIfNotExists();
-        }
-
         private static void SetUpLogger()
         {
             Log.Logger = new LoggerConfiguration()
@@ -92,6 +86,12 @@ namespace ntbs_service
                 Log.Error(ex, "An error occurred migrating the Audit DB.");
                 throw ex;
             }
+        }
+
+        private static async Task CreateMigrationDbTablesAsync(IServiceProvider services)
+        {
+            var _notificationImportHelper = services.GetRequiredService<INotificationImportHelper>();
+            await _notificationImportHelper.CreateTableIfNotExists();
         }
     }
 }

--- a/ntbs-service/Services/LegacySearchService.cs
+++ b/ntbs-service/Services/LegacySearchService.cs
@@ -27,9 +27,7 @@ namespace ntbs_service.Services
             FROM Notifications n 
             LEFT JOIN Addresses addrs ON addrs.OldNotificationId = n.OldNotificationId
             LEFT JOIN Demographics dmg ON dmg.OldNotificationId = n.OldNotificationId
-            WHERE NOT EXISTS (SELECT *
-              FROM {0} impNtfc
-              WHERE impNtfc.LegacyId = n.OldNotificationId)
+            WHERE NOT EXISTS ({0})
             ";
 
         const string SelectQueryEnd = @"
@@ -41,9 +39,7 @@ namespace ntbs_service.Services
             SELECT COUNT(*)
             FROM Notifications n
             LEFT JOIN Demographics dmg ON dmg.OldNotificationId = n.OldNotificationId
-            WHERE NOT EXISTS (SELECT *
-              FROM {0} impNtfc
-              WHERE impNtfc.LegacyId = n.OldNotificationId)
+            WHERE NOT EXISTS ({0})
             ";
 
         private readonly string connectionString;
@@ -76,8 +72,8 @@ namespace ntbs_service.Services
             parameters.Offset = offset;
             parameters.Fetch = numberToFetch;
 
-            string fullSelectQuery = string.Format(SelectQueryStart, _notificationImportHelper.GetImportedNotificationsTableName()) + sqlQuery + SelectQueryEnd;
-            string fullCountQuery = string.Format(CountQuery, _notificationImportHelper.GetImportedNotificationsTableName()) + sqlQuery;
+            string fullSelectQuery = string.Format(SelectQueryStart, _notificationImportHelper.GetSelectImportedNotificationByIdQuery()) + sqlQuery + SelectQueryEnd;
+            string fullCountQuery = string.Format(CountQuery, _notificationImportHelper.GetSelectImportedNotificationByIdQuery()) + sqlQuery;
 
             using (var connection = new SqlConnection(connectionString))
             {

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -164,8 +164,6 @@ namespace ntbs_service
             services.AddScoped<IItemRepository<TreatmentEvent>, TreatmentEventRepository>();
             services.Configure<AdfsOptions>(adfsConfig);
             services.Configure<LdapConnectionSettings>(ldapConnectionSettings);
-            services.Configure<AdfsOptions>(adfsConfig);
-            services.Configure<LdapConnectionSettings>(ldapConnectionSettings);
             services.Configure<MigrationConfig>(Configuration.GetSection("MigrationConfig"));
 
             var referenceLabResultsConfig = Configuration.GetSection("ReferenceLabResultsConfig");

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -146,6 +146,7 @@ namespace ntbs_service
             services.AddScoped<IImportLogger, ImportLogger>();
             services.AddScoped<INotificationImportService, NotificationImportService>();
             services.AddScoped<INotificationImportRepository, NotificationImportRepository>();
+            services.AddScoped<INotificationImportHelper, NotificationImportHelper>();
             services.AddScoped<IMigrationRepository, MigrationRepository>();
             services.AddScoped<IAnnualReportSearchService, AnnualReportSearcher>();
             services.AddScoped<ISearchService, SearchService>();

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -161,6 +161,12 @@ namespace ntbs_service
             services.AddScoped<IAdDirectoryServiceFactory, AdDirectoryServiceServiceFactory>();
             services.AddScoped<IAdImportService, AdImportService>();
             services.AddScoped<IItemRepository<TreatmentEvent>, TreatmentEventRepository>();
+            services.Configure<AdfsOptions>(adfsConfig);
+            services.Configure<LdapConnectionSettings>(ldapConnectionSettings);
+            services.Configure<AdfsOptions>(adfsConfig);
+            services.Configure<LdapConnectionSettings>(ldapConnectionSettings);
+            services.Configure<MigrationConfig>(Configuration.GetSection("MigrationConfig"));
+
             var referenceLabResultsConfig = Configuration.GetSection("ReferenceLabResultsConfig");
             if (referenceLabResultsConfig.GetValue<bool>("MockOutSpecimenMatching"))
             {
@@ -175,9 +181,6 @@ namespace ntbs_service
                 services.AddScoped<ICultureAndResistanceService, CultureAndResistanceService>();
                 services.AddScoped<ISpecimenService, SpecimenService>();
             }
-            services.Configure<AdfsOptions>(adfsConfig);
-            services.Configure<LdapConnectionSettings>(ldapConnectionSettings);
-            services.Configure<MigrationConfig>(Configuration.GetSection("MigrationConfig"));
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -188,7 +191,8 @@ namespace ntbs_service
                 app.UseDeveloperExceptionPage();
                 app.UseWebpackDevMiddleware(new WebpackDevMiddlewareOptions
                 {
-                    HotModuleReplacement = true, ConfigFile = "webpack.dev.js"
+                    HotModuleReplacement = true,
+                    ConfigFile = "webpack.dev.js"
                 });
             }
             else
@@ -241,11 +245,11 @@ namespace ntbs_service
 
             var dashboardOptions = new DashboardOptions
             {
-                Authorization = new[] {new HangfireAuthorisationFilter(GetAdminRoleName())}
+                Authorization = new[] { new HangfireAuthorisationFilter(GetAdminRoleName()) }
             };
             app.UseHangfireDashboard("/hangfire", dashboardOptions);
-            app.UseHangfireServer(new BackgroundJobServerOptions {WorkerCount = 1});
-            GlobalJobFilters.Filters.Add(new AutomaticRetryAttribute {Attempts = 0});
+            app.UseHangfireServer(new BackgroundJobServerOptions { WorkerCount = 1 });
+            GlobalJobFilters.Filters.Add(new AutomaticRetryAttribute { Attempts = 0 });
             HangfireJobScheduler.ScheduleRecurringJobs();
         }
 

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -15,7 +15,7 @@
     "MockOutSpecimenMatching": false,
     "MockedNotificationId": 2010
   },
-  "Environment": {
-    "Name": "Dev"
+  "Migration": {
+    "TablePrefix": "Dev"
   }
 }

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -9,10 +9,13 @@
     "UseDummyAuth": true
   },
   "ExternalLinks": {
-      "ReportingUri": "" 
+    "ReportingUri": ""
   },
   "ReferenceLabResultsConfig": {
     "MockOutSpecimenMatching": false,
     "MockedNotificationId": 2010
+  },
+  "Environment": {
+    "Name": "Dev"
   }
 }

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -60,7 +60,7 @@ spec:
                 key: password
           - name: ExternalLinks__ReportingUri
             value: ""
-          - name: Environment_Name
+          - name: Migration_TablePrefix
             value: "Int"
       imagePullSecrets:
       - name: registery-password

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -60,6 +60,8 @@ spec:
                 key: password
           - name: ExternalLinks__ReportingUri
             value: ""
+          - name: Environment_Name
+            value: "Int"
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -60,8 +60,8 @@ spec:
                 key: password
           - name: ExternalLinks__ReportingUri
             value: ""
-          - name: Environment_Name
-            value: "Test"
+          - name: Migration_TablePrefix
+            value: "Int"
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -61,7 +61,7 @@ spec:
           - name: ExternalLinks__ReportingUri
             value: ""
           - name: Migration_TablePrefix
-            value: "Int"
+            value: "Test"
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -60,6 +60,8 @@ spec:
                 key: password
           - name: ExternalLinks__ReportingUri
             value: ""
+          - name: Environment_Name
+            value: "Test"
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -61,7 +61,7 @@ spec:
           - name: ExternalLinks__ReportingUri
             value: ""
           - name: Migration_TablePrefix
-            value: "Int"
+            value: "Uat"
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -60,8 +60,8 @@ spec:
                 key: password
           - name: ExternalLinks__ReportingUri
             value: ""
-          - name: Environment_Name
-            value: "Uat"
+          - name: Migration_TablePrefix
+            value: "Int"
       imagePullSecrets:
       - name: registery-password
 ---

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -60,6 +60,8 @@ spec:
                 key: password
           - name: ExternalLinks__ReportingUri
             value: ""
+          - name: Environment_Name
+            value: "Uat"
       imagePullSecrets:
       - name: registery-password
 ---


### PR DESCRIPTION
 Use environment name as a prefix for creating and inserting into importedNotifications table

<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
