### PR TITLE
NTBS-565: Navigate to notification view from legacy view if imported

### DIFF
--- a/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
+++ b/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using ntbs_service.DataAccess;
 using ntbs_service.DataMigration;
 using ntbs_service.Models;
 using ntbs_service.Pages.Notifications;
@@ -14,7 +15,8 @@ namespace ntbs_service.Pages.LegacyNotifications
     {
         private readonly ILegacySearchService _legacySearchService;
         private readonly INotificationImportService _notificationImportService;
-        
+        private readonly INotificationRepository _notificationRepository;
+
         public NotificationBannerModel NotificationBannerModel { get; set; }
         
         [BindProperty(SupportsGet = true)]
@@ -23,10 +25,13 @@ namespace ntbs_service.Pages.LegacyNotifications
         public string RequestId { get; set; }
         public ImportResult LegacyImportResult { get; set; }
 
-        public Index(ILegacySearchService legacySearchService, INotificationImportService notificationImportService)
+        public Index(ILegacySearchService legacySearchService, 
+            INotificationImportService notificationImportService,
+            INotificationRepository notificationRepository)
         {
             _legacySearchService = legacySearchService;
             _notificationImportService = notificationImportService;
+            _notificationRepository = notificationRepository;
         }
         
         public async Task<IActionResult> OnGetAsync()
@@ -54,6 +59,12 @@ namespace ntbs_service.Pages.LegacyNotifications
             NotificationBannerModel = await _legacySearchService.GetByIdAsync(LegacyNotificationId);
             if (NotificationBannerModel == null)
             {
+                var notificationWithLegacyIdExists = await _notificationRepository.NotificationWithLegacyIdExistsAsync(LegacyNotificationId);
+                if (notificationWithLegacyIdExists)
+                {
+                    return RedirectToPage("/Notifications/Overview", new {NotificationId = LegacyNotificationId});
+                }
+
                 return NotFound();
             }
             


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
