### PR TITLE
NTBS-864: Add overview section routing logic from edit pages

### DIFF
--- a/.idea/.idea.ntbs/riderModule.iml
+++ b/.idea/.idea.ntbs/riderModule.iml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="RIDER_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$USER_HOME$/.nuget/packages/microsoft.net.test.sdk/16.0.1/build/netcoreapp1.0" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.net.test.sdk/16.4.0/build/netcoreapp2.1" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.4.0/build/netcoreapp2.1/x64/testhost.dll" />
+    <content url="file://$USER_HOME$/.nuget/packages/microsoft.testplatform.testhost/16.4.0/build/netcoreapp2.1/x64/testhost.exe" />
     <content url="file://$USER_HOME$/.nuget/packages/specflow.xunit/3.1.80/lib/netstandard2.0/TechTalk.SpecFlow.xUnit.SpecFlowPlugin.dll" />
     <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.1/build/netcoreapp1.0/xunit.runner.reporters.netcoreapp10.dll" />
     <content url="file://$USER_HOME$/.nuget/packages/xunit.runner.visualstudio/2.4.1/build/netcoreapp1.0/xunit.runner.utility.netcoreapp10.dll" />

--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -17,7 +17,7 @@ namespace ntbs_integration_tests.Helpers
         public const int NOTIFIED_ID = 10002;
         public const int DENOTIFIED_ID = 10003;
         public const int NOTIFIED_ID_WITH_NOTIFICATION_DATE = 10004;
-        public const int NEW_ID = 11000;
+        public const int NEW_ID = 10005;
 
         public const int DENOTIFY_WITH_DESCRIPTION = 10010;
         public const int DENOTIFY_NO_DESCRIPTION = 10011;
@@ -118,7 +118,7 @@ namespace ntbs_integration_tests.Helpers
             context.SaveChanges();
         }
 
-        public static IEnumerable<NotificationGroup> GetTestNotificationGroups()
+        private static IEnumerable<NotificationGroup> GetTestNotificationGroups()
         {
             return new List<NotificationGroup>
             {
@@ -187,7 +187,7 @@ namespace ntbs_integration_tests.Helpers
             };
         }
 
-        public static List<Notification> GetSeedingNotifications()
+        private static IEnumerable<Notification> GetSeedingNotifications()
         {
             return new List<Notification>
             {
@@ -243,7 +243,7 @@ namespace ntbs_integration_tests.Helpers
             };
         }
 
-        public static List<Alert> GetSeedingAlerts()
+        private static IEnumerable<Alert> GetSeedingAlerts()
         {
             return new List<Alert>
             {

--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -543,5 +543,64 @@ namespace ntbs_integration_tests.NotificationPages
             resultDocument.AssertErrorSummaryMessage("ClinicalDetails-IsMDRTreatment", "mdr",
                 "You cannot change the value of this field because an MDR Enhanced Surveillance Questionnaire exists. Please contact NTBS@phe.gov.uk");
         }
+        
+        [Fact]
+        public async Task RedirectsToOverviewWithCorrectAnchorFragment_ForNotified()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+            var document = await GetDocumentForUrl(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+                ["NotificationSiteMap[PULMONARY]"] = "true",
+                ["NotificationSiteMap[OTHER]"] = "true",
+                ["OtherSite.SiteDescription"] = "tissue",
+                ["ClinicalDetails.BCGVaccinationState"] = "Yes",
+                ["ClinicalDetails.BCGVaccinationYear"] = "2000",
+                ["ClinicalDetails.IsSymptomatic"] = "true",
+                ["FormattedSymptomDate.Day"] = "1",
+                ["FormattedSymptomDate.Month"] = "1",
+                ["FormattedSymptomDate.Year"] = "2011",
+                ["FormattedFirstPresentationDate.Day"] = "2",
+                ["FormattedFirstPresentationDate.Month"] = "2",
+                ["FormattedFirstPresentationDate.Year"] = "2012",
+                ["FormattedTbServicePresentationDate.Day"] = "3",
+                ["FormattedTbServicePresentationDate.Month"] = "3",
+                ["FormattedTbServicePresentationDate.Year"] = "2013",
+                ["FormattedDiagnosisDate.Day"] = "4",
+                ["FormattedDiagnosisDate.Month"] = "4",
+                ["FormattedDiagnosisDate.Year"] = "2014",
+                ["ClinicalDetails.IsPostMortem"] = "false",
+                ["ClinicalDetails.IsShortCourseTreatment"] = "true",
+                ["ClinicalDetails.IsMDRTreatment"] = "false",
+                ["ClinicalDetails.IsDotOffered"] = "true",
+                ["ClinicalDetails.EnhancedCaseManagementStatus"] = "No"
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, formData, url);
+
+            // Assert
+            var sectionAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(NotificationSubPath);
+            result.AssertRedirectTo($"/Notifications/{id}#{sectionAnchorId}");
+        }
+        
+        [Fact]
+        public async Task NotifiedPageHasReturnLinkToOverview()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+
+            // Act
+            var document = await GetDocumentForUrl(url);
+
+            // Assert
+            var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);
+            Assert.NotNull(document.QuerySelector($"a[href='{overviewLink}']"));
+        }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
@@ -164,5 +164,44 @@ namespace ntbs_integration_tests.NotificationPages
             }
             Assert.Equal(validationResult, result);
         }
