### PR TITLE
NTBS-910: Fix css sourced network 404 issues

### DIFF
--- a/ntbs-service/Pages/Shared/_Footer.cshtml
+++ b/ntbs-service/Pages/Shared/_Footer.cshtml
@@ -35,7 +35,7 @@
                 </span>
             </div>
             <div class="govuk-footer__meta-item footer-copyright-message-container">
-                <a class="govuk-footer__link govuk-footer__copyright-logo footer-copyright-message" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+                <a class="govuk-footer__link footer-copyright-message" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
             </div>
         </div>
     </div>

--- a/ntbs-service/wwwroot/css/fonts/_govukFontHandler.scss
+++ b/ntbs-service/wwwroot/css/fonts/_govukFontHandler.scss
@@ -1,0 +1,5 @@
+﻿@function govuk-font-handler($filename) {
+  @return none;
+}
+
+$govuk-font-url-function: 'govuk-font-handler';

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -1,4 +1,6 @@
 ﻿@import "./reset.scss";
+// Need to override fontHandler to prevent 404s when looking for the GDS specific fonts
+@import "./fonts/govukFontHandler.scss";
 // We're importing the raw scss instaed of a packaged css bundle since we're using some of the dynamic elements ourselves (colour variables, functions etc)
 @import "../../node_modules/nhsuk-frontend/packages/nhsuk.scss";
 // Govuk css - needed for things like conditionally revealed radios sections


### PR DESCRIPTION
## Description
Add govuk font handler to prevent gets to font woff files which we aren't using.
Remove govuk-footer class with crest background preventing unnecessary get (and 404).

## Checklist:
- [X] Automated tests are passing locally.
### Accessibility testing
- [X] Check the feature looks and works correctly in IE11
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
