### PR TITLE
NTBS-857 relax travel validation

### DIFF
--- a/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
@@ -44,5 +44,19 @@ namespace ntbs_service_unit_tests.Models.Entities
             Assert.False(isValid, "Expected details to be invalid");
             Assert.Equal(ValidationMessages.TravelOrVisitTotalNumberOfCountriesRequired, validationResults.First().ErrorMessage);
         }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void ProvidingTotalNumberOfCountriesAlon_IsValid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.TotalNumberOfCountries = 3;
+    
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.True(isValid, "Expected details to be valid");
+        }
     }
 }

--- a/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using ntbs_service.Models.Entities;
+using ntbs_service.Models.Validations;
 using Xunit;
 
 namespace ntbs_service_unit_tests.Models.Entities
@@ -20,12 +22,27 @@ namespace ntbs_service_unit_tests.Models.Entities
         {
             // Arrange
             var validationResults = new List<ValidationResult>();
-            
+
             // Act
-            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true); 
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
 
             // Assert
             Assert.True(isValid, "Expected details to be valid");
+        }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void ProvidingCountry_ButNotTotalNumberOfCountries_IsInvalid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.Country1Id = 1;
+
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.False(isValid, "Expected details to be invalid");
+            Assert.Equal(ValidationMessages.TravelOrVisitTotalNumberOfCountriesRequired, validationResults.First().ErrorMessage);
         }
     }
 }

--- a/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
@@ -75,5 +75,25 @@ namespace ntbs_service_unit_tests.Models.Entities
             // Assert
             Assert.True(isValid, "Expected details to be valid");
         }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void ProvidingDurationsWithoutCountries_IsNotValid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.TotalNumberOfCountries = 3;
+            details.StayLengthInMonths1 = 1;
+            details.StayLengthInMonths2 = 2;
+            details.StayLengthInMonths3 = 3;
+    
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.False(isValid, "Expected details to be invalid");
+            Assert.Equal(3, validationResults.Count);
+            validationResults.ForEach(result =>
+                Assert.Equal(ValidationMessages.TravelOrVisitDurationHasCountry, result.ErrorMessage));
+        }
     }
 }

--- a/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using ntbs_service.Models.Entities;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Models.Entities
+{
+    public class TravelAndVisitorDetailsTest
+    {
+        public static IEnumerable<object[]> BaseDetails()
+        {
+            yield return new object[] {new TravelDetails {ShouldValidateFull = false, HasTravel = true}};
+            yield return new object[] {new TravelDetails {ShouldValidateFull = true, HasTravel = true}};
+            yield return new object[] {new VisitorDetails {ShouldValidateFull = false, HasVisitor = true}};
+            yield return new object[] {new VisitorDetails {ShouldValidateFull = true, HasVisitor = true}};
+        }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void SelectingYes_AndLeavingRestBlank_IsValidInDraftAndFullModes(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true); 
+
+            // Assert
+            Assert.True(isValid, "Expected details to be valid");
+        }
+    }
+}

--- a/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
@@ -58,5 +58,22 @@ namespace ntbs_service_unit_tests.Models.Entities
             // Assert
             Assert.True(isValid, "Expected details to be valid");
         }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void ProvidingCountriesWithoutDurations_IsValid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.TotalNumberOfCountries = 3;
+            details.Country1Id = 1;
+            details.Country2Id = 2;
+            details.Country3Id = 3;
+    
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.True(isValid, "Expected details to be valid");
+        }
     }
 }

--- a/ntbs-service/Models/Entities/TravelDetails.cs
+++ b/ntbs-service/Models/Entities/TravelDetails.cs
@@ -46,8 +46,6 @@ namespace ntbs_service.Models.Entities
 
         public Country Country2 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country2Id != null",
