### PR TITLE
NTBS-812: Search/padlock issues

### DIFF
--- a/ntbs-service-unit-tests/Pages/SearchPageTest.cs
+++ b/ntbs-service-unit-tests/Pages/SearchPageTest.cs
@@ -63,7 +63,7 @@ namespace ntbs_service_unit_tests.Pages
             var legacyNotificationsAndCount = Task.FromResult(GetLegacyNotificationBanner());
             _mockLegacySearchService.Setup(s => s.SearchAsync(It.IsAny<ILegacySearchBuilder>(), It.IsAny<int>(), It.IsAny<int>())).Returns(legacyNotificationsAndCount);
 
-            _mockAuthorizationService.Setup(s => s.SetFullAccessOnNotificationBanners(It.IsAny<IEnumerable<NotificationBannerModel>>(), It.IsAny<ClaimsPrincipal>()))
+            _mockAuthorizationService.Setup(s => s.SetFullAccessOnNotificationBannersAsync(It.IsAny<IEnumerable<NotificationBannerModel>>(), It.IsAny<ClaimsPrincipal>()))
                 .Verifiable();
             
 

--- a/ntbs-service/Helpers/NotificationExtensionMethods.cs
+++ b/ntbs-service/Helpers/NotificationExtensionMethods.cs
@@ -18,7 +18,10 @@ namespace ntbs_service.Helpers
             return notifications.Select(async n =>
                 {
                     var fullAccess = await authorizationService.GetPermissionLevelForNotificationAsync(user, n) == PermissionLevel.Edit;
-                    return new NotificationBannerModel(n, showPadlock: fullAccess, showLink: true);
+                    return new NotificationBannerModel(
+                        n,
+                        showPadlock: !fullAccess,
+                        showLink: fullAccess || n.NotificationStatus != NotificationStatus.Draft);
                 })
                 .Select(n => n.Result);
         }

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -34,7 +34,7 @@ namespace ntbs_service.Models
         // Access level is treated as a bool for either able to edit or not. This differs from the standard PermissionLevel
         // implemented across the codebase due to there being no visual difference between no permission level and readonly
         // permission on notification banner models
-        public NotificationBannerModel(Notification notification, bool showPadlock = true, bool showLink = false) {
+        public NotificationBannerModel(Notification notification, bool showPadlock = false, bool showLink = false) {
             NotificationId = notification.NotificationId.ToString();
             SortByDate = notification.NotificationDate ?? notification.CreationDate;
             TbService = notification.TBServiceName;

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -47,7 +47,7 @@ namespace ntbs_service.Pages.Notifications
         protected async Task AuthorizeAndSetBannerAsync()
         {
             PermissionLevel = await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification);
-            NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel == PermissionLevel.Edit);
+            NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel != PermissionLevel.Edit);
         }
 
         protected async Task<bool> TryGetLinkedNotifications()

--- a/ntbs-service/Pages/Notifications/UnauthorizedWarning.cshtml
+++ b/ntbs-service/Pages/Notifications/UnauthorizedWarning.cshtml
@@ -5,6 +5,7 @@
 @{
     Layout = "../Shared/_NotificationOverviewLayout.cshtml";
     ViewData["CurrentPage"] = NotificationSubPaths.Overview;
+    ViewData["Title"] = "Unauthorised";
 }
 
 <nhs-width-container container-width="Standard">

--- a/ntbs-service/Pages/Search/Index.cshtml.cs
+++ b/ntbs-service/Pages/Search/Index.cshtml.cs
@@ -90,7 +90,7 @@ namespace ntbs_service.Pages.Search
             var legacyFilteredSearchBuilder = (ILegacySearchBuilder)FilterBySearchParameters(new LegacySearchBuilder(_referenceDataRepository));
 
             var (notificationsToDisplay, count) = await SearchAsync(ntbsFilteredDraftsBuilder, ntbsFilteredNonDraftsBuilder, legacyFilteredSearchBuilder);
