### PR TITLE
NTBS 742 and 296 markups

### DIFF
--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -179,8 +179,12 @@ namespace ntbs_service.DataAccess
                 .Select(n => n.Group)
                 .Include(g => g.Notifications)
                     .ThenInclude(n => n.PatientDetails)
+                        .ThenInclude(p => p.PostcodeLookup)
+                            .ThenInclude(l => l.LocalAuthority)
+                                .ThenInclude(la => la.LocalAuthorityToPHEC)
                 .Include(g => g.Notifications)
                     .ThenInclude(n => n.Episode)
+                        .ThenInclude(e => e.TBService)
                 .SingleOrDefaultAsync();
         }
 

--- a/ntbs-service/Pages/Alerts/TransferRejected.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRejected.cshtml
@@ -13,10 +13,12 @@
     
     <br>
     
-    <div> @Model.TransferRejectedAlert.CaseManagerTbServiceString: </div>
-    
-    <br/>
-    
+    @if(Model.TransferRejectedAlert.CaseManagerTbServiceString != null)
+    {
+        <div> @Model.TransferRejectedAlert.CaseManagerTbServiceString: </div>
+        <br/>
+    }
+
     <div class="rejection-note"> @Model.TransferRejectedAlert.RejectionReason </div>
 
     <form method="post" autocomplete="off">

--- a/ntbs-service/Pages/Index.cshtml.cs
+++ b/ntbs-service/Pages/Index.cshtml.cs
@@ -43,7 +43,7 @@ namespace ntbs_service.Pages
         public async Task OnGetAsync()
         {
             await SetUserNotificationsAsync();
-            await SetUserAlertsAsync();
+            await SetUserAlertsAndTbServicesAsync();
             await SetHomepageKpiDetails();
         }
 
@@ -73,12 +73,13 @@ namespace ntbs_service.Pages
             RecentNotifications = (await _authorizationService.FilterNotificationsByUserAsync(User, recentNotificationsQueryable)).Take(10).ToList();
         }
 
-        private async Task SetUserAlertsAsync()
+        private async Task SetUserAlertsAndTbServicesAsync()
         {
             var services = (await _userService.GetTbServicesAsync(User)).ToList();
             var tbServiceCodes = services.Select(s => s.Code);
             TbServices = new SelectList(services, nameof(TBService.Code), nameof(TBService.Name));
-            Alerts = await _alertRepository.GetAlertsByTbServiceCodesAsync(tbServiceCodes);
+            var nonFilteredAlerts = await _alertRepository.GetAlertsByTbServiceCodesAsync(tbServiceCodes);
+            Alerts = await _authorizationService.FilterAlertsForUserAsync(User, nonFilteredAlerts);
         }
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -103,7 +103,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
             var notificationIds =
                 await NotificationRepository.GetNotificationIdsByNhsNumber(nhsNumber);
-            var idsInGroup = Group?.Notifications?.Select(n => n.NotificationId) ?? new List<int>();
+            var idsInGroup = Notification.Group?.Notifications?.Select(n => n.NotificationId) ?? new List<int>();
             var filteredIds = notificationIds
                 .Except(idsInGroup)
                 .Where(n => n != NotificationId)

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -37,7 +38,7 @@ namespace ntbs_service.Pages.Notifications
             await AuthorizeAndSetBannerAsync();
 
             // Deleted notifications should have their group ID removed so they should not appear here
-            LinkedNotifications = Group.Notifications
+            LinkedNotifications = Notification.Group.Notifications
                 .Where(n => n.NotificationId != NotificationId)
                 .CreateNotificationBanners(User, AuthorizationService).ToList();
 

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -53,15 +53,15 @@ namespace ntbs_service.Pages.Notifications
         protected async Task<bool> TryGetLinkedNotifications()
         {
             await GetLinkedNotifications();
-            return Group != null;
+            return Notification.Group != null;
         }
 
         protected async Task GetLinkedNotifications()
         {
-            if (Group == null)
+            if (Notification.Group == null)
             {
-                Group = await GetNotificationGroupAsync();
-                NumberOfLinkedNotifications = Group?.Notifications.Count - 1 ?? 0;
+                Notification.Group = await GetNotificationGroupAsync();
+                NumberOfLinkedNotifications = Notification.Group?.Notifications.Count - 1 ?? 0;
             }
         }
 

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -26,8 +26,6 @@ namespace ntbs_service.Pages.Notifications
             AuthorizationService = authorizationService;
             NotificationRepository = notificationRepository;
         }
-
-        protected NotificationGroup Group;
         public int NumberOfLinkedNotifications { get; set; }
 
         public Notification Notification { get; set; }


### PR DESCRIPTION
## Description
Remove Group on modelBase and use NotificationGroup where possible
Filter alerts on home page

## Checklist:
- [X] Automated tests are passing locally.
- [X] Sanity checked new EF-generated queries for performance.
### Accessibility testing
- [X] Test functionality without javascript
- [X] Test in small window (imitating small screen)
- [X] Check the feature looks and works correctly in IE11
- [X] Zoom page to 400% - content still visible?
- [X] Test feature works with keyboard only operation
- [X] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