+        
+        [Fact]
+        public async Task RedirectsToOverviewWithCorrectAnchorFragment_ForNotified()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+            var document = await GetDocumentForUrl(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+                ["ImmunosuppressionStatus"] = "Yes",
+                ["HasOther"] = "True",
+                ["OtherDescription"] = "test description",
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, formData, url);
+
+            // Assert
+            var sectionAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(NotificationSubPath);
+            result.AssertRedirectTo($"/Notifications/{id}#{sectionAnchorId}");
+        }
+        
+        [Fact]
+        public async Task NotifiedPageHasReturnLinkToOverview()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+
+            // Act
+            var document = await GetDocumentForUrl(url);
+
+            // Assert
+            var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);
+            Assert.NotNull(document.QuerySelector($"a[href='{overviewLink}']"));
+        }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
@@ -199,6 +200,37 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
             var document = await GetDocumentForUrl(url);
             Assert.Null(document.QuerySelector("#overview-denotification-reason"));
+        }
+        
+        public static IEnumerable<object[]> AnchorSubPaths() => new List<string>
+        {
+           NotificationSubPaths.EditPatientDetails,
+           NotificationSubPaths.EditEpisode,
+           NotificationSubPaths.EditClinicalDetails,
+           NotificationSubPaths.EditContactTracing,
+           NotificationSubPaths.EditTestResults,
+           NotificationSubPaths.EditSocialRiskFactors,
+           NotificationSubPaths.EditTravel,
+           NotificationSubPaths.EditComorbidities,
+           NotificationSubPaths.EditSocialContextAddresses,
+           NotificationSubPaths.EditSocialContextVenues,
+           NotificationSubPaths.EditPreviousHistory,
+           NotificationSubPaths.EditMDRDetails
+        }.Select(subPath => new object[] { subPath });
+
+        [Theory]
+        [MemberData(nameof(AnchorSubPaths))]
+        public async Task OverviewPageContainsAnchorId_ForNotificationSubPath(string subPath)
+        {
+            // Arrange
+            var expectedAnchorString = OverviewSubPathToAnchorMap.GetOverviewAnchorId(subPath);
+            var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
+            
+            // Act
+            var document = await GetDocumentForUrl(url);
+            
+            // Assert
+            Assert.NotNull(document.QuerySelector($"#{expectedAnchorString}"));
         }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/PreviousHistoryPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PreviousHistoryPageTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_service;
+using ntbs_service.Helpers;
+using Xunit;
+
+namespace ntbs_integration_tests.NotificationPages
+{
+    public class PreviousHistoryPageTests : TestRunnerNotificationBase
+    {
+        protected override string NotificationSubPath => NotificationSubPaths.EditPreviousHistory;
+
+        public PreviousHistoryPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task RedirectsToOverviewWithCorrectAnchorFragment_ForNotified()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+            var document = await GetDocumentForUrl(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, formData, url);
+
+            // Assert
+            var sectionAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(NotificationSubPath);
+            result.AssertRedirectTo($"/Notifications/{id}#{sectionAnchorId}");
+        }
+        
+        [Fact]
+        public async Task NotifiedPageHasReturnLinkToOverview()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+
+            // Act
+            var document = await GetDocumentForUrl(url);
+
+            // Assert
+            var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);
+            Assert.NotNull(document.QuerySelector($"a[href='{overviewLink}']"));
+        }
+    }
+}

--- a/ntbs-integration-tests/NotificationPages/SocialContextAddressEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/SocialContextAddressEditPageTests.cs
@@ -245,5 +245,38 @@ namespace ntbs_integration_tests.NotificationPages
             var result = await response.Content.ReadAsStringAsync();
             Assert.Contains("To must be later than date from", result);
         }