-            ErrorMessage = ValidationMessages.TravelCountryRequiresDuration)]
         [AssertThat("!ShouldValidateFull || Country2Id != null",
             ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
@@ -67,8 +65,6 @@ namespace ntbs_service.Models.Entities
 
         public Country Country3 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country3Id != null",
-            ErrorMessage = ValidationMessages.TravelCountryRequiresDuration)]
         [AssertThat("!ShouldValidateFull || Country3Id != null",
             ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]

--- a/ntbs-service/Models/Entities/TravelDetails.cs
+++ b/ntbs-service/Models/Entities/TravelDetails.cs
@@ -16,7 +16,6 @@ namespace ntbs_service.Models.Entities
 
         public bool? HasTravel { get; set; }
 
-        [RequiredIf("ShouldValidateFull && HasTravel == true", ErrorMessage = ValidationMessages.TravelOrVisitTotalNumberOfCountriesRequired)]
         [Range(1, 50)]
         [AssertThat("TotalNumberGreaterOrEqualToInputCountries == true", ErrorMessage = ValidationMessages.TotalNumberOfCountriesTravelledToGreaterThanInputNumber)]
         [Display(Name = "total number of countries")]
@@ -24,12 +23,10 @@ namespace ntbs_service.Models.Entities
 
 
         // First country block
-        [RequiredIf("ShouldValidateFull && HasTravel == true", ErrorMessage = ValidationMessages.TravelMostRecentCountryRequired)]
         public int? Country1Id { get; set; }
 
         public virtual Country Country1 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && HasTravel == true", ErrorMessage = ValidationMessages.TravelCountryRequiresDuration)]
         [Range(1, MaxTotalLengthOfStay)]
         [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
         [Display(Name = "duration of travel")]

--- a/ntbs-service/Models/Entities/TravelDetails.cs
+++ b/ntbs-service/Models/Entities/TravelDetails.cs
@@ -31,6 +31,7 @@ namespace ntbs_service.Models.Entities
         public virtual Country Country1 { get; set; }
 
         [Range(1, MaxTotalLengthOfStay)]
+        [AssertThat("Country1Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
         [Display(Name = "duration of travel")]
         public int? StayLengthInMonths1 { get; set; }
@@ -46,9 +47,8 @@ namespace ntbs_service.Models.Entities
 
         public Country Country2 { get; set; }
 
-        [AssertThat("!ShouldValidateFull || Country2Id != null",
-            ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
+        [AssertThat("Country2Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
         [Display(Name = "duration of travel")]
         public int? StayLengthInMonths2 { get; set; }
@@ -65,9 +65,8 @@ namespace ntbs_service.Models.Entities
 
         public Country Country3 { get; set; }
 
-        [AssertThat("!ShouldValidateFull || Country3Id != null",
-            ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
+        [AssertThat("Country3Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
         [Display(Name = "duration of travel")]
         public int? StayLengthInMonths3 { get; set; }

--- a/ntbs-service/Models/Entities/TravelDetails.cs
+++ b/ntbs-service/Models/Entities/TravelDetails.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 using EFAuditer;
 using ExpressiveAnnotations.Attributes;
 using Microsoft.EntityFrameworkCore;
@@ -17,69 +16,88 @@ namespace ntbs_service.Models.Entities
         public bool? HasTravel { get; set; }
 
         [Range(1, 50)]
-        [AssertThat("TotalNumberGreaterOrEqualToInputCountries == true", ErrorMessage = ValidationMessages.TotalNumberOfCountriesTravelledToGreaterThanInputNumber)]
+        [RequiredIf(nameof(AnyCountrySupplied),
+            ErrorMessage = ValidationMessages.TravelOrVisitTotalNumberOfCountriesRequired)]
+        [AssertThat(nameof(TotalNumberGreaterOrEqualToInputCountries),
+            ErrorMessage = ValidationMessages.TotalNumberOfCountriesTravelledToGreaterThanInputNumber)]
         [Display(Name = "total number of countries")]
         public int? TotalNumberOfCountries { get; set; }
 
 
-        // First country block
+        #region First country
+
         public int? Country1Id { get; set; }
 
         public virtual Country Country1 { get; set; }
 
         [Range(1, MaxTotalLengthOfStay)]
-        [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
+        [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
         [Display(Name = "duration of travel")]
         public int? StayLengthInMonths1 { get; set; }
 
+        #endregion
 
-        // Second country block
-        [AssertThat("!ShouldValidateFull || Country1Id != null", ErrorMessage = ValidationMessages.TravelIsChronological)]
+        #region Second country
+
+        [AssertThat("!ShouldValidateFull || Country1Id != null",
+            ErrorMessage = ValidationMessages.TravelIsChronological)]
         [AssertThat("Country2Id != Country1Id", ErrorMessage = ValidationMessages.TravelUniqueCountry)]
         public int? Country2Id { get; set; }
 
         public Country Country2 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country2Id != null", ErrorMessage = ValidationMessages.TravelCountryRequiresDuration)]
-        [AssertThat("!ShouldValidateFull || Country2Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
+        [RequiredIf("ShouldValidateFull && Country2Id != null",
+            ErrorMessage = ValidationMessages.TravelCountryRequiresDuration)]
+        [AssertThat("!ShouldValidateFull || Country2Id != null",
+            ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
-        [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
+        [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
         [Display(Name = "duration of travel")]
         public int? StayLengthInMonths2 { get; set; }
 
+        #endregion
 
-        // Third country block
-        [AssertThat("!ShouldValidateFull || Country2Id != null", ErrorMessage = ValidationMessages.TravelIsChronological)]
-        [AssertThat("Country3Id != Country1Id && Country3Id != Country2Id", ErrorMessage = ValidationMessages.TravelUniqueCountry)]
+        #region Third country
+
+        [AssertThat("!ShouldValidateFull || Country2Id != null",
+            ErrorMessage = ValidationMessages.TravelIsChronological)]
+        [AssertThat("Country3Id != Country1Id && Country3Id != Country2Id",
+            ErrorMessage = ValidationMessages.TravelUniqueCountry)]
         public int? Country3Id { get; set; }
 
         public Country Country3 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country3Id != null", ErrorMessage = ValidationMessages.TravelCountryRequiresDuration)]
-        [AssertThat("!ShouldValidateFull || Country3Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
+        [RequiredIf("ShouldValidateFull && Country3Id != null",
+            ErrorMessage = ValidationMessages.TravelCountryRequiresDuration)]
+        [AssertThat("!ShouldValidateFull || Country3Id != null",
+            ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
-        [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
+        [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.TravelTotalDurationWithinLimit)]
         [Display(Name = "duration of travel")]
         public int? StayLengthInMonths3 { get; set; }
 
+        #endregion
 
-        // Helper properties for use in expressive annotations
-        [NotMapped]
+        #region Helper properties for use in expressive annotations
+
+        // ReSharper disable MemberCanBePrivate.Global
+        public bool AnyCountrySupplied => Country1Id.HasValue || Country2Id.HasValue || Country3Id.HasValue;
+
         public bool TotalNumberGreaterOrEqualToInputCountries =>
             TotalNumberOfCountries >=
             Convert.ToInt32(Country1Id.HasValue) +
             Convert.ToInt32(Country2Id.HasValue) +
             Convert.ToInt32(Country3Id.HasValue);
 
-        [NotMapped]
         public bool TotalLengthWithinLimit =>
             MaxTotalLengthOfStay >= TotalDurationOfTravel;
 
-        [NotMapped]
-        public int TotalDurationOfTravel => 
+        public int TotalDurationOfTravel =>
             Convert.ToInt32(StayLengthInMonths1) +
             Convert.ToInt32(StayLengthInMonths2) +
             Convert.ToInt32(StayLengthInMonths3);
+
+        #endregion
 
         string IOwnedEntity.RootEntityType => RootEntities.Notification;
     }

--- a/ntbs-service/Models/Entities/VisitorDetails.cs
+++ b/ntbs-service/Models/Entities/VisitorDetails.cs
@@ -31,6 +31,7 @@ namespace ntbs_service.Models.Entities
         public virtual Country Country1 { get; set; }
 
         [Range(1, MaxTotalLengthOfStay)]
+        [AssertThat("Country1Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
         [Display(Name = "duration of visit")]
         public int? StayLengthInMonths1 { get; set; }
@@ -46,9 +47,8 @@ namespace ntbs_service.Models.Entities
 
         public Country Country2 { get; set; }
 
-        [AssertThat("!ShouldValidateFull || Country2Id != null",
-            ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
+        [AssertThat("Country2Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
         [Display(Name = "duration of visit")]
         public int? StayLengthInMonths2 { get; set; }
@@ -65,9 +65,8 @@ namespace ntbs_service.Models.Entities
 
         public Country Country3 { get; set; }
 
-        [AssertThat("!ShouldValidateFull || Country3Id != null",
-            ErrorMessage = ValidationMessages.VisitIsChronological)]
         [Range(1, MaxTotalLengthOfStay)]
+        [AssertThat("Country3Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
         [Display(Name = "duration of visit")]
         public int? StayLengthInMonths3 { get; set; }

--- a/ntbs-service/Models/Entities/VisitorDetails.cs
+++ b/ntbs-service/Models/Entities/VisitorDetails.cs
@@ -46,8 +46,6 @@ namespace ntbs_service.Models.Entities
 
         public Country Country2 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country2Id != null",
-            ErrorMessage = ValidationMessages.VisitCountryRequiresDuration)]
         [AssertThat("!ShouldValidateFull || Country2Id != null",
             ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
@@ -67,8 +65,6 @@ namespace ntbs_service.Models.Entities
 
         public Country Country3 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country3Id != null",
-            ErrorMessage = ValidationMessages.VisitCountryRequiresDuration)]
         [AssertThat("!ShouldValidateFull || Country3Id != null",
             ErrorMessage = ValidationMessages.VisitIsChronological)]
         [Range(1, MaxTotalLengthOfStay)]

--- a/ntbs-service/Models/Entities/VisitorDetails.cs
+++ b/ntbs-service/Models/Entities/VisitorDetails.cs
@@ -16,68 +16,88 @@ namespace ntbs_service.Models.Entities
         public bool? HasVisitor { get; set; }
 
         [Range(1, 50)]
-        [AssertThat("TotalNumberGreaterOrEqualToInputCountries == true", ErrorMessage = ValidationMessages.TotalNumberOfCountriesVisitedFromGreaterThanInputNumber)]
+        [RequiredIf(nameof(AnyCountrySupplied),
+            ErrorMessage = ValidationMessages.TravelOrVisitTotalNumberOfCountriesRequired)]
+        [AssertThat(nameof(TotalNumberGreaterOrEqualToInputCountries),
+            ErrorMessage = ValidationMessages.TotalNumberOfCountriesVisitedFromGreaterThanInputNumber)]
         [Display(Name = "total number of countries")]
         public int? TotalNumberOfCountries { get; set; }
 
 
-        // First country block
+        #region First country
+
         public int? Country1Id { get; set; }
 
         public virtual Country Country1 { get; set; }
 
         [Range(1, MaxTotalLengthOfStay)]
-        [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
+        [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
         [Display(Name = "duration of visit")]
         public int? StayLengthInMonths1 { get; set; }
 
+        #endregion
 
-        // Second country block
-        [AssertThat("!ShouldValidateFull || Country1Id != null", ErrorMessage = ValidationMessages.VisitIsChronological)]
+        #region Second country
+
+        [AssertThat("!ShouldValidateFull || Country1Id != null",
+            ErrorMessage = ValidationMessages.VisitIsChronological)]
         [AssertThat("Country2Id != Country1Id", ErrorMessage = ValidationMessages.VisitUniqueCountry)]
         public int? Country2Id { get; set; }
 
         public Country Country2 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country2Id != null", ErrorMessage = ValidationMessages.VisitCountryRequiresDuration)]
-        [AssertThat("!ShouldValidateFull || Country2Id != null", ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
+        [RequiredIf("ShouldValidateFull && Country2Id != null",
+            ErrorMessage = ValidationMessages.VisitCountryRequiresDuration)]
+        [AssertThat("!ShouldValidateFull || Country2Id != null",
+            ErrorMessage = ValidationMessages.TravelOrVisitDurationHasCountry)]
         [Range(1, MaxTotalLengthOfStay)]
-        [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
+        [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
         [Display(Name = "duration of visit")]
         public int? StayLengthInMonths2 { get; set; }
 
+        #endregion
 
-        // Third country block
-        [AssertThat("!ShouldValidateFull || Country2Id != null", ErrorMessage = ValidationMessages.VisitIsChronological)]
-        [AssertThat("Country3Id != Country1Id && Country3Id != Country2Id", ErrorMessage = ValidationMessages.VisitUniqueCountry)]
+        #region Third country
+
+        [AssertThat("!ShouldValidateFull || Country2Id != null",
+            ErrorMessage = ValidationMessages.VisitIsChronological)]
+        [AssertThat("Country3Id != Country1Id && Country3Id != Country2Id",
+            ErrorMessage = ValidationMessages.VisitUniqueCountry)]
         public int? Country3Id { get; set; }
 
         public Country Country3 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && Country3Id != null", ErrorMessage = ValidationMessages.VisitCountryRequiresDuration)]
-        [AssertThat("!ShouldValidateFull || Country3Id != null", ErrorMessage = ValidationMessages.VisitIsChronological)]
+        [RequiredIf("ShouldValidateFull && Country3Id != null",
+            ErrorMessage = ValidationMessages.VisitCountryRequiresDuration)]
+        [AssertThat("!ShouldValidateFull || Country3Id != null",
+            ErrorMessage = ValidationMessages.VisitIsChronological)]
         [Range(1, MaxTotalLengthOfStay)]
-        [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
+        [AssertThat(nameof(TotalLengthWithinLimit), ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
         [Display(Name = "duration of visit")]
         public int? StayLengthInMonths3 { get; set; }
 
-        // Helper properties for use in expressive annotations
-        [NotMapped]
+        #endregion
+
+        #region Helper properties for use in expressive annotations
+
+        // ReSharper disable MemberCanBePrivate.Global
+        public bool AnyCountrySupplied => Country1Id.HasValue || Country2Id.HasValue || Country3Id.HasValue;
+
         public bool TotalNumberGreaterOrEqualToInputCountries =>
             TotalNumberOfCountries >=
-                Convert.ToInt32(Country1Id.HasValue) +
-                Convert.ToInt32(Country2Id.HasValue) +
-                Convert.ToInt32(Country3Id.HasValue);
+            Convert.ToInt32(Country1Id.HasValue) +
+            Convert.ToInt32(Country2Id.HasValue) +
+            Convert.ToInt32(Country3Id.HasValue);
 
-        [NotMapped]
         public bool TotalLengthWithinLimit =>
             MaxTotalLengthOfStay >= TotalDurationOfVisit;
 
-        [NotMapped]
         public int TotalDurationOfVisit =>
             Convert.ToInt32(StayLengthInMonths1) +
             Convert.ToInt32(StayLengthInMonths2) +
             Convert.ToInt32(StayLengthInMonths3);
+
+        #endregion
 
         string IOwnedEntity.RootEntityType => RootEntities.Notification;
     }

--- a/ntbs-service/Models/Entities/VisitorDetails.cs
+++ b/ntbs-service/Models/Entities/VisitorDetails.cs
@@ -15,7 +15,6 @@ namespace ntbs_service.Models.Entities
 
         public bool? HasVisitor { get; set; }
 
-        [RequiredIf("ShouldValidateFull && HasVisitor == true", ErrorMessage = ValidationMessages.TravelOrVisitTotalNumberOfCountriesRequired)]
         [Range(1, 50)]
         [AssertThat("TotalNumberGreaterOrEqualToInputCountries == true", ErrorMessage = ValidationMessages.TotalNumberOfCountriesVisitedFromGreaterThanInputNumber)]
         [Display(Name = "total number of countries")]
@@ -23,12 +22,10 @@ namespace ntbs_service.Models.Entities
 
 
         // First country block
-        [RequiredIf("ShouldValidateFull && HasVisitor == true", ErrorMessage = ValidationMessages.VisitMostRecentCountryRequired)]
         public int? Country1Id { get; set; }
 
         public virtual Country Country1 { get; set; }
 
-        [RequiredIf("ShouldValidateFull && HasVisitor == true", ErrorMessage = ValidationMessages.VisitCountryRequiresDuration)]
         [Range(1, MaxTotalLengthOfStay)]
         [AssertThat("TotalLengthWithinLimit == true", ErrorMessage = ValidationMessages.VisitTotalDurationWithinLimit)]
         [Display(Name = "duration of visit")]

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -25,7 +25,6 @@
         public const string YearIfMonthRequired = "Year and month must be provided if a day has been provided";
         public const string YearRequired = "A year must be provided";
         public const string SupplyAParameter = "Please supply at least one of these fields";
-        public const string ValidYearRange = "Year must be provided between {1} and {2}";
         public const string Mandatory = "{0} is a mandatory field";
         public const string RequiredEnter = "Please enter {0}";
         public const string RequiredSelect = "Please select {0}";
@@ -44,18 +43,16 @@
         #endregion
 
         #region Clinical Details
-        public const string RiskFactorSelection = "At least one field should be selected";
+
         public const string DiseaseSiteIsRequired = "Please choose at least one site of disease";
         public const string ValidTreatmentOptions = "Short course and MDR treatment cannot both be true";
-        public const string ShortTreatmentIsRequired = "Short course treatment cannot be Yes if MDR treatment is Yes";
-        public const string MDRIsRequired = "MDR treatment cannot be Yes if Short course treatment is Yes";
         public const string MDRCantChange = "You cannot change the value of this field because an MDR Enhanced Surveillance Questionnaire exists. Please contact NTBS@phe.gov.uk";
         #endregion
 
         #region Test Results
         public const string InvalidTestAndSampleTypeCombination = "{0} does not match test type selected";
         public const string NoTestResult = "Please add a test result or confirm no sample was taken";
-        public const string RemoveTestResultsBeforeSayingNoSample = "Please remove all test results or confirm sample was taken";
+
         #endregion
 
         #region Contact Tracing
@@ -82,8 +79,6 @@
         public const string TravelOrVisitTotalNumberOfCountriesRequired = "Please supply total number of countries";
         public const string TotalNumberOfCountriesVisitedFromGreaterThanInputNumber = "Number of countries entered exceeds total number of countries visited from";
         public const string TotalNumberOfCountriesTravelledToGreaterThanInputNumber = "Number of countries entered exceeds total number of countries travelled to";
-        public const string TravelMostRecentCountryRequired = "Please supply most recent country visited";
-        public const string VisitMostRecentCountryRequired = "Please supply most recent country visited from";
         public const string TravelTotalDurationWithinLimit = "Total duration of travel must not exceed 24 months";
         public const string VisitTotalDurationWithinLimit = "Total duration of visits must not exceed 24 months";
         public const string TravelUniqueCountry = "Multiple visits to same country - record as single period of travel";
@@ -91,8 +86,6 @@
         public const string TravelIsChronological = "Travel must be recorded in chronological order";
         public const string VisitIsChronological = "Visits must be recorded in chronological order";
         public const string TravelOrVisitDurationHasCountry = "Duration cannot be added without a corresponding country";
-        public const string VisitCountryRequiresDuration = "Please supply a duration for visit";
-        public const string TravelCountryRequiresDuration = "Please supply a duration for travel";
         #endregion
 
         #region Immunosuppression
@@ -105,7 +98,7 @@
         #endregion
 
         #region Denotify
-        public const string DenotificationDateAfterNotification = "Date of denotification must be after the date of notification";
+
         public const string DenotificationDateLatestToday = "Date of denotification cannot be later than today";
         public const string DenotificationReasonRequired = "Please supply a reason for denotification";
         public const string DenotificationReasonOtherRequired = "Please supply additional details for the denotification reason";


### PR DESCRIPTION
## Description
Post migration trial the validation was found to be overly scrutinous. The requested changes:
Yes followed by everything else blank is valid. In particular, total number of countries and first country are not strictly required

If any country is supplied, then total number of countries becomes required

Yes + Total number of countries as the only filled in field is valid

Each duration is optional, but can only by supplied together with a corresponding country

## Checklist:
- [x] Automated tests are passing locally.