### PR TITLE
Stop browser from launching on service start in dev

### DIFF
--- a/ntbs-service/Properties/launchSettings.json
+++ b/ntbs-service/Properties/launchSettings.json
@@ -10,14 +10,12 @@
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
     "ntbs_service": {
       "commandName": "Project",
-      "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION
@conorsheehansw @ffarmanov @ChristianMcc how would you feel about this change? It would stop the browser from auto-launching on each service restart.

(I have a vague recollection of doing this once before, so not sure if those changes got wiped or actually never merged, or whatnot)