### PR TITLE
NTBS-398 qa mark ups

### DIFF
--- a/ntbs-service/Models/Entities/Alert.cs
+++ b/ntbs-service/Models/Entities/Alert.cs
@@ -18,6 +18,7 @@ namespace ntbs_service.Models.Entities
         public virtual Notification Notification { get; set; }
         public DateTime CreationDate { get; set; }
         [Required(ErrorMessage = ValidationMessages.FieldRequired)]
+        [AssertThat("TransferDestinationNotCurrentTbService", ErrorMessage = ValidationMessages.TransferDestinationCannotBeCurrentTbService)]
         [Display(Name = "TB Service")]
         public string TbServiceCode { get; set; }
         public virtual TBService TbService { get; set; }
@@ -33,10 +34,10 @@ namespace ntbs_service.Models.Entities
         public virtual string ActionLink { get; }
         public virtual string Action { get; }
         public virtual bool NotDismissable  { get; }
+        [Display(Name = "Case manager")]
+        public virtual string CaseManagerFullName => CaseManager?.FullName ?? "System";
         [Display(Name = "Alert date")]
         public string FormattedCreationDate => CreationDate.ConvertToString();
-        [Display(Name = "Case manager")]
-        public string CaseManagerFullName => CaseManager?.FullName ?? "System";
         [Display(Name = "TB Service")]
         public string TbServiceName => TbService?.Name;
 
@@ -57,6 +58,21 @@ namespace ntbs_service.Models.Entities
                 }
 
                 return CaseManager.CaseManagerTbServices.Any(c => c.TbServiceCode == TbServiceCode);
+            }
+        }
+
+        [NotMapped]
+        public string NotificationTbServiceCode { get; set; }
+        public bool TransferDestinationNotCurrentTbService
+        {
+            get
+            {
+                if (TbServiceCode == NotificationTbServiceCode && AlertType == AlertType.TransferRequest)
+                {
+                    return false;
+                }
+
+                return true;
             }
         }
     }

--- a/ntbs-service/Models/Entities/Alert.cs
+++ b/ntbs-service/Models/Entities/Alert.cs
@@ -63,18 +63,7 @@ namespace ntbs_service.Models.Entities
 
         [NotMapped]
         public string NotificationTbServiceCode { get; set; }
-        public bool TransferDestinationNotCurrentTbService
-        {
-            get
-            {
-                if (TbServiceCode == NotificationTbServiceCode && AlertType == AlertType.TransferRequest)
-                {
-                    return false;
-                }
-
-                return true;
-            }
-        }
+        public bool TransferDestinationNotCurrentTbService => AlertType != AlertType.TransferRequest || TbServiceCode != NotificationTbServiceCode;
     }
 
 }

--- a/ntbs-service/Models/Entities/TransferAlert.cs
+++ b/ntbs-service/Models/Entities/TransferAlert.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.Models.Entities
         public override string Action => "Transfer request to your TB service";
         public override string ActionLink => RouteHelper.GetNotificationPath(NotificationId.GetValueOrDefault(), NotificationSubPaths.TransferRequest);
         public override bool NotDismissable => true;
-        public string TransferReasonString => TransferReason.GetDisplayName().ToString() + 
+        public string TransferReasonString => TransferReason.GetDisplayName() + 
             (TransferReason == TransferReason.Other ? $" - {OtherReasonDescription}" : "");
     }
 }

--- a/ntbs-service/Models/Entities/TransferAlert.cs
+++ b/ntbs-service/Models/Entities/TransferAlert.cs
@@ -3,6 +3,7 @@ using ntbs_service.Models.Enums;
 using ntbs_service.Models.Validations;
 using System.ComponentModel.DataAnnotations;
 using ntbs_service.Helpers;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ntbs_service.Models.Entities
 {
@@ -28,8 +29,11 @@ namespace ntbs_service.Models.Entities
             ErrorMessage = ValidationMessages.StringWithNumbersAndForwardSlashFormat)]
         [Display(Name = "Optional note")]
         public string TransferRequestNote { get; set; }
+        public override string CaseManagerFullName => CaseManager?.FullName ?? "";
         public override string Action => "Transfer request to your TB service";
         public override string ActionLink => RouteHelper.GetNotificationPath(NotificationId.GetValueOrDefault(), NotificationSubPaths.TransferRequest);
         public override bool NotDismissable => true;
+        public string TransferReasonString => TransferReason.GetDisplayName().ToString() + 
+            (TransferReason == TransferReason.Other ? $" - {OtherReasonDescription}" : "");
     }
 }

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -131,6 +131,10 @@
         public const string TreatmentOutcomeInvalidForRestart = "Treatment outcome type is not allowed for a treatment restart";
 
         #endregion
