### PR TITLE
NTBS-377 make draft quality alerts visible on homepage

### DIFF
--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -58,7 +58,7 @@ namespace ntbs_service.DataAccess
         {
             return await GetBaseAlertIQueryable()
                 .Where(a => tbServices.Contains(a.TbServiceCode))
-                .Where(a => a.NotificationId == null || a.Notification.NotificationStatus != NotificationStatus.Draft)
+                .Where(a => a.NotificationId == null && (a.Notification.NotificationStatus != NotificationStatus.Draft || a.AlertType == AlertType.DataQualityDraft ))
                 .OrderByDescending(a => a.CreationDate)
                 .ToListAsync();
         }

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -58,7 +58,7 @@ namespace ntbs_service.DataAccess
         {
             return await GetBaseAlertIQueryable()
                 .Where(a => tbServices.Contains(a.TbServiceCode))
-                .Where(a => a.NotificationId == null && (a.Notification.NotificationStatus != NotificationStatus.Draft || a.AlertType == AlertType.DataQualityDraft ))
+                .Where(a => a.NotificationId == null || a.Notification.NotificationStatus != NotificationStatus.Draft || a.AlertType == AlertType.DataQualityDraft)
                 .OrderByDescending(a => a.CreationDate)
                 .ToListAsync();
         }


### PR DESCRIPTION
Draft alerts were normally hidden  - draft data quality alerts want to not be hidden and are an exception to this rule.