### PR TITLE
NTBS-854 relax validation for legacy notifications

### DIFF
--- a/ntbs-migration-tests/NotificationImportTest.cs
+++ b/ntbs-migration-tests/NotificationImportTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
-using ntbs_service.Models.Enums;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 using Moq;
@@ -58,7 +57,7 @@ namespace ntbs_migration_tests
         public async Task NotificationExists()
         {
             //Given
-            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExists("1")).Returns(true);
+            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExistsAsync("1")).Returns(Task.FromResult(true));
             var ids = new List<string>() { "1" };
 
             //When
@@ -73,7 +72,7 @@ namespace ntbs_migration_tests
         public async Task NotificationNotFound()
         {
             //Given
-            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExists(It.IsAny<string>())).Returns(false);
+            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExistsAsync(It.IsAny<string>())).Returns(Task.FromResult(false));
             var ids = new List<string>() { "0" };
 
             //When
@@ -88,8 +87,8 @@ namespace ntbs_migration_tests
         public async Task NotificationWithoutValidationErrors()
         {
             //Given
-            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExists(It.IsAny<string>()))
-                                        .Returns(false);
+            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExistsAsync(It.IsAny<string>()))
+                                        .Returns(Task.FromResult(false));
 
             var ids = new List<string>() { "66-1" };
             var dummyPostcodeList = new List<PostcodeLookup> {
@@ -120,8 +119,8 @@ namespace ntbs_migration_tests
         public async Task NotificationValidationErrors()
         {
             //Given
-            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExists(It.IsAny<string>()))
-                                        .Returns(false);
+            _mockNotificationRepository.Setup(x => x.NotificationWithLegacyIdExistsAsync(It.IsAny<string>()))
+                                        .Returns(Task.FromResult(false));
 
             var ids = new List<string>() { "41-1" };
             var dummyPostcodeList = new List<PostcodeLookup> {

--- a/ntbs-service-unit-tests/Models/Entities/PatientDetailsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/PatientDetailsTest.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using ntbs_service.Models.Entities;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Models.Entities
+{
+    public class PatientDetailsTest
+    {
+        [Theory]
+        [InlineData("AB10AA")]
+        [InlineData("AB10AB")]
+        [InlineData("AB10AD")]
+        [InlineData("AB10AE")]
+        public void Postcode_WithMatchingLookup_IsValid(string postcode)
+        {
+            // Arrange
+            var patientDetails = new PatientDetails {Postcode = postcode, PostcodeToLookup = postcode};
+            var validationResults = new List<ValidationResult>();
+            
+            // Act
+            var isValid = Validator.TryValidateObject(patientDetails, new ValidationContext(patientDetails), validationResults, true); 
+
+            // Assert
+            Assert.True(isValid, "Expected no postcode errors");
+        }
+        
+        [Theory]
+        [InlineData("DE142GL")]
+        [InlineData("W187SB")]
+        [InlineData("MK777FB")]
+        public void Postcode_WithNoMatchingLookup_IsInvalid(string postcode)
+        {
+            // Arrange
+            var patientDetails = new PatientDetails {Postcode = postcode};
+            var validationResults = new List<ValidationResult>();
+            
+            // Act
+            var isValid = Validator.TryValidateObject(patientDetails, new ValidationContext(patientDetails), validationResults, true); 
+
+            // Assert
+            Assert.False(isValid, "Expected postcode errors");
+            validationResults.ForEach(result =>
+                Assert.Equal("Postcode is not found", result.ErrorMessage));
+            
+        }
+        
+        [Theory]
+        [InlineData("DE142GL")]
+        [InlineData("W187SB")]
+        [InlineData("MK777FB")]
+        public void Postcode_WithNoMatchingLookupForLegacyNotification_IsValid(string postcode)
+        {
+            // Arrange
+            var patientDetails = new PatientDetails {Postcode = postcode, IsLegacy = true};
+            var validationResults = new List<ValidationResult>();
+            
+            // Act
+            var isValid = Validator.TryValidateObject(patientDetails, new ValidationContext(patientDetails), validationResults, true); 
+
+            // Assert
+            Assert.True(isValid, "Expected no postcode errors for legacy notifications");
+        }
+        
+        [Theory]
+        [InlineData("CB29J")]
+        [InlineData("4156255")]
+        [InlineData("garbage")]
+        public void Postcode_WithJunkContent_IsInvalidEvenForLegacyNotifications(string postcode)
+        {
+            // Arrange
+            var patientDetails = new PatientDetails {Postcode = postcode, IsLegacy = true};
+            var validationResults = new List<ValidationResult>();
+            
+            // Act
+            var isValid = Validator.TryValidateObject(patientDetails, new ValidationContext(patientDetails), validationResults, true); 
+
+            // Assert
+            Assert.False(isValid, "Expected postcode errors as postcode doesn't conform to postcode format");
+            validationResults.ForEach(result =>
+                Assert.Equal("Postcode is not valid", result.ErrorMessage));
+            
+        }
+    }
+}

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -28,7 +28,7 @@ namespace ntbs_service.DataAccess
         Task<IEnumerable<NotificationBannerModel>> GetNotificationBannerModelsByIdsAsync(IList<int> ids);
         Task<IList<int>> GetNotificationIdsByNhsNumber(string nhsNumber);
         Task<NotificationGroup> GetNotificationGroupAsync(int notificationId);
-        bool NotificationWithLegacyIdExists(string id);
+        Task<bool> NotificationWithLegacyIdExistsAsync(string id);
     }
 
     public class NotificationRepository : INotificationRepository
@@ -75,10 +75,10 @@ namespace ntbs_service.DataAccess
                 .SingleOrDefaultAsync(n => n.NotificationId == notificationId);
         }
 