+
+        #region TransferAlert
+        public const string TransferDestinationCannotBeCurrentTbService = "{0} can not be transferred to the notification's current TB service";
+        #endregion
     }
 
     public static class ValidDates

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml
@@ -64,7 +64,7 @@
                         </select>
                     </nhs-form-group>
                 </div>
-            </cascading-dropdown-dropdown>
+            </cascading-dropdown>
         </div>
 
         @{
@@ -139,7 +139,7 @@
         </nhs-form-group>
 
         <div class="flex-container">
-            <button id="confirm-transfer-button" nhs-button-type="Standard" asp-page-handler="Confirm" classes="confirm-transfer-button">
+            <button id="confirm-transfer-button" nhs-button-type="Standard" classes="confirm-transfer-button">
                 Confirm transfer
             </button>
 

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
@@ -74,7 +74,7 @@ namespace ntbs_service.Pages.Alerts
             return Page();
         }
 
-        public async Task<IActionResult> OnPostConfirmAsync()
+        public async Task<IActionResult> OnPostAsync()
         {
             Notification = await NotificationRepository.GetNotificationAsync(NotificationId);
             await GetRelatedEntities();

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
@@ -101,6 +101,7 @@ namespace ntbs_service.Pages.Alerts
             {
                 TransferAlert.CaseManager = await _referenceDataRepository.GetCaseManagerByUsernameAsync(TransferAlert.CaseManagerUsername);
             }
+            TransferAlert.NotificationTbServiceCode = Notification.Episode.TBServiceCode;
         }
 
         private async Task SetDropdownsAsync()
@@ -122,30 +123,6 @@ namespace ntbs_service.Pages.Alerts
             NotificationBannerModel = new NotificationBannerModel(Notification);
             return Partial("_CancelTransferConfirmation", this);
         }