+        
+        [Fact]
+        public async Task RedirectsToOverviewWithCorrectAnchorFragment_ForNotified()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var notificationSubPath = NotificationSubPaths.EditSocialContextAddresses;
+            var url = GetPathForId(notificationSubPath, id);
+            var document = await GetDocumentForUrl(url);
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, null, url);
+
+            // Assert
+            var sectionAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(notificationSubPath);
+            result.AssertRedirectTo($"/Notifications/{id}#{sectionAnchorId}");
+        }
+        
+        [Fact]
+        public async Task NotifiedPageHasReturnLinkToOverview()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var notificationSubPath = NotificationSubPaths.EditSocialContextAddresses;
+            var url = GetPathForId(notificationSubPath, id);
+
+            // Act
+            var document = await GetDocumentForUrl(url);
+
+            // Assert
+            var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, notificationSubPath);
+            Assert.NotNull(document.QuerySelector($"a[href='{overviewLink}']"));
+        }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/SocialContextVenueEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/SocialContextVenueEditPageTests.cs
@@ -260,5 +260,38 @@ namespace ntbs_integration_tests.NotificationPages
             var result = await response.Content.ReadAsStringAsync();
             Assert.Contains("To must be later than date from", result);
         }
+        
+        [Fact]
+        public async Task RedirectsToOverviewWithCorrectAnchorFragment_ForNotified()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var notificationSubPath = NotificationSubPaths.EditSocialContextVenues;
+            var url = GetPathForId(notificationSubPath, id);
+            var document = await GetDocumentForUrl(url);
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, null, url);
+
+            // Assert
+            var sectionAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(notificationSubPath);
+            result.AssertRedirectTo($"/Notifications/{id}#{sectionAnchorId}");
+        }
+        
+        [Fact]
+        public async Task NotifiedPageHasReturnLinkToOverview()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var notificationSubPath = NotificationSubPaths.EditSocialContextVenues;
+            var url = GetPathForId(notificationSubPath, id);
+
+            // Act
+            var document = await GetDocumentForUrl(url);
+
+            // Assert
+            var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, notificationSubPath);
+            Assert.NotNull(document.QuerySelector($"a[href='{overviewLink}']"));
+        }
     }
 }

--- a/ntbs-integration-tests/NotificationPages/SocialRiskFactorPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/SocialRiskFactorPageTests.cs
@@ -1,0 +1,55 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_service;
+using ntbs_service.Helpers;
+using Xunit;
+
+namespace ntbs_integration_tests.NotificationPages
+{
+    public class SocialRiskFactorPageTests : TestRunnerNotificationBase
+    {
+        protected override string NotificationSubPath => NotificationSubPaths.EditSocialRiskFactors;
+
+        public SocialRiskFactorPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task RedirectsToOverviewWithCorrectAnchorFragment_ForNotified()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+            var document = await GetDocumentForUrl(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, formData, url);
+
+            // Assert
+            var sectionAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(NotificationSubPath);
+            result.AssertRedirectTo($"/Notifications/{id}#{sectionAnchorId}");
+        }
+        
+        [Fact]
+        public async Task NotifiedPageHasReturnLinkToOverview()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+
+            // Act
+            var document = await GetDocumentForUrl(url);
+
+            // Assert
+            var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);
+            Assert.NotNull(document.QuerySelector($"a[href='{overviewLink}']"));
+        }
+    }
+}

--- a/ntbs-integration-tests/NotificationPages/TestResultsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TestResultsPageTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
@@ -45,6 +46,43 @@ namespace ntbs_integration_tests.NotificationPages
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
             Assert.Null(document.QuerySelector("div[id='lab-results-summary']"));
             Assert.Null(document.QuerySelector("div[id='specimens-details']"));
+        }
+        
+        [Fact]
+        public async Task RedirectsToOverviewWithCorrectAnchorFragment_ForNotified()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+            var document = await GetDocumentForUrl(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+                ["TestData.HasTestCarriedOut"] = "false"
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, formData, url);
+
+            // Assert
+            var sectionAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(NotificationSubPath);
+            result.AssertRedirectTo($"/Notifications/{id}#{sectionAnchorId}");
+        }
+        
+        [Fact]
+        public async Task NotifiedPageHasReturnLinkToOverview()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+
+            // Act
+            var document = await GetDocumentForUrl(url);
+
+            // Assert
+            var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);
+            Assert.NotNull(document.QuerySelector($"a[href='{overviewLink}']"));
         }
     }
 }

--- a/ntbs-service/Helpers/RouteHelper.cs
+++ b/ntbs-service/Helpers/RouteHelper.cs
@@ -5,7 +5,7 @@ namespace ntbs_service.Helpers
 {
     public static class RouteHelper
     {
-        public static string NotificationBasePath => "/Notifications/{0}/{1}";
+        private static string NotificationBasePath => "/Notifications/{0}/{1}";
 
         public static string GetSubmittingNotificationPath(int notificationId, string subPath)
         {
@@ -22,6 +22,13 @@ namespace ntbs_service.Helpers
             }
 
             return string.Format(NotificationBasePath, notificationId, path);
+        }
+
+        public static string GetNotificationOverviewPathWithSectionAnchor(int notificationId, string sectionSubPath)
+        {
+            var overviewPath = GetNotificationPath(notificationId, NotificationSubPaths.Overview);
+            var anchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath);
+            return string.IsNullOrEmpty(anchorId) ? overviewPath : $"{overviewPath}#{anchorId}";
         }
 
         public static string GetAlertPath(int alertId, string subPath)
