### PR TITLE
NTBS-854 Fix dynamic validation for Notification date

### DIFF
--- a/ntbs-service/Models/Entities/ModelBase.cs
+++ b/ntbs-service/Models/Entities/ModelBase.cs
@@ -9,7 +9,7 @@ namespace ntbs_service.Models.Entities
         public bool ShouldValidateFull { get; set; }
 
         [NotMapped]
-        public bool? IsLegacy { get; set; }
+        public virtual bool? IsLegacy { get; set; }
 
         /* 
         * Full Validation is done if the form is being submitted or already been submitted.

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -57,7 +57,7 @@ namespace ntbs_service.Models.Entities
         public NotificationStatus NotificationStatus { get; set; }
 
         [NotMapped]
-        public new bool IsLegacy => LTBRID != null || ETSID != null;
+        public override bool? IsLegacy => LTBRID != null || ETSID != null;
 
         #endregion
 

--- a/ntbs-service/Services/ValidationService.cs
+++ b/ntbs-service/Services/ValidationService.cs
@@ -41,7 +41,7 @@ namespace ntbs_service.Services
         public ContentResult GetMultiplePropertiesValidationResult<T>(
             IEnumerable<(string, object)> propertyValueTuples,
             bool shouldValidateFull = false,
-            bool isLegacy = false)
+            bool? isLegacy = false)
             where T : ModelBase
         {
             T model = (T)Activator.CreateInstance(typeof(T));


### PR DESCRIPTION
The shadowing, rather than overriding the property, was causing the validation to work wrongly on the notification model directly


On-screen approved by @conorsheehansw 