-        public bool NotificationWithLegacyIdExists(string id)
+        public async Task<bool> NotificationWithLegacyIdExistsAsync(string id)
         {
-            return _context.Notification
-                .Any(e => e.LTBRID == id || e.ETSID == id);
+            return await _context.Notification
+                .AnyAsync(e => e.LTBRID == id || e.ETSID == id);
         }
         
         public async Task<IList<int>> GetNotificationIdsByNhsNumber(string nhsNumber)

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using EFAuditer;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
@@ -29,6 +28,7 @@ namespace ntbs_service.DataAccess
         Task<IList<int>> GetNotificationIdsByNhsNumber(string nhsNumber);
         Task<NotificationGroup> GetNotificationGroupAsync(int notificationId);
         Task<bool> NotificationWithLegacyIdExistsAsync(string id);
+        Task<bool> IsNotificationLegacyAsync(int id);
     }
 
     public class NotificationRepository : INotificationRepository
@@ -80,7 +80,14 @@ namespace ntbs_service.DataAccess
             return await _context.Notification
                 .AnyAsync(e => e.LTBRID == id || e.ETSID == id);
         }
-        
+
+        public async Task<bool> IsNotificationLegacyAsync(int id)
+        {
+            return await _context.Notification.Where(n => n.NotificationId == id)
+                .Select(n => n.LTBRID != null || n.ETSID != null)
+                .SingleAsync();
+        }
+
         public async Task<IList<int>> GetNotificationIdsByNhsNumber(string nhsNumber)
         {
             return await _context.Notification

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using EFAuditer;
@@ -17,34 +16,34 @@ namespace ntbs_service.Models.Entities
         public bool? IsSymptomatic { get; set; }
 
         [Display(Name = "Symptom onset date")]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"AfterDob(SymptomStartDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? SymptomStartDate { get; set; }
 
         [Display(Name = "Presentation to any health service")]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"AfterDob(FirstPresentationDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? FirstPresentationDate { get; set; }
 
         [Display(Name = "Presentation to TB service")]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"AfterDob(TBServicePresentationDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? TBServicePresentationDate { get; set; }
 
         [Display(Name = "Diagnosis date")]
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.FieldRequired)]
         [AssertThat(@"AfterDob(DiagnosisDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         public DateTime? DiagnosisDate { get; set; }
 
         [Display(Name = "Treatment start date")]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"AfterDob(TreatmentStartDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? TreatmentStartDate { get; set; }
 
         [Display(Name = "Date of death")]
         [RequiredIf(@"ShouldValidateFull && IsPostMortem == true", ErrorMessage = ValidationMessages.FieldRequired)]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"AfterDob(DeathDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? DeathDate { get; set; }
 
@@ -64,7 +63,7 @@ namespace ntbs_service.Models.Entities
         public bool? IsMDRTreatment { get; set; }
 
         [Display(Name = "RR/MDR/XDR treatment date")]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"AfterDob(MDRTreatmentStartDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? MDRTreatmentStartDate { get; set; }
         
@@ -84,7 +83,7 @@ namespace ntbs_service.Models.Entities
         public Status? HomeVisitCarriedOut { get; set; }
         
         [Display(Name = "First home visit date")]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"AfterDob(FirstHomeVisitDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? FirstHomeVisitDate { get; set; } 
         

--- a/ntbs-service/Models/Entities/ManualTestResult.cs
+++ b/ntbs-service/Models/Entities/ManualTestResult.cs
@@ -10,7 +10,7 @@ using ntbs_service.Models.Validations;
 
 namespace ntbs_service.Models.Entities
 {
-    public class ManualTestResult : IHasRootEntity
+    public class ManualTestResult : ModelBase, IHasRootEntity
     {
         // Even for values which are non-nullable in db, we make them a nullable runtime type so 
         // the Required attribute can be applied properly, producing correct error messages
@@ -22,7 +22,7 @@ namespace ntbs_service.Models.Entities
 
         [Display(Name = "Test date")]
         [Required(ErrorMessage = ValidationMessages.RequiredEnter)]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"TestDateAfterDob", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         public DateTime? TestDate { get; set; }
 

--- a/ntbs-service/Models/Entities/ModelBase.cs
+++ b/ntbs-service/Models/Entities/ModelBase.cs
@@ -8,7 +8,8 @@ namespace ntbs_service.Models.Entities
         [NotMapped]
         public bool ShouldValidateFull { get; set; }
 
-        [NotMapped] public bool? IsLegacy { get; set; }
+        [NotMapped]
+        public bool? IsLegacy { get; set; }
 
         /* 
         * Full Validation is done if the form is being submitted or already been submitted.

--- a/ntbs-service/Models/Entities/ModelBase.cs
+++ b/ntbs-service/Models/Entities/ModelBase.cs
@@ -8,14 +8,17 @@ namespace ntbs_service.Models.Entities
         [NotMapped]
         public bool ShouldValidateFull { get; set; }
 
+        [NotMapped] public bool? IsLegacy { get; set; }
+
         /* 
         * Full Validation is done if the form is being submitted or already been submitted.
         * Since the ModelBase does not have direct access to NotificationStatus, 
         * this methods is used to set Validation State from ViewModel
         */ 
-        public void SetFullValidation(NotificationStatus notificationStatus, bool isBeingSubmitted = false) 
+        public void SetValidationContext(Notification notification, bool isBeingSubmitted = false) 
         {
-            ShouldValidateFull = isBeingSubmitted || notificationStatus != NotificationStatus.Draft;
+            ShouldValidateFull = isBeingSubmitted || notification.NotificationStatus != NotificationStatus.Draft;
+            IsLegacy = notification.IsLegacy;
         }
     }
 }

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -52,7 +52,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Notification date")]
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.FieldRequired)]
         [AssertThat(@"PatientDetails.Dob == null || NotificationDate > PatientDetails.Dob", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         public DateTime? NotificationDate { get; set; }
         public NotificationStatus NotificationStatus { get; set; }
 

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -56,6 +56,9 @@ namespace ntbs_service.Models.Entities
         public DateTime? NotificationDate { get; set; }
         public NotificationStatus NotificationStatus { get; set; }
 
+        [NotMapped]
+        public new bool IsLegacy => LTBRID != null || ETSID != null;
+
         #endregion
 
         #region Navigation Properties

--- a/ntbs-service/Models/Entities/PatientDetails.cs
+++ b/ntbs-service/Models/Entities/PatientDetails.cs
@@ -49,8 +49,10 @@ namespace ntbs_service.Models.Entities
             ErrorMessage = ValidationMessages.StringWithNumbersAndForwardSlashFormat)]
         public string Address { get; set; }
 