@@ -71,6 +78,35 @@ namespace ntbs_service.Helpers
 
         public static string EditTreatmentEvent(int treatmentEventId) => $"Edit/TreatmentEvent/{treatmentEventId}";
         public static string AddTreatmentEvent => $"Edit/TreatmentEvent/New";
+    }
+
+    public static class OverviewSubPathToAnchorMap
+    {
+        private static readonly Dictionary<string, string> _subPathToAnchorId = new Dictionary<string, string>
+        {
+            {NotificationSubPaths.EditPatientDetails, "overview-patient-details"},
+            {NotificationSubPaths.EditEpisode, "overview-hospital-details"},
+            {NotificationSubPaths.EditClinicalDetails, "overview-clinical-details"},
+            {NotificationSubPaths.EditContactTracing, "overview-contact-tracing"},
+            {NotificationSubPaths.EditTestResults, "overview-test-results"},
+            {NotificationSubPaths.EditSocialRiskFactors, "overview-social-risks"},
+            {NotificationSubPaths.EditComorbidities, "overview-comorbidities"},
+            {NotificationSubPaths.EditTravel, "overview-travel-and-visitors"},
+            {NotificationSubPaths.EditSocialContextAddresses, "overview-social-addresses"},
+            {NotificationSubPaths.EditSocialContextVenues, "overview-social-venues"},
+            {NotificationSubPaths.EditPreviousHistory, "overview-previous-history"},
+            {NotificationSubPaths.EditMDRDetails, "overview-mdr-details"},
+        };
+
+        public static string GetOverviewAnchorId(string notificationSubPath)
+        {
+            if (string.IsNullOrEmpty(notificationSubPath))
+            {
+                return null;
+            }
+            
+            return _subPathToAnchorId.ContainsKey(notificationSubPath) ? _subPathToAnchorId[notificationSubPath] : null;
+        }
     }
 
     public static class AlertSubPaths

