### PR TITLE
NTBS-674: Correlation error fix

### DIFF
--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -77,7 +77,7 @@ namespace ntbs_service
 
             var adfsConfig = Configuration.GetSection("AdfsOptions");
             var ldapConnectionSettings = Configuration.GetSection("LdapConnectionSettings");
-            var setupDummyAuth = false;
+            var setupDummyAuth = adfsConfig.GetValue("UseDummyAuth", false);
             var authSetup = services
                 .AddAuthentication(sharedOptions =>
                 {
@@ -228,7 +228,7 @@ namespace ntbs_service
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            if (false)
+            if (env.IsDevelopment())	
             {
                 app.UseDeveloperExceptionPage();
                 app.UseWebpackDevMiddleware(new WebpackDevMiddlewareOptions
@@ -239,8 +239,8 @@ namespace ntbs_service
             }
             else
             {
-                // app.UseStatusCodePagesWithReExecute("/errors/{0}");
-                // app.UseExceptionHandler("/errors/500");
+                app.UseStatusCodePagesWithReExecute("/errors/{0}");
+                app.UseExceptionHandler("/errors/500");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading.Tasks;
 using EFAuditer;
 using Hangfire;
 using Hangfire.Console;
@@ -76,17 +77,35 @@ namespace ntbs_service
 
             var adfsConfig = Configuration.GetSection("AdfsOptions");
             var ldapConnectionSettings = Configuration.GetSection("LdapConnectionSettings");
-            var setupDummyAuth = adfsConfig.GetValue("UseDummyAuth", false);
-            var authSetup = services.AddAuthentication(sharedOptions =>
+            var setupDummyAuth = false;
+            var authSetup = services
+                .AddAuthentication(sharedOptions =>
                 {
                     sharedOptions.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                     sharedOptions.DefaultSignInScheme = CookieAuthenticationDefaults.AuthenticationScheme;
                     sharedOptions.DefaultChallengeScheme = WsFederationDefaults.AuthenticationScheme;
-                }).AddWsFederation(options =>
+                })
+                .AddWsFederation(options =>
                 {
                     options.MetadataAddress =
                         adfsConfig["AdfsUrl"] + "/FederationMetadata/2007-06/FederationMetadata.xml";
                     options.Wtrealm = adfsConfig["Wtrealm"];
+                    
+                    /*
+                     * Below event handler is to prevent stale logins from showing a 500 error screen, instead to force
+                     * back to the landing page - and cause a re-challenge or continue if already authenticated.
+                     * https://community.auth0.com/t/asp-net-core-2-intermittent-correlation-failed-errors/11918/14
+                     */
+                    options.Events.OnRemoteFailure += context =>
+                    {
+                        if (context.Failure.Message == "Correlation failed.")
+                        {
+                            context.HandleResponse();
+                            context.Response.Redirect("/");
+                        }
+
+                        return Task.CompletedTask;
+                    };
                 })
                 .AddCookie(options =>
                 {
@@ -209,7 +228,7 @@ namespace ntbs_service
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            if (env.IsDevelopment())
+            if (false)
             {
                 app.UseDeveloperExceptionPage();
                 app.UseWebpackDevMiddleware(new WebpackDevMiddlewareOptions
@@ -220,8 +239,8 @@ namespace ntbs_service
             }
             else
             {
-                app.UseStatusCodePagesWithReExecute("/errors/{0}");
-                app.UseExceptionHandler("/errors/500");
+                // app.UseStatusCodePagesWithReExecute("/errors/{0}");
+                // app.UseExceptionHandler("/errors/500");
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }


### PR DESCRIPTION
## Description
Add event handler to handle stale logins more cleanly. 
If login is stale and user is authenticated this will navigate to the landing page (unfortunately couldn't route to their original intended location).
If login is stale and user is not authenticated this will attempt to navigate to the landing page and force them through another challenge.