+        [Display(Name = "Postcode")]
         [RequiredIf(@"ShouldValidateFull && !NoFixedAbode", ErrorMessage = ValidationMessages.FieldRequired)]
-        [AssertThat(@"PostcodeToLookup != null", ErrorMessage = ValidationMessages.PostcodeIsNotValid)]
+        [RegularExpression(ValidationRegexes.PostcodeValidation, ErrorMessage = ValidationMessages.NotValid)]
+        [AssertThat(@"PostcodeToLookup != null || IsLegacy == true", ErrorMessage = ValidationMessages.PostcodeNotFound)]
         public string Postcode { get; set; }
 
         public string PostcodeToLookup { get; set; }

--- a/ntbs-service/Models/Entities/SocialContextBase.cs
+++ b/ntbs-service/Models/Entities/SocialContextBase.cs
@@ -23,7 +23,7 @@ namespace ntbs_service.Models.Entities
         public string Address { get; set; }
 
         [RequiredIf("PostcodeIsRequired", ErrorMessage =  ValidationMessages.RequiredEnter)]
-        [RegularExpression(ValidationRegexes.PostcodeValidation, ErrorMessage = ValidationMessages.PostcodeIsNotValid)]
+        [RegularExpression(ValidationRegexes.PostcodeValidation, ErrorMessage = ValidationMessages.NotValid)]
         [Display(Name = "Postcode")]
         public string Postcode { get; set; }
 