--- a/ntbs-service/Models/Entities/DataQualityBirthCountryAlert.cs
+++ b/ntbs-service/Models/Entities/DataQualityBirthCountryAlert.cs
@@ -6,9 +6,11 @@ namespace ntbs_service.Models.Entities
     public class DataQualityBirthCountryAlert : Alert
     {
         public override string Action => "Please review to see if more accurate information available.";
-        // TODO: NTBS-864 overview id
+
         public override string ActionLink =>
-            RouteHelper.GetNotificationPath(NotificationId.GetValueOrDefault(), NotificationSubPaths.Overview);
+            RouteHelper.GetNotificationOverviewPathWithSectionAnchor(
+                NotificationId.GetValueOrDefault(),
+                NotificationSubPaths.EditPatientDetails);
 
         public DataQualityBirthCountryAlert()
         {

--- a/ntbs-service/Models/Entities/DataQualityClinicalDatesAlert.cs
+++ b/ntbs-service/Models/Entities/DataQualityClinicalDatesAlert.cs
@@ -5,10 +5,13 @@ namespace ntbs_service.Models.Entities
 {
     public class DataQualityClinicalDatesAlert : Alert
     {
-        public override string Action => "One or more of the clinical dates appears to be out of sequence, please review.";
-        // TODO: NTBS-864 overview id
-        public override string ActionLink => RouteHelper.GetNotificationPath(NotificationId.GetValueOrDefault(),
-            NotificationSubPaths.Overview) + "#clinical-details-overview-details";
+        public override string Action =>
+            "One or more of the clinical dates appears to be out of sequence, please review.";
+
+        public override string ActionLink =>
+            RouteHelper.GetNotificationOverviewPathWithSectionAnchor(
+                NotificationId.GetValueOrDefault(),
+                NotificationSubPaths.EditClinicalDetails);
 
         public DataQualityClinicalDatesAlert()
         {

--- a/ntbs-service/Models/Entities/DataQualityClusterAlert.cs
+++ b/ntbs-service/Models/Entities/DataQualityClusterAlert.cs
@@ -6,10 +6,11 @@ namespace ntbs_service.Models.Entities
     public class DataQualityClusterAlert : Alert
     {
         public override string Action => "Notification is in a Cluster, please review social context information.";
-        // TODO: NTBS-864 overview id
+
         public override string ActionLink =>
-            RouteHelper.GetNotificationPath(NotificationId.GetValueOrDefault(),
-                NotificationSubPaths.Overview) + "#social-context-addresses-overview-details";
+            RouteHelper.GetNotificationOverviewPathWithSectionAnchor(
+                NotificationId.GetValueOrDefault(),
+                NotificationSubPaths.EditSocialContextAddresses);
 
         public DataQualityClusterAlert()
         {

--- a/ntbs-service/Models/Entities/DataQualityDraftAlert.cs
+++ b/ntbs-service/Models/Entities/DataQualityDraftAlert.cs
@@ -6,8 +6,9 @@ namespace ntbs_service.Models.Entities
     public class DataQualityDraftAlert : Alert
     {
         public override string Action => "Draft record has been open for more than 90 days, please review and action.";
-        // TODO: NTBS-864 overview id
-        public override string ActionLink => RouteHelper.GetNotificationPath(NotificationId.GetValueOrDefault(),
+
+        public override string ActionLink => RouteHelper.GetNotificationPath(
+            NotificationId.GetValueOrDefault(),
             NotificationSubPaths.EditPatientDetails);
 
         public DataQualityDraftAlert()

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml
@@ -9,7 +9,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Clinical Details";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditClinicalDetails;
     var fullValidation = Model.ClinicalDetails.ShouldValidateFull ? "True" : "False";
     ViewData["FullValidation"] = fullValidation;
 }

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -48,6 +48,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         {
             _referenceDataRepository = referenceDataRepository;
             _alertService = alertService;
+
+            CurrentPage = NotificationSubPaths.EditClinicalDetails;
         }
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml
@@ -5,7 +5,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Comorbidities";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditComorbidities;
 }
 
 <partial name="_SinglePageErrorSummaryPartial" />

--- a/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
 using ntbs_service.Services;
@@ -32,7 +33,10 @@ namespace ntbs_service.Pages.Notifications.Edit
         public ComorbiditiesModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository) { }
+            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+        {
+            CurrentPage = NotificationSubPaths.EditComorbidities;
+        }
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)
         {

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml
@@ -6,7 +6,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Contact Tracing";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditContactTracing;
 }
 
 <partial name="_SinglePageErrorSummaryPartial"/>

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -13,6 +14,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
         {
+            CurrentPage = NotificationSubPaths.EditContactTracing;
         }
 
         [BindProperty]

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml
@@ -8,7 +8,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Hospital Details";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditEpisode;
     var fullValidation = Model.Episode.ShouldValidateFull ? "True" : "False";
 }
 

--- a/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Episode.cshtml.cs
@@ -42,6 +42,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             _context = context;
             _userService = userService;
             _referenceDataRepository = referenceDataRepository;
+
+            CurrentPage = NotificationSubPaths.EditEpisode;
         }
 
         protected override Task<Notification> GetNotificationAsync(int notificationId)

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
@@ -7,7 +7,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - MDRDetails";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditMDRDetails;
     var fullValidation = Model.MDRDetails.ShouldValidateFull ? "True" : "False";
 }
 

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
@@ -24,6 +25,8 @@ namespace ntbs_service.Pages.Notifications.Edit
                     nameof(Country.CountryId),
                     nameof(Country.Name)
                 );
+
+                CurrentPage = NotificationSubPaths.EditMDRDetails;
             }
 
         [BindProperty]

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
@@ -7,7 +7,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Personal Details";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditPatientDetails;
     var fullValidation = Model.PatientDetails.ShouldValidateFull ? "True" : "False";
 }
 

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -40,6 +40,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         {
             _postcodeService = postcodeService;
             GenerateReferenceData(referenceDataRepository);
+            
+            CurrentPage = NotificationSubPaths.EditPatientDetails;
         }
 
         private void GenerateReferenceData(IReferenceDataRepository referenceDataRepository)

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
@@ -6,7 +6,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Patient TB History";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditPreviousHistory;
     var fullValidation = Model.PatientTbHistory.ShouldValidateFull ? "True" : "False";
 }
 

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -11,7 +12,10 @@ namespace ntbs_service.Pages.Notifications.Edit
         public PreviousHistoryModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository) { }
+            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+        {
+            CurrentPage = NotificationSubPaths.EditPreviousHistory;
+        }
 
         [BindProperty]
         public PatientTBHistory PatientTbHistory { get; set; }

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml
@@ -6,7 +6,7 @@
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Social Context Addresses";
     ViewData["ShowSocialContextAddressEditLinks"] = true;
-    ViewData["IsNonEditPage"] = true;
+    ViewData["IsEditPage"] = false;
 }
 
 <h2>Social Context - Addresses</h2>

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml
@@ -6,8 +6,7 @@
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Social Context Addresses";
     ViewData["ShowSocialContextAddressEditLinks"] = true;