-            _authorizationService.SetFullAccessOnNotificationBanners(notificationsToDisplay, User);
+            await _authorizationService.SetFullAccessOnNotificationBannersAsync(notificationsToDisplay, User);
             SearchResults = new PaginatedList<NotificationBannerModel>(notificationsToDisplay, count, PaginationParameters);
             var (nextNtbsOffset, nextLegacyOffset) = CalculateNextOffsets(PaginationParameters.PageIndex, legacyOffset, ntbsOffset, notificationsToDisplay);
             SetPaginationDetails(nextNtbsOffset, nextLegacyOffset, previousNtbsOffset, previousLegacyOffset, ntbsOffset, legacyOffset);

--- a/ntbs-service/Pages/Shared/_NotificationBanner.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationBanner.cshtml
@@ -15,7 +15,7 @@
                     <div> @Model.NotificationStatusString </div>
 
                     <div>
-                        @if (@Model.ShowLink)
+                        @if (Model.ShowLink)
                         {
                             <a href="@Model.RedirectPath" class="notification-banner-id-link" id="notification-banner-id">#@Model.NotificationId</a>
                         }
@@ -32,7 +32,7 @@
                             }
                         }
 
-                        @if (!Model.ShowPadlock)
+                        @if (Model.ShowPadlock)
                         {
                             <span class="govuk-visually-hidden">Limited Access</span>
                             <svg width="16" height="18" xmlns="http://www.w3.org/2000/svg">

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -40,22 +40,15 @@ namespace ntbs_service.Services
             IEnumerable<NotificationBannerModel> notificationBanners,
             ClaimsPrincipal user)
         {
-            List<Task> tasks = new List<Task>();
-
-            async Task SetPadlockForBanner(ClaimsPrincipal u, NotificationBannerModel bannerModel)
+            async Task SetPadlockForBannerAsync(ClaimsPrincipal u, NotificationBannerModel bannerModel)
             {
                 bannerModel.ShowPadlock = !(await CanEditBannerModelAsync(u, bannerModel));
             }
 
-            notificationBanners.ForEach(n =>
-            {
-                if (n.NotificationStatus != NotificationStatus.Legacy)
-                {
-                    tasks.Add(SetPadlockForBanner(user, n));
-                }
-            });
-
-            await Task.WhenAll(tasks);
+            await Task.WhenAll(
+                notificationBanners
+                    .Where(n => n.NotificationStatus != NotificationStatus.Legacy)
+                    .Select(n => SetPadlockForBannerAsync(user, n)));
         }
 
         public async Task<PermissionLevel> GetPermissionLevelForNotificationAsync(ClaimsPrincipal user,

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using MoreLinq;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
@@ -14,7 +15,7 @@ namespace ntbs_service.Services
         Task<IQueryable<Notification>> FilterNotificationsByUserAsync(ClaimsPrincipal user, IQueryable<Notification> notifications);
         Task<bool> IsUserAuthorizedToManageAlert(ClaimsPrincipal user, Alert alert);
         Task<IList<Alert>> FilterAlertsForUserAsync(ClaimsPrincipal user, IList<Alert> alerts);
-        void SetFullAccessOnNotificationBanners(
+        Task SetFullAccessOnNotificationBannersAsync(
             IEnumerable<NotificationBannerModel> notificationBanners,
             ClaimsPrincipal user);
     }
@@ -35,17 +36,26 @@ namespace ntbs_service.Services
             return userTbServiceCodes.Contains(alert.TbServiceCode);
         }
 