--- a/ntbs-service/Models/Entities/TreatmentEvent.cs
+++ b/ntbs-service/Models/Entities/TreatmentEvent.cs
@@ -15,7 +15,7 @@ namespace ntbs_service.Models.Entities
 
         [Display(Name = "Event Date")]
         [Required(ErrorMessage = ValidationMessages.RequiredEnter)]
-        [ValidDateRange(ValidDates.EarliestClinicalDate)]
+        [ValidClinicalDate]
         [AssertThat(@"EventDateAfterDob", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         [AssertThat(@"EventDateAfterNotificationDate", ErrorMessage = ValidationMessages.DateShouldBeLaterThanNotification)]
         public DateTime? EventDate { get; set; }

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -29,6 +29,7 @@
         public const string Mandatory = "{0} is a mandatory field";
         public const string RequiredEnter = "Please enter {0}";
         public const string RequiredSelect = "Please select {0}";
+        public const string NotValid = "{0} is not valid";
         public const string DateShouldBeLaterThanDob = "{0} must be later than date of birth"; 
         public const string DateShouldBeLaterThanNotification = "{0} must be after the date of notification";
 
@@ -38,7 +39,7 @@
         public const string NhsNumberLength = "{0} needs to be 10 digits long";
         public const string InvalidNhsNumber = "This {0} is not valid. Confirm you have entered it correctly";
         public const string FieldRequired = "{0} is a mandatory field";
-        public const string PostcodeIsNotValid = "Postcode is not valid";
+        public const string PostcodeNotFound = "{0} is not found";
         public const string YearOfUkEntryMustBeAfterDob = "Year of entry to the UK must be after patient's date of birth";
         public const string YearOfUkEntryMustNotBeInFuture = "Year of entry to the UK must be no later than this year";
         #endregion

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -263,9 +263,10 @@ namespace ntbs_service.Pages.Notifications.Edit
             }
         }
 