-    ViewData["ShowContinueButton"] = true;
-    ViewData["CurrentPage"] = NotificationSubPaths.EditSocialContextAddresses;
+    ViewData["IsNonEditPage"] = true;
 }
 
 <h2>Social Context - Addresses</h2>

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -16,6 +17,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
         {
+            CurrentPage = NotificationSubPaths.EditSocialContextAddresses;
         }
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml
@@ -6,7 +6,7 @@
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Social Context Venues";
     ViewData["ShowSocialContextVenueEditLinks"] = true;
-    ViewData["IsNonEditPage"] = true;
+    ViewData["IsEditPage"] = false;
 }
 
 <h2>Social Context - Venues</h2>

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml
@@ -6,8 +6,7 @@
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Social Context Venues";
     ViewData["ShowSocialContextVenueEditLinks"] = true;
-    ViewData["ShowContinueButton"] = true;
-    ViewData["CurrentPage"] = NotificationSubPaths.EditSocialContextVenues;
+    ViewData["IsNonEditPage"] = true;
 }
 
 <h2>Social Context - Venues</h2>

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -16,6 +17,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
         {
+            CurrentPage = NotificationSubPaths.EditSocialContextVenues;
         }
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml
@@ -6,7 +6,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Social Risk Factors";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditSocialRiskFactors;
     var statuses = EnumHelper.GetEnumList<Status>();
 }
 

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -16,6 +17,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
         {
+            CurrentPage = NotificationSubPaths.EditSocialRiskFactors;
         }
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml
@@ -6,7 +6,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Test Results";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditTestResults;
     var fullValidation = Model.TestData.ShouldValidateFull ? "True" : "False";
 }
 

--- a/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -22,6 +23,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         {
             _cultureAndResistanceService = cultureAndResistanceService;
             _specimenService = specimenService;
+            
+            CurrentPage = NotificationSubPaths.EditTestResults;
         }
 
         [BindProperty]

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml
@@ -5,7 +5,6 @@
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
     ViewData["Title"] = "Notification - Travel and visitor history";
-    ViewData["CurrentPage"] = NotificationSubPaths.EditTravel;
 }
 
 <partial name="_SinglePageErrorSummaryPartial" />

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Services;
@@ -28,6 +29,8 @@ namespace ntbs_service.Pages.Notifications.Edit
                 referenceDataRepository.GetAllHighTbIncidenceCountriesAsync().Result,
                 nameof(Country.CountryId),
                 nameof(Country.Name));
+            
+            CurrentPage = NotificationSubPaths.EditTravel;
         }
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
 using ntbs_service.Services;
@@ -16,11 +17,9 @@ namespace ntbs_service.Pages.Notifications.Edit
         public TreatmentEventsModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository)
-            : base(notificationService,
-                   authorizationService,
-                   notificationRepository)
+            INotificationRepository notificationRepository) : base(notificationService, authorizationService, notificationRepository)
         {
+            CurrentPage = NotificationSubPaths.EditTreatmentEvents;
         }
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml
@@ -1,6 +1,5 @@
 @page "/Notifications/{NotificationId:int}/Edit/TreatmentEvents/{handler?}"
 @model TreatmentEventsModel
-@using static NHSUK.FrontEndLibrary.TagHelpers.FormGroupType
 
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";

--- a/ntbs-service/Pages/Notifications/Edit/_SaveButton.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_SaveButton.cshtml
@@ -4,11 +4,11 @@
 
 @{
     var isDraft = Model.NotificationStatus == NotificationStatus.Draft;
-    var isNonEditPage = (bool?) ViewData["IsNonEditPage"] ?? false;
+    var isEditPage = (bool?) ViewData["IsEditPage"] ?? true;
     var currentPage = (string) ViewData["CurrentPage"];
 
     var buttonName = "";
-    if (isNonEditPage)
+    if (!isEditPage)
     {
         buttonName = "Continue";
     }
@@ -20,8 +20,7 @@
     var id = ViewData.ContainsKey("id") ? ViewData["id"] : "save-button";
 }
 
