### PR TITLE
NTBS-835: Add missing comma

### DIFF
--- a/ntbs-service/Services/NotificationClusterService.cs
+++ b/ntbs-service/Services/NotificationClusterService.cs
@@ -26,7 +26,7 @@ namespace ntbs_service.Services
             var query = $@"
                 SELECT
                     [{nameof(NotificationClusterValue.NotificationId)}]
-                    [{nameof(NotificationClusterValue.ClusterId)}]
+                    ,[{nameof(NotificationClusterValue.ClusterId)}]
                 FROM [dbo].[vwNotificationClusterMatch]";
 
             using (var connection = new SqlConnection(_reportingDbConnectionString))


### PR DESCRIPTION
## Description
As missing comma to query.

Would have been tricky to pick up in local testing due to the int-reporting view not having notifications that match with my local version e.g. 1007 etc.

For anyone's interest it considered the second 'select field' as an alias for the first in the absence of a comma.

## Checklist:
- [X] Automated tests are passing locally.