-        public ContentResult OnGetValidateClinicalDetailsDate(string key, string day, string month, string year)
+        public async Task<ContentResult> OnGetValidateClinicalDetailsDate(string key, string day, string month, string year)
         {
-            return ValidationService.GetDateValidationResult<ClinicalDetails>(key, day, month, year);
+            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<ClinicalDetails>(key, day, month, year, notification.IsLegacy);
         }
 
         public ContentResult OnGetValidateNotificationSites(IEnumerable<string> valueList, bool shouldValidateFull)

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -140,8 +140,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             // Add additional field required for date validation
             ClinicalDetails.Dob = Notification.PatientDetails.Dob;
 
-            ClinicalDetails.SetFullValidation(Notification.NotificationStatus);
-            OtherSite?.SetFullValidation(Notification.NotificationStatus);
+            ClinicalDetails.SetValidationContext(Notification);
+            OtherSite?.SetValidationContext(Notification);
 
             // Since notification has other properties which are not populated by this page but have validation rules, 
             // validation of a whole Notification model will result in validation errors.

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -265,8 +265,8 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         public async Task<ContentResult> OnGetValidateClinicalDetailsDate(string key, string day, string month, string year)
         {
-            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-            return ValidationService.GetDateValidationResult<ClinicalDetails>(key, day, month, year, notification.IsLegacy);
+            var isLegacy = await NotificationRepository.IsNotificationLegacyAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<ClinicalDetails>(key, day, month, year, isLegacy);
         }
 
         public ContentResult OnGetValidateNotificationSites(IEnumerable<string> valueList, bool shouldValidateFull)

