### PR TITLE
NTBS-726 hide button when notification under year old

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -45,6 +45,8 @@ namespace ntbs_integration_tests.Helpers
         public const int CLINICAL_NOTIFICATION_EXTRA_PULMONARY_ID = 80;
 
         public const int LATE_DOB_ID = 90;
+        public const int NOTIFICATION_DATE_TODAY = 95;
+        public const int NOTIFICATION_DATE_OVER_YEAR_AGO = 96;
 
         public const int NOTIFICATION_GROUP_ID = 1;
 
@@ -79,6 +81,7 @@ namespace ntbs_integration_tests.Helpers
             context.Alert.AddRange(GetSeedingAlerts());
 
             // Entities required for specific test suites
+            context.Notification.AddRange(OverviewPageTests.GetSeedingNotifications());
             context.Notification.AddRange(DenotifyPageTests.GetSeedingNotifications());
             context.Notification.AddRange(DeletePageTests.GetSeedingNotifications());
             context.Notification.AddRange(PatientPageTests.GetSeedingNotifications());

--- a/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
@@ -23,7 +23,8 @@ namespace ntbs_integration_tests.NotificationPages
             {
                 new Notification(){ NotificationId = Utilities.DENOTIFY_WITH_DESCRIPTION, NotificationStatus = NotificationStatus.Notified },
                 new Notification(){ NotificationId = Utilities.DENOTIFY_NO_DESCRIPTION, NotificationStatus = NotificationStatus.Notified },
-                new Notification(){
+                new Notification()
+                {
                     NotificationId = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE,
                     NotificationStatus = NotificationStatus.Notified,
                     NotificationDate = new DateTime(2011, 1, 1)

--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -1,10 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
 using ntbs_integration_tests.TestServices;
 using ntbs_service;
 using ntbs_service.Helpers;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Enums;
 using ntbs_service.Pages;
 using Xunit;
 
@@ -16,6 +19,25 @@ namespace ntbs_integration_tests.NotificationPages
         protected override string NotificationSubPath => NotificationSubPaths.Overview;
 
         public OverviewPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
+
+        public static IList<Notification> GetSeedingNotifications()
+        {
+            return new List<Notification>
+            {
+                new Notification
+                { 
+                    NotificationId = Utilities.NOTIFICATION_DATE_TODAY,
+                    NotificationStatus = NotificationStatus.Notified,
+                    NotificationDate = DateTime.Now
+                },
+                new Notification
+                {
+                    NotificationId = Utilities.NOTIFICATION_DATE_OVER_YEAR_AGO,
+                    NotificationStatus = NotificationStatus.Notified,
+                    NotificationDate = new DateTime(2015, 1, 1)
+                }
+            };
+        }
 
         public static IEnumerable<object[]> OverviewRoutes()
         {
@@ -95,6 +117,24 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Contains(GetRedirectLocation(result), url);
             var reloadedDocument = await GetDocumentForUrl(GetRedirectLocation(result));
             Assert.Null(reloadedDocument.QuerySelector("#alert-1"));
+        }
+
+        [Fact]
+        public async Task OverviewPageHidesCreateNewNotificationForThisPatientButton_IfNotificationNotOverOneYearOld()
+        {
+            // Arrange
+            var url = GetCurrentPathForId(Utilities.NOTIFICATION_DATE_TODAY);
+            var document = await GetDocumentForUrl(url);
+            Assert.Null(document.QuerySelector("#new-linked-notification-button"));
+        }
+
+        [Fact]
+        public async Task OverviewPageShowsCreateNewNotificationForThisPatientButton_IfNotificationOverOneYearOld()
+        {
+            // Arrange
+            var url = GetCurrentPathForId(Utilities.NOTIFICATION_DATE_OVER_YEAR_AGO);
+            var document = await GetDocumentForUrl(url);
+            Assert.NotNull(document.QuerySelector("#new-linked-notification-button"));
         }
     }
 }

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -133,7 +133,8 @@ namespace ntbs_service.Models.Entities
         public string MDRCaseCountryName => MDRDetails.Country?.Name;
         public bool HasBeenNotified => NotificationStatus == NotificationStatus.Notified || NotificationStatus == NotificationStatus.Legacy;
         public string LegacyId => LTBRID ?? ETSID;
-        public bool TransferRequestPending => Alerts?.Any(x => x.AlertType == AlertType.TransferRequest && x.AlertStatus == AlertStatus.Open) == true; 
+        public bool TransferRequestPending => Alerts?.Any(x => x.AlertType == AlertType.TransferRequest && x.AlertStatus == AlertStatus.Open) == true;
+        public bool OverOneYearOld => NotificationDate != null ? DateTime.Now > NotificationDate.Value.AddYears(1) : false;
 
         private string GetNotificationStatusString()
         {

--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -46,12 +46,15 @@
     <nhs-grid-column grid-column-width="OneThird">
         <div class="@manageNotificationClass">
             <nhs-details display-text="Manage notification" nhs-details-type="Expander" id="manage-notification">
-                <form method="post">
-                    <input hidden value="@Model.NotificationId" name="NotificationId" />
-                    <button nhs-button-type="Standard" classes="ntbsuk-button--secondary" asp-page-handler="CreateLink">
-                        New notification for this patient
-                    </button>
-                </form>
+                @if(Model.Notification.OverOneYearOld)
+                {
+                    <form method="post">
+                        <input hidden value="@Model.NotificationId" name="NotificationId" />
+                        <button nhs-button-type="Standard" classes="ntbsuk-button--secondary" asp-page-handler="CreateLink" id="new-linked-notification-button">
+                            New notification for this patient
+                        </button>
+                    </form>
+                }
                 @if (Model.Notification.NotificationStatus == NotificationStatus.Notified && Model.HasEditPermission)
                 {
                     var transferRequestHref = @RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.TransferRequest);


### PR DESCRIPTION
Hide "new notification for this patient" button for notifications under a year old.

## Checklist:
- [X] Automated tests are passing locally.
