### PR TITLE
NTBS-359: Remove incorrect non-working vue shorthand

### DIFF
--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -57,7 +57,7 @@
                 @if (Model.Notification.NotificationStatus != NotificationStatus.Draft)
                 {
                     <print-button inline-template>
-                        <button nhs-button-type="Standard" classes="ntbsuk-button--secondary hidden" :click="print" id="print-notification-overview-button">
+                        <button nhs-button-type="Standard" classes="ntbsuk-button--secondary hidden" v-on:click="print" id="print-notification-overview-button">
                             Print notification overview
                         </button>
                     </print-button>


### PR DESCRIPTION
## Description
As a late change in working of my previous ticket... I swapped v-on:click to :click which not only is the correct shorthand for v-on (being @click), but even the correct shorthand doesn't work for some reason.

This is reverting that change.

## Checklist:
- [X] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [X] Test functionality without javascript
- [X] Check the feature looks and works correctly in IE11
