### PR TITLE
NTBS-368: Use View instead of Reusable notifications table

### DIFF
--- a/ntbs-service/DataAccess/DrugResistanceProfileRepository.cs
+++ b/ntbs-service/DataAccess/DrugResistanceProfileRepository.cs
@@ -25,10 +25,10 @@ namespace ntbs_service.DataAccess
         public async Task<Dictionary<int, DrugResistanceProfile>> GetDrugResistanceProfilesAsync()
         {
             var query = $@"
-                SELECT [ReusableNotificationId] AS NotificationId,
-                    [DrugResistanceProfile],
-                    [Species]
-                FROM [dbo].[ReusableNotification]";
+                SELECT NotificationId,
+                    [New DrugResistanceProfile] AS [DrugResistanceProfile],
+                    [New Species] AS [Species]
+                FROM [dbo].[vwChangesToDRPSpecies]";
 
             using (var connection = new SqlConnection(_reportingDbConnectionString))
             {


### PR DESCRIPTION
Use vwChangesToDRPSpecies view instead of Reusable notifications table

<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
