### PR TITLE
NTBS-792: Do not pull total number of countries in when visitor/travel is 0

### DIFF
--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -150,29 +150,41 @@ namespace ntbs_service.DataMigration
             DeathDate = notification.DeathDate
         };
 
-        private static TravelDetails ExtractTravelDetails(dynamic notification) => new TravelDetails
+        private static TravelDetails ExtractTravelDetails(dynamic notification)
         {
-            HasTravel = StringToValueConverter.GetNullableBoolValue(notification.HasTravel),
-            TotalNumberOfCountries = StringToValueConverter.ToNullableInt(notification.travel_TotalNumberOfCountries),
-            Country1Id = notification.travel_Country1,
-            Country2Id = notification.travel_Country2,
-            Country3Id = notification.travel_Country3,
-            StayLengthInMonths1 = notification.StayLengthInMonths1,
-            StayLengthInMonths2 = notification.StayLengthInMonths2,
-            StayLengthInMonths3 = notification.StayLengthInMonths3
-        };
+            bool? hasTravel = StringToValueConverter.GetNullableBoolValue(notification.HasTravel);
+            var totalNumberOfCountries = hasTravel ?? false ? StringToValueConverter.ToNullableInt(notification.travel_TotalNumberOfCountries) : null;
 
-        private static VisitorDetails ExtractVisitorDetails(dynamic notification) => new VisitorDetails
+            return new TravelDetails
+            {
+                HasTravel = hasTravel,
+                TotalNumberOfCountries = totalNumberOfCountries,
+                Country1Id = notification.travel_Country1,
+                Country2Id = notification.travel_Country2,
+                Country3Id = notification.travel_Country3,
+                StayLengthInMonths1 = notification.StayLengthInMonths1,
+                StayLengthInMonths2 = notification.StayLengthInMonths2,
+                StayLengthInMonths3 = notification.StayLengthInMonths3
+            };
+        }
+
+        private static VisitorDetails ExtractVisitorDetails(dynamic notification)
         {
-            HasVisitor = StringToValueConverter.GetNullableBoolValue(notification.HasVisitor),
-            TotalNumberOfCountries = StringToValueConverter.ToNullableInt(notification.visitor_TotalNumberOfCountries),
-            Country1Id = notification.visitor_Country1,
-            Country2Id = notification.visitor_Country2,
-            Country3Id = notification.visitor_Country3,
-            StayLengthInMonths1 = notification.visitor_StayLengthInMonths1,
-            StayLengthInMonths2 = notification.visitor_StayLengthInMonths2,
-            StayLengthInMonths3 = notification.visitor_StayLengthInMonths3
-        };
+            bool? hasVisitor = StringToValueConverter.GetNullableBoolValue(notification.HasVisitor);
+            var totalNumberOfCountries = hasVisitor ?? false ? StringToValueConverter.ToNullableInt(notification.visitor_TotalNumberOfCountries) : null;
+
+            return new VisitorDetails
+            {
+                HasVisitor = hasVisitor,
+                TotalNumberOfCountries = totalNumberOfCountries,
+                Country1Id = notification.visitor_Country1,
+                Country2Id = notification.visitor_Country2,
+                Country3Id = notification.visitor_Country3,
+                StayLengthInMonths1 = notification.visitor_StayLengthInMonths1,
+                StayLengthInMonths2 = notification.visitor_StayLengthInMonths2,
+                StayLengthInMonths3 = notification.visitor_StayLengthInMonths3
+            };
+        }
 
         private static PatientDetails ExtractPatientDetails(dynamic notification) => new PatientDetails
         {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->
After discussing it with Alex we came to conclusion that views in migration does not clean the data but just display it. And we do have "bad_data" queries that highlight issues. So the easiest way would be not to pull total number of countries when visitor/travel is 0/null.

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