-        public void SetFullAccessOnNotificationBanners(
+        public async Task SetFullAccessOnNotificationBannersAsync(
             IEnumerable<NotificationBannerModel> notificationBanners,
             ClaimsPrincipal user)
         {
-            notificationBanners.ToList().ForEach(async n =>
+            List<Task> tasks = new List<Task>();
+
+            async Task SetPadlockForBanner(ClaimsPrincipal u, NotificationBannerModel bannerModel)
             {
-                if(n.NotificationStatus != NotificationStatus.Legacy)
+                bannerModel.ShowPadlock = !(await CanEditBannerModelAsync(u, bannerModel));
+            }
+
+            notificationBanners.ForEach(n =>
+            {
+                if (n.NotificationStatus != NotificationStatus.Legacy)
                 {
-                    n.ShowPadlock = await CanEditBannerModelAsync(user, n);
+                    tasks.Add(SetPadlockForBanner(user, n));
                 }
             });
+
+            await Task.WhenAll(tasks);
         }
 
         public async Task<PermissionLevel> GetPermissionLevelForNotificationAsync(ClaimsPrincipal user,
@@ -69,34 +79,35 @@ namespace ntbs_service.Services
             return PermissionLevel.None;
         }
         
-        private async Task<bool> CanEditBannerModelAsync(ClaimsPrincipal user,
+        private async Task<bool> CanEditBannerModelAsync(
+            ClaimsPrincipal user,
             NotificationBannerModel notificationBannerModel)
         {
             if (_userPermissionsFilter == null)
             {
                 _userPermissionsFilter = await GetUserPermissionsFilterAsync(user);
             }
-            if (_userPermissionsFilter.Type == UserType.NationalTeam)
-            {
-                return true;
-            }
-            if (_userPermissionsFilter.Type == UserType.PheUser)
-            {
-                var allowedCodes = _userPermissionsFilter.IncludedPHECCodes;
-                return allowedCodes.Contains(notificationBannerModel.TbServicePHECCode) ||
-                       allowedCodes.Contains(notificationBannerModel.LocationPHECCode);
-            }
-            if (_userPermissionsFilter.Type == UserType.NhsUser)
-            {
-                return _userPermissionsFilter.IncludedTBServiceCodes.Contains(notificationBannerModel.TbServiceCode);
-            }
-            return false;
             
+            switch (_userPermissionsFilter.Type)
+            {
+                case UserType.NationalTeam:
+                    return true;
+                case UserType.PheUser:
+                {
+                    var allowedCodes = _userPermissionsFilter.IncludedPHECCodes;
+                    return allowedCodes.Contains(notificationBannerModel.TbServicePHECCode) ||
+                           allowedCodes.Contains(notificationBannerModel.LocationPHECCode);
+                }
+                case UserType.NhsUser:
+                    return _userPermissionsFilter.IncludedTBServiceCodes.Contains(notificationBannerModel.TbServiceCode);
+                default:
+                    return false;
+            }
         }
         
         private bool UserHasDirectRelationToLinkedNotification(IEnumerable<Notification> linkedNotifications)
         {
-            return linkedNotifications != null && linkedNotifications.Select(UserHasDirectRelationToNotification).Any(x => x == true);
+            return linkedNotifications != null && linkedNotifications.Select(UserHasDirectRelationToNotification).Any(x => x);
         }
 
         private bool UserHasDirectRelationToNotification(Notification notification)
@@ -133,7 +144,7 @@ namespace ntbs_service.Services
             }
             else if (_userPermissionsFilter.Type == UserType.PheUser)
             {
-                // Having a method in LINQ clause breaks IQuaryable abstraction. We have to use inline expression over methods
+                // Having a method in LINQ clause breaks IQueryable abstraction. We have to use inline expression over methods
                 notifications = notifications.Where(n => 
                     (
                         n.Episode.TBService != null && 


### PR DESCRIPTION
## Description
Await changes to banner models which need to be completed before rendering the page.
Flip 'ShowPadlock' logic to accurately reflect the naming convention.
Add missing 'tab title' for unauthorised page which was originally showing ~"- ntbs service" .

## Checklist:
- [X] Automated tests are passing locally.