--- a/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
@@ -68,7 +68,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         protected override async Task ValidateAndSave()
         {
-            ComorbidityDetails.SetFullValidation(Notification.NotificationStatus);
+            ComorbidityDetails.SetValidationContext(Notification);
 
             ImmunosuppressionDetails = new ImmunosuppressionDetails {
                 Status = ImmunosuppressionStatus,
@@ -78,7 +78,7 @@ namespace ntbs_service.Pages.Notifications.Edit
                 OtherDescription = OtherDescription,
             };
 
-            ImmunosuppressionDetails.SetFullValidation(Notification.NotificationStatus);
+            ImmunosuppressionDetails.SetValidationContext(Notification);
 
             if (TryValidateModel(ComorbidityDetails, nameof(ComorbidityDetails))
                 && TryValidateModel(ImmunosuppressionDetails, nameof(ImmunosuppressionDetails)))

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         protected override async Task ValidateAndSave()
         {
-            ContactTracing.SetFullValidation(Notification.NotificationStatus);
+            ContactTracing.SetValidationContext(Notification);
             if (TryValidateModel(ContactTracing, ContactTracing.GetType().Name))
             {
                 await Service.UpdateContactTracingAsync(Notification, ContactTracing);

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
@@ -136,7 +136,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         private async Task SetValuesForValidation()
         {
-            Episode.SetFullValidation(Notification.NotificationStatus);
+            Episode.SetValidationContext(Notification);
             ValidationService.TrySetFormattedDate(Notification, "Notification", nameof(Notification.NotificationDate), FormattedNotificationDate);
             /*
             Binding only sets the entity ids, but not the actual entities.

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -154,8 +154,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
 
         public async Task<ContentResult> OnGetValidateTestResultForEditDateAsync(string key, string day, string month, string year)
         {
-            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-            return ValidationService.GetDateValidationResult<ManualTestResult>(key, day, month, year, notification.IsLegacy);
+            var isLegacy = await NotificationRepository.IsNotificationLegacyAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<ManualTestResult>(key, day, month, year, isLegacy);
         }
 
         public async Task<JsonResult> OnGetFilteredSampleTypesForManualTestType(int value)

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -60,9 +60,10 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
 
         protected override async Task ValidateAndSave()
         {
+            TestResultForEdit.SetValidationContext(Notification);
             TestResultForEdit.NotificationId = NotificationId;
             TestResultForEdit.Dob = Notification.PatientDetails.Dob;
-            await SetRelatedEntities();
+            await SetRelatedEntitiesAsync();
             SetDate();
 
             if (TryValidateModel(TestResultForEdit, "TestResultForEdit"))
@@ -128,7 +129,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             return await NotificationRepository.GetNotificationWithTestsAsync(notificationId);
         }
 
-        private async Task SetRelatedEntities()
+        private async Task SetRelatedEntitiesAsync()
         {
             if (TestResultForEdit.ManualTestTypeId != null)
             {
@@ -151,9 +152,10 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
                 FormattedTestDate);
         }
 
-        public ContentResult OnGetValidateTestResultForEditDate(string key, string day, string month, string year)
+        public async Task<ContentResult> OnGetValidateTestResultForEditDateAsync(string key, string day, string month, string year)
         {
-            return ValidationService.GetDateValidationResult<ManualTestResult>(key, day, month, year);
+            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<ManualTestResult>(key, day, month, year, notification.IsLegacy);
         }
 
         public async Task<JsonResult> OnGetFilteredSampleTypesForManualTestType(int value)

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
@@ -95,8 +95,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
 
         public async Task<ContentResult> OnGetValidateSocialContextDate(string key, string day, string month, string year)
         {
-            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-            return ValidationService.GetDateValidationResult<T>(key, day, month, year, notification.IsLegacy);
+            var isLegacy = await NotificationRepository.IsNotificationLegacyAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<T>(key, day, month, year, isLegacy);
         }
 
         public ContentResult OnGetValidateSocialContextDates(IEnumerable<Dictionary<string, string>> keyValuePairs)

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
@@ -93,9 +93,10 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             return ValidationService.GetPropertyValidationResult<SocialContextVenue>(key, value, shouldValidateFull);
         }
 
-        public ContentResult OnGetValidateSocialContextDate(string key, string day, string month, string year)
+        public async Task<ContentResult> OnGetValidateSocialContextDate(string key, string day, string month, string year)
         {
-            return ValidationService.GetDateValidationResult<T>(key, day, month, year);
+            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<T>(key, day, month, year, notification.IsLegacy);
         }
 
         public ContentResult OnGetValidateSocialContextDates(IEnumerable<Dictionary<string, string>> keyValuePairs)

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
@@ -44,7 +44,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             model.NotificationId = NotificationId;
             model.Dob = Notification.PatientDetails.Dob;
             SetDates(model, modelName);
-            model.SetFullValidation(Notification.NotificationStatus);
+            model.SetValidationContext(Notification);
 
             if (TryValidateModel(model, modelName))
             {

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -189,8 +189,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
 
         public async Task<ContentResult> OnGetValidateTreatmentEventDate(string key, string day, string month, string year)
         {
-            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-            return ValidationService.GetDateValidationResult<TreatmentEvent>(key, day, month, year, notification.IsLegacy);
+            var isLegacy = await NotificationRepository.IsNotificationLegacyAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<TreatmentEvent>(key, day, month, year, isLegacy);
         }
 
         public ContentResult OnGetValidateSelectedTreatmentOutcomeTypeProperty(string key, TreatmentOutcomeType? value)

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -187,9 +187,10 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             return ValidationService.GetPropertyValidationResult<TreatmentEvent>(key, value, true);
         }
 
-        public ContentResult OnGetValidateTreatmentEventDate(string key, string day, string month, string year)
+        public async Task<ContentResult> OnGetValidateTreatmentEventDate(string key, string day, string month, string year)
         {
-            return ValidationService.GetDateValidationResult<TreatmentEvent>(key, day, month, year);
+            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<TreatmentEvent>(key, day, month, year, notification.IsLegacy);
         }
 
         public ContentResult OnGetValidateSelectedTreatmentOutcomeTypeProperty(string key, TreatmentOutcomeType? value)

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -55,7 +55,7 @@ namespace ntbs_service.Pages.Notifications.Edit
         {
             UpdateFlags();
             await ValidateRelatedNotification();
-            MDRDetails.SetFullValidation(Notification.NotificationStatus);
+            MDRDetails.SetValidationContext(Notification);
 
             if (TryValidateModel(MDRDetails.GetType().Name))
             {

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -168,9 +168,10 @@ namespace ntbs_service.Pages.Notifications.Edit
             return ValidationService.GetPropertyValidationResult<PatientDetails>(key, value, shouldValidateFull);
         }
 
-        public ContentResult OnGetValidatePatientDetailsDate(string key, string day, string month, string year)
+        public async Task<ContentResult> OnGetValidatePatientDetailsDate(string key, string day, string month, string year)
         {
-            return ValidationService.GetDateValidationResult<PatientDetails>(key, day, month, year);
+            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<PatientDetails>(key, day, month, year, notification.IsLegacy);
         }
 
         public async Task<JsonResult> OnGetNhsNumberDuplicates(int notificationId, string nhsNumber)

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -170,8 +170,8 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         public async Task<ContentResult> OnGetValidatePatientDetailsDate(string key, string day, string month, string year)
         {
-            var notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-            return ValidationService.GetDateValidationResult<PatientDetails>(key, day, month, year, notification.IsLegacy);
+            var isLegacy = await NotificationRepository.IsNotificationLegacyAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<PatientDetails>(key, day, month, year, isLegacy);
         }
 
         public async Task<JsonResult> OnGetNhsNumberDuplicates(int notificationId, string nhsNumber)

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
@@ -46,7 +46,7 @@ namespace ntbs_service.Pages.Notifications.Edit
         protected override async Task ValidateAndSave()
         {
             UpdateFlags();
-            PatientTbHistory.SetFullValidation(Notification.NotificationStatus);
+            PatientTbHistory.SetValidationContext(Notification);
 
             if (TryValidateModel(PatientTbHistory.GetType().Name))
             {

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
@@ -28,7 +28,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         protected override async Task ValidateAndSave()
         {
-            SocialRiskFactors.SetFullValidation(Notification.NotificationStatus);
+            SocialRiskFactors.SetValidationContext(Notification);
             if (TryValidateModel(SocialRiskFactors))
             {
                 await Service.UpdateSocialRiskFactorsAsync(Notification, SocialRiskFactors);

--- a/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
@@ -60,7 +60,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             // Set the collection so it can be included in the validation
             TestData.ManualTestResults = Notification.TestData.ManualTestResults;
             TestData.ProceedingToAdd = ActionName == "Create";
-            TestData.SetFullValidation(Notification.NotificationStatus);
+            TestData.SetValidationContext(Notification);
             if (TryValidateModel(TestData, nameof(TestData)))
             {
                 await Service.UpdateTestDataAsync(Notification, TestData);

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
@@ -52,8 +52,8 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         protected override async Task ValidateAndSave()
         {
-            TravelDetails.SetFullValidation(Notification.NotificationStatus);
-            VisitorDetails.SetFullValidation(Notification.NotificationStatus);
+            TravelDetails.SetValidationContext(Notification);
+            VisitorDetails.SetValidationContext(Notification);
 
             CleanModel();
 

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -134,10 +134,10 @@ namespace ntbs_service.Pages.Notifications
             return RedirectToPage("/Notifications/Overview", new { NotificationId });
         }
 
-        protected async Task SetNotificationProperties<T>(bool isBeingSubmitted, T ownedModel) where T : ModelBase
+        protected async Task SetNotificationProperties<T>(bool isBeingSubmitted, T subModel) where T : ModelBase
         {
             await SetNotificationProperties(isBeingSubmitted);
-            ownedModel.SetValidationContext(Notification, isBeingSubmitted);
+            subModel.SetValidationContext(Notification, isBeingSubmitted);
         }
 
         protected async Task SetNotificationProperties(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -137,18 +137,18 @@ namespace ntbs_service.Pages.Notifications
         protected async Task SetNotificationProperties<T>(bool isBeingSubmitted, T ownedModel) where T : ModelBase
         {
             await SetNotificationProperties(isBeingSubmitted);
-            ownedModel.ShouldValidateFull = Notification.ShouldValidateFull;
+            ownedModel.SetValidationContext(Notification, isBeingSubmitted);
         }
 
         protected async Task SetNotificationProperties(bool isBeingSubmitted)
         {
-            Notification.SetFullValidation(Notification.NotificationStatus, isBeingSubmitted);
+            Notification.SetValidationContext(Notification, isBeingSubmitted);
             await GetLinkedNotifications();
         }
 
         private async Task<bool> TryValidateAndSave()
         {
-            Notification.SetFullValidation(Notification.NotificationStatus);
+            Notification.SetValidationContext(Notification);
             await ValidateAndSave();
             return ModelState.IsValid;
         }
@@ -163,19 +163,6 @@ namespace ntbs_service.Pages.Notifications
             var foundPostcode = await postcodeService.FindPostcode(model.Postcode);
             model.PostcodeToLookup = foundPostcode?.Postcode;
         }
-
-        public async Task<ContentResult> OnGetValidatePostcode<T>(IPostcodeService postcodeService, string postcode, bool shouldValidateFull) where T : ModelBase, IHasPostcode
-        {
-            var foundPostcode = await postcodeService.FindPostcode(postcode);
-            var propertyValueTuples = new List<(string, object)>
-            {
-                ("PostcodeToLookup", foundPostcode?.Postcode),
-                ("Postcode", postcode)
-            };
-
-            return ValidationService.GetMultiplePropertiesValidationResult<T>(propertyValueTuples, shouldValidateFull);
-        }
-
 
         protected ContentResult CreateJsonResponse(object content)
         {

--- a/ntbs-service/Services/ValidationService.cs
+++ b/ntbs-service/Services/ValidationService.cs
@@ -87,15 +87,17 @@ namespace ntbs_service.Services
             property.SetValue(model, value);
         }
 
-        public ContentResult GetDateValidationResult<T>(string key, string day, string month, string year)
+        public ContentResult GetDateValidationResult<T>(string key, string day, string month, string year,
+            bool isLegacy) where T : ModelBase
         {
             T model = (T)Activator.CreateInstance(typeof(T));
-            return GetDateValidationResult<T>(model, key, day, month, year);
+            model.IsLegacy = isLegacy;
+            return GetDateValidationResult(model, key, day, month, year);
         }
 
         public ContentResult GetDateValidationResult<T>(T model, string key, string day, string month, string year)
         {
-            var formattedDate = new FormattedDate() { Day = day, Month = month, Year = year };
+            var formattedDate = new FormattedDate { Day = day, Month = month, Year = year };
             var modelType = model.GetType();
             if (formattedDate.TryConvertToDateTime(out DateTime? convertedDob))
             {

--- a/ntbs-service/Services/ValidationService.cs
+++ b/ntbs-service/Services/ValidationService.cs
@@ -40,11 +40,13 @@ namespace ntbs_service.Services
 
         public ContentResult GetMultiplePropertiesValidationResult<T>(
             IEnumerable<(string, object)> propertyValueTuples,
-            bool shouldValidateFull = false)
+            bool shouldValidateFull = false,
+            bool isLegacy = false)
             where T : ModelBase
         {
             T model = (T)Activator.CreateInstance(typeof(T));
             model.ShouldValidateFull = shouldValidateFull;
+            model.IsLegacy = isLegacy;
 
             var keys = new List<string>();
             foreach (var tuple in propertyValueTuples)


### PR DESCRIPTION
Make dates older than 2010 valid for legacy notifications.
Relax Legacy notifications' postcode validation to regex only, instead of enforcing a match with current list.
Dynamic validation included for both.