-
-        // public async Task<IActionResult> OnPostAcceptAsync()
-        // {
-        //     Notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-        //     if (!await AuthorizationService.CanEditNotificationAsync(User, Notification))
-        //     {
-        //         return ForbiddenResult();
-        //     }
-        //     Notification.Episode.CaseManagerEmail = TransferAlert.CaseManagerEmail;
-        //     Notification.Episode.TBServiceCode = TransferAlert.TbServiceCode;
-
-        //     return RedirectToPage("/Notifications/Overview", new { NotificationId });
-        // }
-
-        //  public async Task<IActionResult> OnPostDeclineAsync()
-        // {
-        //     Notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-        //     if (!await AuthorizationService.CanEditNotificationAsync(User, Notification))
-        //     {
-        //         return ForbiddenResult();
-        //     }
-
-        //     return RedirectToPage("/Notifications/Overview", new { NotificationId });
-        // }
 
         public async Task<JsonResult> OnGetFilteredTbServiceListsByPhecCode(string value)
         {

--- a/ntbs-service/Pages/Alerts/_CancelTransferConfirmation.cshtml
+++ b/ntbs-service/Pages/Alerts/_CancelTransferConfirmation.cshtml
@@ -1,3 +1,4 @@
+@using ntbs_service.Helpers
 @model ntbs_service.Pages.Alerts.TransferRequestModel
 
 @{
@@ -8,7 +9,8 @@
 <nhs-width-container container-width="Standard">
     <h2> Transfer of Notification #@Model.NotificationId has been cancelled </h2>
     <br>
-    <a id="return-to-homepage" href="/" class="nhsuk-button return-to-homepage-link">
-        Return to the homepage
+    <a id="return-to-homepage" href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.Overview)" 
+        class="nhsuk-button return-to-homepage-link">
+        Return to the notification
     </a>
 </nhs-width-container>

--- a/ntbs-service/Pages/Alerts/_TransferPendingPartial.cshtml
+++ b/ntbs-service/Pages/Alerts/_TransferPendingPartial.cshtml
@@ -55,7 +55,7 @@
             Reason for transfer
         </span>
         <div>
-            @Model.TransferAlert.TransferReason
+            @Model.TransferAlert.TransferReasonString
         </div>
 
         <br>

--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -10,45 +10,36 @@
     @if ((string)ViewData["CurrentPage"] == NotificationSubPaths.Overview)
     {
         <nhs-grid-column grid-column-width="TwoThirds">
-            @if(!Model.HasEditPermission)
-            {  
-                <!-- provide non breaking space so that nhs-grid-column is rendered and pushes manage notification
-                    to the right when alerts are hidden -->
-                @:&nbsp;
-            }
-            else
-            {
-                <div class="@manageNotificationClass">
-                    <h2>
-                        Alerts
-                    </h2>
-                    @if(Model.Alerts.Count > 0)
+            <div class="@manageNotificationClass">
+                <h2>
+                    Alerts
+                </h2>
+                @if(Model.Alerts.Count > 0)
+                {
+                    <div class="overview-alerts-container">
+                    @foreach (var alert in Model.Alerts)
                     {
-                        <div class="overview-alerts-container">
-                        @foreach (var alert in Model.Alerts)
-                        {
-                        
-                            <div class="flex-container overview-alert" id="alert-@alert.AlertId">
-                                <div class="alert-description--overview-view">@alert.Action</div>
-                                <a href="@alert.ActionLink" class="alert-take-action-link">Take action</a>
-                                @if(!alert.NotDismissable)
-                                {
-                                    <form method="post" action="@RouteHelper.GetAlertPath(@alert.AlertId, AlertSubPaths.Dismiss)?page=Overview" 
-                                        class="dismiss-alert-button--overview-view">
-                                        @Html.AntiForgeryToken()
-                                        <button class="button-link nhsuk-link govuk-link--no-visited-state govuk-link"
-                                            aria-label="Dismiss alert">
-                                            X
-                                        </button>
-                                    </form>
-                                }
-                            </div>
-                            
-                        }
+                    
+                        <div class="flex-container overview-alert" id="alert-@alert.AlertId">
+                            <div class="alert-description--overview-view">@alert.Action</div>
+                            <a href="@alert.ActionLink" class="alert-take-action-link">Take action</a>
+                            @if(!alert.NotDismissable)
+                            {
+                                <form method="post" action="@RouteHelper.GetAlertPath(@alert.AlertId, AlertSubPaths.Dismiss)?page=Overview" 
+                                    class="dismiss-alert-button--overview-view">
+                                    @Html.AntiForgeryToken()
+                                    <button class="button-link nhsuk-link govuk-link--no-visited-state govuk-link"
+                                        aria-label="Dismiss alert">
+                                        X
+                                    </button>
+                                </form>
+                            }
                         </div>
+                        
                     }
-                </div>
-            }
+                    </div>
+                }
+            </div>
         </nhs-grid-column>
     }
 

--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -97,7 +97,7 @@ namespace ntbs_service.Services
         public async Task<IList<Alert>> GetAlertsForNotificationAsync(int notificationId, ClaimsPrincipal user)
         {
             var alerts = await _alertRepository.GetAlertsForNotificationAsync(notificationId);
-            var filteredAlerts = await _authorizationService.FilterTransferAlertsFromListOfAlertsByUserAsync(user, alerts);
+            var filteredAlerts = await _authorizationService.FilterAlertsForUserAsync(user, alerts);
 
             return filteredAlerts;
         }

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -14,7 +14,7 @@ namespace ntbs_service.Services
         Task<bool> CanEditBannerModelAsync(ClaimsPrincipal user, NotificationBannerModel notificationBannerModel);
         Task<IQueryable<Notification>> FilterNotificationsByUserAsync(ClaimsPrincipal user, IQueryable<Notification> notifications);
         Task<bool> IsUserAuthorizedToManageAlert(ClaimsPrincipal user, Alert alert);
-        Task<IList<Alert>> FilterTransferAlertsFromListOfAlertsByUserAsync(ClaimsPrincipal user, IList<Alert> alerts);
+        Task<IList<Alert>> FilterAlertsForUserAsync(ClaimsPrincipal user, IList<Alert> alerts);
         IEnumerable<NotificationBannerModel> SetFullAccessOnNotificationBanners(
             IEnumerable<NotificationBannerModel> notificationBanners,
             ClaimsPrincipal user);
@@ -116,12 +116,12 @@ namespace ntbs_service.Services
             return notifications;
         }
 
