### PR TITLE
NTBS-381: Fix audit and add TbService name to potential match partial

### DIFF
--- a/ntbs-service/Models/Entities/SpecimenPotentialMatch.cs
+++ b/ntbs-service/Models/Entities/SpecimenPotentialMatch.cs
@@ -32,6 +32,9 @@ namespace ntbs_service.Models.Entities
         
         public string ConfidenceLevel { get; set; }
 
+        [Display(Name = "TB Service")]
+        public string TbServiceName { get; set; }
+
         public string FormattedDob => NtbsBirthDate.ConvertToString();
         public string FormattedNotificationDate => NotificationDate.ConvertToString();
         public string FormattedNhsNumber => NtbsNhsNumber.FormatStringToNhsNumberFormat();

--- a/ntbs-service/Pages/LabResults/Index.cshtml.cs
+++ b/ntbs-service/Pages/LabResults/Index.cshtml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -84,7 +85,8 @@ namespace ntbs_service.Pages.LabResults
                     "number was either previously matched, or unavailable to the user.");
             }
 
-            await _specimenService.MatchSpecimenAsync(notificationId, laboratoryReferenceNumber, User.Identity.Name);
+            var userName = User.FindFirstValue(ClaimTypes.Email);
+            await _specimenService.MatchSpecimenAsync(notificationId, laboratoryReferenceNumber, userName);
             AddTempDataForSuccessfulMessage(notificationId, laboratoryReferenceNumber);
 
             // Explicit path to the current page to avoid persisting any 'scroll to id' path values
@@ -226,7 +228,8 @@ namespace ntbs_service.Pages.LabResults
                 NtbsPostcode = notification.PatientDetails.Postcode,
                 NtbsBirthDate = notification.PatientDetails.Dob,
                 NtbsNhsNumber = notification.FormattedNhsNumber,
-                NtbsSex = notification.SexLabel
+                NtbsSex = notification.SexLabel,
+                TbServiceName = notification.TBServiceName
             };
         }
     }

--- a/ntbs-service/Pages/LabResults/_labResultsDemographics.cshtml
+++ b/ntbs-service/Pages/LabResults/_labResultsDemographics.cshtml
@@ -37,4 +37,10 @@
             <dd class="cell-min-height"> @Model.NtbsAddress </dd>
         </nhs-grid-column>
     </nhs-grid-row>
+    <nhs-grid-row classes="lab-results-demographics-row">
+        <nhs-grid-column grid-column-width="OneHalf">
+            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.TbServiceName) </dt>
+            <dd class="cell-min-height"> @Model.TbServiceName </dd>
+        </nhs-grid-column>
+    </nhs-grid-row>
 </div>

--- a/ntbs-service/Services/SpecimenQueryHelper.cs
+++ b/ntbs-service/Services/SpecimenQueryHelper.cs
@@ -27,6 +27,7 @@ namespace ntbs_service.Services
                 ,[{nameof(SpecimenPotentialMatch.NtbsBirthDate)}]
                 ,[{nameof(SpecimenPotentialMatch.NtbsAddress)}]
                 ,[{nameof(SpecimenPotentialMatch.NtbsPostcode)}]
+                ,[{nameof(SpecimenPotentialMatch.TbServiceName)}]
                 ,[{nameof(SpecimenPotentialMatch.ConfidenceLevel)}]";
 
         private static readonly string _orderByUnmatchedStatement =

--- a/ntbs-service/Services/SpecimenService.cs
+++ b/ntbs-service/Services/SpecimenService.cs
@@ -148,7 +148,7 @@ namespace ntbs_service.Services
                     commandType: CommandType.StoredProcedure);
             }
 
-            await _auditService.AuditUnmatchSpecimen(notificationId, referenceLaboratoryNumber, userName);
+            await _auditService.AuditMatchSpecimen(notificationId, referenceLaboratoryNumber, userName);
         }
 
         private class UnmatchedQueryResultRow


### PR DESCRIPTION
## Description
Add TB Service 'field' to demographics view to give a pre-match indicator that the match might fail for permissions - this was raised by developer during dev cycle but decided not to implement, then requested as QA.

Correct audit messages.

## Checklist:
- [X] Automated tests are passing locally.
### Accessibility testing
- [X] Test in small window (imitating small screen)
- [X] Check the feature looks and works correctly in IE11
- [X] Zoom page to 400% - content still visible?