-@* Conditional excluding (!isDraft && isNonEdit) *@
-@if (isDraft || !isNonEditPage)
+@if (isDraft || isEditPage)
 {
     <button
         nhs-button-type="Standard"

--- a/ntbs-service/Pages/Notifications/Edit/_SaveButton.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_SaveButton.cshtml
@@ -1,21 +1,39 @@
+@using ntbs_service.Helpers
 @using ntbs_service.Models.Enums
 @model ntbs_service.Models.Entities.Notification
 
 @{
+    var isDraft = Model.NotificationStatus == NotificationStatus.Draft;
+    var isNonEditPage = (bool?) ViewData["IsNonEditPage"] ?? false;
+    var currentPage = (string) ViewData["CurrentPage"];
+
     var buttonName = "";
-    if (@ViewData.ContainsKey("ShowContinueButton") && (bool)@ViewData["ShowContinueButton"])
+    if (isNonEditPage)
     {
         buttonName = "Continue";
-    } else {
-        buttonName = Model?.NotificationStatus == NotificationStatus.Draft ? "Save and continue" : "Save";
     }
-    var id = @ViewData.ContainsKey("id") ? @ViewData["id"] : "save-button";
+    else
+    {
+        buttonName = isDraft ? "Save and continue" : "Save";
+    }
+
+    var id = ViewData.ContainsKey("id") ? ViewData["id"] : "save-button";
 }
-<button
-    nhs-button-type="Standard"
-    classes="ntbsuk-button--primary"
-    name="actionName"
-    value="Save"
-    id=@id >
-    @buttonName
-</button>
+
+@* Conditional excluding (!isDraft && isNonEdit) *@
+@if (isDraft || !isNonEditPage)
+{
+    <button
+        nhs-button-type="Standard"
+        classes="ntbsuk-button--primary"
+        name="actionName"
+        value="Save"
+        id="@id">
+        @buttonName
+    </button>
+}
+
+@if (!isDraft)
+{
+    <nhs-back-link href="@RouteHelper.GetNotificationOverviewPathWithSectionAnchor(Model.NotificationId, currentPage)">Cancel & go back</nhs-back-link>
+}

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -14,7 +14,7 @@ namespace ntbs_service.Pages.Notifications
 {
     public abstract class NotificationEditModelBase : NotificationModelBase
     {
-        protected ValidationService ValidationService;
+        protected readonly ValidationService ValidationService;
 
         protected NotificationEditModelBase(
             INotificationService service,
@@ -37,6 +37,9 @@ namespace ntbs_service.Pages.Notifications
         */
         [BindProperty]
         public string ActionName { get; set; }
+
+        [ViewData]
+        public string CurrentPage { get; set; }
 
         public virtual async Task<IActionResult> OnGetAsync(bool isBeingSubmitted = false)
         {
@@ -131,7 +134,12 @@ namespace ntbs_service.Pages.Notifications
         // but this can be overriden for sub-entity pages such as TestResult
         protected virtual IActionResult RedirectAfterSaveForNotified()
         {
-            return RedirectToPage("/Notifications/Overview", new { NotificationId });
+            var overviewAnchorId = OverviewSubPathToAnchorMap.GetOverviewAnchorId(CurrentPage);
+            return RedirectToPage(
+                pageName: "/Notifications/Overview", 
+                pageHandler: null,  
+                routeValues: new { NotificationId }, 
+                fragment: overviewAnchorId);
         }
 
         protected async Task SetNotificationProperties<T>(bool isBeingSubmitted, T ownedModel) where T : ModelBase

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container">
+@{
+    var sectionSubPath = NotificationSubPaths.EditClinicalDetails;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Clinical details </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditClinicalDetails)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
@@ -6,7 +6,6 @@
     var sectionSubPath = NotificationSubPaths.EditClinicalDetails;
 }
 
-@* TODO: NTBS-864 overview id *@
 <div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Clinical details </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ComorbiditiesAndImmunosuppresionOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ComorbiditiesAndImmunosuppresionOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container">
+@{
+    var sectionSubPath = NotificationSubPaths.EditComorbidities;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Co-morbidities and immunosuppression </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditComorbidities)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ContactTracingOverviewPartial.cshtml
@@ -3,14 +3,14 @@
 @model OverviewModel
 
 @{
-    var notificationId = (int) ViewData["NotificationId"];
+    var sectionSubPath = NotificationSubPaths.EditContactTracing;
 }
 
-<div class="notification-overview-type-and-edit-container">
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Contact tracing </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(notificationId, NotificationSubPaths.EditContactTracing)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_EpisodeOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_EpisodeOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container">
+@{
+    var sectionSubPath = NotificationSubPaths.EditEpisode;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Hospital Details </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditEpisode)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container">
+@{
+    var sectionSubPath = NotificationSubPaths.EditMDRDetails;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> MDR Details </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditMDRDetails)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_PatientOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_PatientOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container" id="patient-details-overview-header">
+@{
+    var sectionSubPath = NotificationSubPaths.EditPatientDetails;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Personal details of patient </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditPatientDetails)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_PreviousHistoryOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_PreviousHistoryOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container">
+@{
+    var sectionSubPath = NotificationSubPaths.EditPreviousHistory;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Other history of TB </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditPreviousHistory)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_SocialContextAddressesOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_SocialContextAddressesOverviewPartial.cshtml
@@ -6,7 +6,6 @@
     var sectionSubPath = NotificationSubPaths.EditSocialContextAddresses;
 }
 
-@* TODO: NTBS-864 overview id *@
 <div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Social Context - Addresses </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_SocialContextAddressesOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_SocialContextAddressesOverviewPartial.cshtml
@@ -3,14 +3,14 @@
 @model OverviewModel
 
 @{
-    var notificationId = (int) ViewData["NotificationId"];
+    var sectionSubPath = NotificationSubPaths.EditSocialContextAddresses;
 }
 
-<div class="notification-overview-type-and-edit-container">
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Social Context - Addresses </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(notificationId, NotificationSubPaths.EditSocialContextAddresses)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_SocialContextVenuesOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_SocialContextVenuesOverviewPartial.cshtml
@@ -3,14 +3,14 @@
 @model OverviewModel
 
 @{
-    var notificationId = (int) ViewData["NotificationId"];
+    var sectionSubPath = NotificationSubPaths.EditSocialContextVenues;
 }
 
-<div class="notification-overview-type-and-edit-container">
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Social Context - Venues </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(notificationId, NotificationSubPaths.EditSocialContextVenues)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_SocialRiskFactorsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_SocialRiskFactorsOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container">
+@{
+    var sectionSubPath = NotificationSubPaths.EditSocialRiskFactors;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Social risk factors </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditSocialRiskFactors)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TestResultsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TestResultsOverviewPartial.cshtml
@@ -3,15 +3,15 @@
 @model OverviewModel
 
 @{
-    var notificationId = (int) ViewData["NotificationId"];
     var testData = Model.Notification.TestData;
+    var sectionSubPath = NotificationSubPaths.EditTestResults;
 }
 
-<div class="notification-overview-type-and-edit-container">
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Test results </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(notificationId, NotificationSubPaths.EditTestResults)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TravelOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TravelOverviewPartial.cshtml
@@ -2,11 +2,15 @@
 @using ntbs_service.Models.Enums
 @model OverviewModel
 
-<div class="notification-overview-type-and-edit-container">
+@{
+    var sectionSubPath = NotificationSubPaths.EditTravel;
+}
+
+<div class="notification-overview-type-and-edit-container" id="@OverviewSubPathToAnchorMap.GetOverviewAnchorId(sectionSubPath)">
     <h3 class="notification-details-type"> Travel/visitors </h3>
     @if (Model.PermissionLevel == PermissionLevel.Edit)
     {
-        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.EditTravel)"
+        <a href="@RouteHelper.GetNotificationPath(Model.NotificationId, sectionSubPath)"
            class="notification-edit-link govuk-link--no-visited-state">
             Edit
         </a>

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -149,6 +149,7 @@ namespace ntbs_service.Services
 
         public async Task UpdateTestDataAsync(Notification notification, TestData testData)
         {
+            testData.NotificationId = notification.NotificationId;
             _context.SetValues(notification.TestData, testData);
 
             await UpdateDatabaseAsync();

--- a/ntbs-ui-tests/Steps/Steps.cs
+++ b/ntbs-ui-tests/Steps/Steps.cs
@@ -115,7 +115,7 @@ namespace ntbs_ui_tests.StepDefinitions
         [Then(@"I should see the Notification")]
         public void ThenIShouldSeeTheNotification()
         {
-            var urlRegex = new Regex(@".*/Notifications/(\d+)/?$");
+            var urlRegex = new Regex(@".*/Notifications/(\d+)/?.*$");
             var match = urlRegex.Match(Browser.Url);
             var idString = match.Groups[1].Value;
             Assert.True(match.Success, $"Url I am on instead: {Browser.Url}");

--- a/ntbs-ui-tests/Steps/Steps.cs
+++ b/ntbs-ui-tests/Steps/Steps.cs
@@ -115,7 +115,7 @@ namespace ntbs_ui_tests.StepDefinitions
         [Then(@"I should see the Notification")]
         public void ThenIShouldSeeTheNotification()
         {
-            var urlRegex = new Regex(@".*/Notifications/(\d+)/?.*$");
+            var urlRegex = new Regex(@".*/Notifications/(\d+)/?(#.+)?$");
             var match = urlRegex.Match(Browser.Url);
             var idString = match.Groups[1].Value;
             Assert.True(match.Success, $"Url I am on instead: {Browser.Url}");


### PR DESCRIPTION
## Description
Move 'CurrentPage' configuration into the view model to enable redirect after save for notified to take add anchor id to URL.
Heap of surrounding changes to allow as neat a solution as I could fathom for the routing from edit pages to overview etc.
A chunk of repetitive testing to provide adequate coverage for this functionality.

## Checklist:
- [X] Automated tests are passing locally.
### Accessibility testing
- [X] Check the feature looks and works correctly in IE11
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