-        public async Task<IList<Alert>> FilterTransferAlertsFromListOfAlertsByUserAsync(ClaimsPrincipal user, IList<Alert> alerts)
+        public async Task<IList<Alert>> FilterAlertsForUserAsync(ClaimsPrincipal user, IList<Alert> alerts)
         {
             var userTbServiceCodes = (await _userService.GetTbServicesAsync(user)).Select(s => s.Code);
             for (int i = alerts.Count - 1; i >= 0; i--)
             {
-                if (alerts[i].AlertType == AlertType.TransferRequest && !userTbServiceCodes.Contains(alerts[i].TbServiceCode)  )
+                if (alerts[i].TbServiceCode != null && !userTbServiceCodes.Contains(alerts[i].TbServiceCode))
                     alerts.RemoveAt(i);
             }
             return alerts;

--- a/ntbs-service/wwwroot/source/Components/CascadingDropdown.ts
+++ b/ntbs-service/wwwroot/source/Components/CascadingDropdown.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { getHeaders } from "../helpers";
+import { getHeaders, buildPath } from "../helpers";
 import axios from "axios";
 
 type OptionValue = {
@@ -57,7 +57,7 @@ const CascadingDropdown = Vue.extend({
         },
         fetchFilteredList: function (value: string, path: string) {
             const requestConfig = {
-                url: `${window.location.pathname}/${path}`,
+                url: buildPath(path),
                 headers: getHeaders(),
                 params: {
                     "value": value

--- a/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
+++ b/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { getHeaders } from "../helpers";
+import { getHeaders, buildPath } from "../helpers";
 import axios from "axios";
 
 type OptionValue = {
@@ -62,7 +62,7 @@ const FilteredDropdown = Vue.extend({
         },
         fetchFilteredLists: function (value: string) {
             const requestConfig = {
-                url: `${window.location.pathname}/${this.filterHandlerPath}`,
+                url: buildPath(this.filterHandlerPath),
                 headers: getHeaders(),
                 params: {
                     "value": value

--- a/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
+++ b/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { getHeaders } from "../helpers";
+import { getHeaders, buildPath } from "../helpers";
 import axios from "axios";
 
 const NhsNumberDuplicateWarning = Vue.extend({
@@ -7,7 +7,7 @@ const NhsNumberDuplicateWarning = Vue.extend({
         handleValid: function (value: String) {
             const notificationId = (document.querySelector("#NotificationId") as HTMLInputElement).value;
             const requestConfig = {
-                url: `${window.location.pathname}/NhsNumberDuplicates`,
+                url: buildPath("NhsNumberDuplicates"),
                 headers: getHeaders(),
                 params: {
                     "notificationId": notificationId,

--- a/ntbs-service/wwwroot/source/Components/ValidatePostcode.ts
+++ b/ntbs-service/wwwroot/source/Components/ValidatePostcode.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { getHeaders } from "../helpers";
+import { getHeaders, buildPath } from "../helpers";
 import axios from "axios";
 
 const ValidatePostcode = Vue.extend({
@@ -11,7 +11,7 @@ const ValidatePostcode = Vue.extend({
             const newValue = inputField.value;
 
             let requestConfig = {
-                url: `${window.location.pathname}/ValidatePostcode`,
+                url: buildPath("ValidatePostcode"),
                 headers: getHeaders(),
                 params: {
                     "shouldValidateFull": this.$props.shouldvalidatefull || false,

--- a/ntbs-service/wwwroot/source/helpers.ts
+++ b/ntbs-service/wwwroot/source/helpers.ts
@@ -5,7 +5,13 @@ var getHeaders = function() {
 }
 
 var getValidationPath = function(modelName: string) {
-    return `${window.location.pathname}/Validate${modelName}`;
+    return buildPath(`Validate${modelName}`);
+}
+
+var buildPath = function(actionPath: string) {
+    var currentPath = window.location.pathname;
+    var pathWithNoTrailingSlash = currentPath.charAt(currentPath.length-1) === "/" ? currentPath.slice(0, -1) : currentPath;
+    return `${pathWithNoTrailingSlash}/${actionPath}`;
 }
 
 type FormattedDate = { day: any, month: any, year: any };
@@ -15,5 +21,5 @@ var convertFormattedDateToDate = function(date: FormattedDate) {
 }
 
 export { 
-    getHeaders, getValidationPath, FormattedDate, convertFormattedDateToDate
+    getHeaders, getValidationPath, FormattedDate, convertFormattedDateToDate, buildPath
 };


### PR DESCRIPTION
List of QA markups to fix:
If no case manager is selected, the alert is displayed on the homepage with ‘System’ showing as the case manager. (Likewise when the user opens the alert). Should just display nothing.

 On the ‘pending transfer’ screen (i.e. on the view of the alert), the free text associated with the reason ‘other’ is not displayed.

The receiving case manager cannot view the transfer alert on the notification overview, unless they happen to be able to edit the notification already.

The case manager can set up a transfer into the service that the case is already in.  This was not excluded in the requirements, i.e. it’s my fault.

After cancelling a transfer, the user is only able to go back to the home page. This is what the sketch said, but isn’t consist with the behaviour when the user has just viewed a pending transfer request, where the user can return to the notification.

These are all fixed with these changes

## Checklist:
- [X] Automated tests are passing locally.
