### PR TITLE
NTBS-680: Add SocialRiskFactors to NotificationMapper

### DIFF
--- a/.idea/.idea.ntbs/.idea/sqldialects.xml
+++ b/.idea/.idea.ntbs/.idea/sqldialects.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="SqlDialectMappings">
+    <file url="PROJECT" dialect="TSQL" />
+  </component>
+</project>

--- a/ntbs-service/DataMigration/MigrationRepository.cs
+++ b/ntbs-service/DataMigration/MigrationRepository.cs
@@ -34,7 +34,19 @@ namespace ntbs_service.DataMigration
                 vstr.TotalNumberOfCountries AS visitor_TotalNumberOfCountries,
                 vstr.StayLengthInMonths1 AS visitor_StayLengthInMonths1,
                 vstr.StayLengthInMonths2 AS visitor_StayLengthInMonths2,
-                vstr.StayLengthInMonths3 AS visitor_StayLengthInMonths3
+                vstr.StayLengthInMonths3 AS visitor_StayLengthInMonths3,
+                rfd.Status AS riskFactorDrugs_Status,
+                rfd.IsCurrent AS riskFactorDrugs_IsCurrent,
+                rfd.InPastFiveYears AS riskFactorDrugs_InPastFiveYears,
+                rfd.MoreThanFiveYearsAgo AS riskFactorDrugs_MoreThanFiveYearsAgo,
+                rfh.Status AS riskFactorHomelessNess_Status,
+                rfh.IsCurrent AS riskFactorHomelessNess_IsCurrent,
+                rfh.InPastFiveYears AS riskFactorHomelessNess_InPastFiveYears,
+                rfh.MoreThanFiveYearsAgo AS riskFactorHomelessNess_MoreThanFiveYearsAgo,
+                rfi.Status AS riskFactorImprisonment_Status,
+                rfi.IsCurrent AS riskFactorImprisonment_IsCurrent,
+                rfi.InPastFiveYears AS riskFactorImprisonment_InPastFiveYears,
+                rfi.MoreThanFiveYearsAgo AS riskFactorImprisonment_MoreThanFiveYearsAgo
             FROM Notifications n 
             LEFT JOIN Addresses addrs ON addrs.OldNotificationId = n.OldNotificationId
             LEFT JOIN Demographics dmg ON dmg.OldNotificationId = n.OldNotificationId
@@ -44,6 +56,10 @@ namespace ntbs_service.DataMigration
             LEFT JOIN ClinicalDetails clncl ON clncl.OldNotificationId = n.OldNotificationId
             LEFT JOIN Comorbidities cmrbd ON cmrbd.OldNotificationId = n.OldNotificationId
             LEFT JOIN ImmunoSuppression immn ON immn.OldNotificationId = n.OldNotificationId
+            LEFT JOIN SocialRiskFactors srf ON srf.OldNotificationId = n.OldNotificationId
+            LEFT JOIN RiskFactorDrugs rfd on n.OldNotificationId = rfd.OldNotificationId
+            LEFT JOIN RiskFactorHomelessness rfh on n.OldNotificationId = rfh.OldNotificationId
+            LEFT JOIN RiskFactorImprisonment rfi on n.OldNotificationId = rfi.OldNotificationId
             WHERE GroupId IN (
                 SELECT GroupId
                 FROM Notifications n 

--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -1,11 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using ntbs_service.Models.Entities;
-using ntbs_service.Models.ReferenceEntities;
-using Dapper;
 using Microsoft.Extensions.Configuration;
 using ntbs_service.Models.Enums;
 using ntbs_service.Helpers;
@@ -84,6 +81,7 @@ namespace ntbs_service.DataMigration
                 VisitorDetails = ExtractVisitorDetails(rawNotification),
                 ComorbidityDetails = ExtractComorbidityDetails(rawNotification),
                 ImmunosuppressionDetails = ExtractImmunosuppressionDetails(rawNotification),
+                SocialRiskFactors = ExtractSocialRiskFactors(rawNotification),
                 Episode = ExtractEpisodeDetails(rawNotification),
                 NotificationStatus = NotificationStatus.Notified,
                 NotificationSites = sites
@@ -204,6 +202,36 @@ namespace ntbs_service.DataMigration
             NoFixedAbode = notification.NoFixedAbode == 1,
             OccupationId = notification.NtbsOccupationId,
             OccupationOther = notification.NtbsOccupationFreeText
+        };
+
+        private static SocialRiskFactors ExtractSocialRiskFactors(dynamic notification) => new SocialRiskFactors
+        {
+            AlcoholMisuseStatus = StringToValueConverter.GetStatusFromString(notification.AlcoholMisuseStatus),
+            SmokingStatus = StringToValueConverter.GetStatusFromString(notification.SmokingStatus),
+            MentalHealthStatus = StringToValueConverter.GetStatusFromString(notification.MentalHealthStatus),
+            AsylumSeekerStatus = StringToValueConverter.GetStatusFromString(notification.AsylumSeekerStatus),
+            ImmigrationDetaineeStatus = StringToValueConverter.GetStatusFromString(notification.ImmigrationDetaineeStatus),
+            RiskFactorDrugs =
+            {
+                Status = StringToValueConverter.GetStatusFromString(notification.riskFactorDrugs_Status),
+                IsCurrent = StringToValueConverter.GetBoolValue(notification.riskFactorDrugs_IsCurrent),
+                InPastFiveYears = StringToValueConverter.GetBoolValue(notification.riskFactorDrugs_InPastFiveYears),
+                MoreThanFiveYearsAgo = StringToValueConverter.GetBoolValue(notification.riskFactorDrugs_MoreThanFiveYearsAgo)
+            },
+            RiskFactorHomelessness =
+            {
+                Status = StringToValueConverter.GetStatusFromString(notification.riskFactorHomelessness_Status),
+                IsCurrent = StringToValueConverter.GetBoolValue(notification.riskFactorHomelessness_IsCurrent),
+                InPastFiveYears = StringToValueConverter.GetBoolValue(notification.riskFactorHomelessness_InPastFiveYears),
+                MoreThanFiveYearsAgo = StringToValueConverter.GetBoolValue(notification.riskFactorHomelessness_MoreThanFiveYearsAgo)
+            },
+            RiskFactorImprisonment =
+            {
+                Status = StringToValueConverter.GetStatusFromString(notification.riskFactorImprisonment_Status),
+                IsCurrent = StringToValueConverter.GetBoolValue(notification.riskFactorImprisonment_IsCurrent),
+                InPastFiveYears = StringToValueConverter.GetBoolValue(notification.riskFactorImprisonment_InPastFiveYears),
+                MoreThanFiveYearsAgo = StringToValueConverter.GetBoolValue(notification.riskFactorImprisonment_MoreThanFiveYearsAgo)
+            },
         };
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
Follow up review from #298. Covers adding SocialRiskFactors to the NotificationMapper

## Testing
Ran the migration against 3 different notifications with various statuses and checked the 4 affected tables (SocialRiskFactors, RiskFactorHomelessness, RiskFactorImprisonment, RiskFactorDrugs) were all populated correctly.

**One thing that didn't work was the INSERT into the ntbs-migration table DevImportedNotifications as the credentials have read-only access. Do we want to change this?**

## Checklist:
- [X] Automated tests are passing locally.

