### PR TITLE
Set deployment definition images away from `latest`

### DIFF
--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: ntbs-int
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service"
+        image: "ntbscontainerregistry.azurecr.io/ntbs-service:int"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
         - name: ntbs-live
-          image: "ntbscontainerregistry.azurecr.io/ntbs-service"
+          image: "ntbscontainerregistry.azurecr.io/ntbs-service:live"
           imagePullPolicy: Always
           resources:
             requests:

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: ntbs-test
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service"
+        image: "ntbscontainerregistry.azurecr.io/ntbs-service:test"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: ntbs-uat
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service"
+        image: "ntbscontainerregistry.azurecr.io/ntbs-service:uat"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
This change is done in response to the scenario of calling `kubectl apply uat.yml` directly,
 rather than through the release script (which follows it up with `kubectl set image ...`). It had the following adverse effects:
 - the newest version of code got released to uat
 - from that point onwards uat auto-updated to the newest image, until the release script got used again

 This was caused by the fact that:
 - `ntbscontainerregistry.azurecr.io/ntbs-service` implicitly described the tag `ntbs-service:latest`
 - we have `imagePullPolicy: Always` set on the definitions (and it is also the default behaviour for `latest` tags)

The change in this commit should stop this behaviour by giving each environment a non-existent image to pull in as the baseline. That way if `apply` is called, the new replica set would simply fail to start and the old one will keep running.
It will not affect the current deployment process (which, as mentioned above, overrides the image value anyways).
