### PR TITLE
NTBS-590: Add full width background for drafts on landing page

### DIFF
--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -1,6 +1,5 @@
 ﻿@page
 @using ntbs_service.Helpers
-@using ntbs_service.Models.Enums
 @model IndexModel
 @{
     ViewData["Title"] = "Home page";
@@ -22,11 +21,11 @@
         <div>
             <div class="flex-container">
                 <h2 class="heading"> Alerts </h2>
-                <label nhs-label-type="Standard" for="tb-service-filter-dropdown" classes="filter-label" >
+                <label nhs-label-type="Standard" for="tb-service-filter-dropdown" classes="filter-label">
                     Filter by TB Service
                 </label>
-                <select id="tb-service-filter-dropdown" nhs-select-type="Standard" ref="tbService" asp-items="Model.TbServices" 
-                    v-on:change="updateTable" classes="filter-dropdown">
+                <select id="tb-service-filter-dropdown" nhs-select-type="Standard" ref="tbService" asp-items="Model.TbServices"
+                        v-on:change="updateTable" classes="filter-dropdown">
                     <option> Show all </option>
                 </select>
             </div>
@@ -44,7 +43,7 @@
                     </nhs-table-item>
                     <nhs-table-item>
                         @Html.DisplayNameFor(model => model.Alerts[0].CaseManagerFullName)
-                        <br />
+                        <br/>
                         @Html.DisplayNameFor(model => model.Alerts[0].TbServiceName)
                     </nhs-table-item>
                     <nhs-table-item>
@@ -52,15 +51,15 @@
                     </nhs-table-item>
                 </nhs-table-head>
                 <nhs-table-body>
-                    @foreach (var item in Model.Alerts) 
+                    @foreach (var item in Model.Alerts)
                     {
                         <nhs-table-body-row id="alert-@item.AlertId" v-if="TbServiceCode === '@item.TbServiceCode' || TbServiceCode === 'Show all'">
                             <nhs-table-item>
-                                @if(item.NotificationId != null) 
+                                @if (item.NotificationId != null)
                                 {
                                     var overviewPageLink = RouteHelper.GetNotificationPath(item.NotificationId.GetValueOrDefault(), NotificationSubPaths.Overview);
                                     <a href="@overviewPageLink" class="govuk-link govuk-link--no-visited-state">
-                                        @Html.DisplayFor(_ => item.NotificationId) 
+                                        @Html.DisplayFor(_ => item.NotificationId)
                                     </a>
                                 }
                             </nhs-table-item>
@@ -81,7 +80,7 @@
                                 @item.TbServiceName
                             </nhs-table-item>
                             <nhs-table-item>
-                                @if(!item.NotDismissable)
+                                @if (!item.NotDismissable)
                                 {
                                     <form method="post" action="@RouteHelper.GetAlertPath(@item.AlertId, AlertSubPaths.Dismiss)">
                                         @Html.AntiForgeryToken()
@@ -97,47 +96,53 @@
             </nhs-table>
         </div>
     </tb-service-filtered-alerts>
+</nhs-width-container>
 
-    <h2 class="heading"> Draft notifications </h2>
+<div class="draft-notifications-container">
+    <nhs-width-container container-width="Standard">
+        <h2 class="heading"> Draft notifications </h2>
 
-    <nhs-table class="notifications-table">
-        <nhs-table-head>
-            <nhs-table-item>
-                @Html.DisplayNameFor(model => model.DraftNotifications[0].NotificationId)
-            </nhs-table-item>
-            <nhs-table-item>
-                @Html.DisplayNameFor(model => model.DraftNotifications[0].FormattedCreationDate)
-            </nhs-table-item>
-            <nhs-table-item>
-                @Html.DisplayNameFor(model => model.DraftNotifications[0].TBServiceName)
-            </nhs-table-item>
-            <nhs-table-item>
-                @Html.DisplayNameFor(model => model.DraftNotifications[0].Episode.CaseManagerName)
-            </nhs-table-item>
-        </nhs-table-head>
-        <nhs-table-body>
-            @foreach (var item in Model.DraftNotifications) 
-            {
-                <nhs-table-body-row>
-                    <nhs-table-item>
-                        <a href="@RouteHelper.GetNotificationPath(item.NotificationId, NotificationSubPaths.Overview)" class="govuk-link govuk-link--no-visited-state">
-                            @Html.DisplayFor(_ => item.NotificationId)
-                        </a>
-                    </nhs-table-item>
-                    <nhs-table-item>
-                        @Html.DisplayFor(_ => item.FormattedCreationDate)
-                    </nhs-table-item>
-                    <nhs-table-item>
-                        @Html.DisplayFor(_ => item.TBServiceName)
-                    </nhs-table-item>
-                    <nhs-table-item>
-                        @Html.DisplayFor(_ => item.Episode.CaseManagerName)
-                    </nhs-table-item>
-                </nhs-table-body-row>
-            }
-        </nhs-table-body>
-    </nhs-table>
+        <nhs-table class="notifications-table">
+            <nhs-table-head>
+                <nhs-table-item>
+                    @Html.DisplayNameFor(model => model.DraftNotifications[0].NotificationId)
+                </nhs-table-item>
+                <nhs-table-item>
+                    @Html.DisplayNameFor(model => model.DraftNotifications[0].FormattedCreationDate)
+                </nhs-table-item>
+                <nhs-table-item>
+                    @Html.DisplayNameFor(model => model.DraftNotifications[0].TBServiceName)
+                </nhs-table-item>
+                <nhs-table-item>
+                    @Html.DisplayNameFor(model => model.DraftNotifications[0].Episode.CaseManagerName)
+                </nhs-table-item>
+            </nhs-table-head>
+            <nhs-table-body>
+                @foreach (var item in Model.DraftNotifications)
+                {
+                    <nhs-table-body-row>
+                        <nhs-table-item>
+                            <a href="@RouteHelper.GetNotificationPath(item.NotificationId, NotificationSubPaths.Overview)" class="govuk-link govuk-link--no-visited-state">
+                                @Html.DisplayFor(_ => item.NotificationId)
+                            </a>
+                        </nhs-table-item>
+                        <nhs-table-item>
+                            @Html.DisplayFor(_ => item.FormattedCreationDate)
+                        </nhs-table-item>
+                        <nhs-table-item>
+                            @Html.DisplayFor(_ => item.TBServiceName)
+                        </nhs-table-item>
+                        <nhs-table-item>
+                            @Html.DisplayFor(_ => item.Episode.CaseManagerName)
+                        </nhs-table-item>
+                    </nhs-table-body-row>
+                }
+            </nhs-table-body>
+        </nhs-table>
+    </nhs-width-container>
+</div>
 
+<nhs-width-container container-width="Standard">
     <h2 class="heading"> Recent notifications </h2>
     <nhs-table class="notifications-table">
         <nhs-table-head>
@@ -155,7 +160,8 @@
             </nhs-table-item>
         </nhs-table-head>
         <nhs-table-body>
-            @foreach (var item in Model.RecentNotifications) {
+            @foreach (var item in Model.RecentNotifications)
+            {
                 <nhs-table-body-row>
                     <nhs-table-item>
                         <a href="@RouteHelper.GetNotificationPath(item.NotificationId, NotificationSubPaths.Overview)" class="govuk-link--no-visited-state">

--- a/ntbs-service/Pages/LabResults/Index.cshtml
+++ b/ntbs-service/Pages/LabResults/Index.cshtml
@@ -40,7 +40,7 @@
     </nhs-details>
 </nhs-width-container>
 
-<div class="search-results-section" id="search-results-section">
+<div class="unmatched-results-container">
 <nhs-width-container container-width="Standard">
 
 @if (!Model.UnmatchedSpecimens.Any())

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -36,7 +36,4 @@
   <ItemGroup>
     <ProjectReference Include="..\EFAuditer\EFAuditer.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <_ContentIncludedByDefault Remove="Pages\Admin\UsersSync.cshtml" />
-  </ItemGroup>
 </Project>

--- a/ntbs-service/wwwroot/css/_colors.scss
+++ b/ntbs-service/wwwroot/css/_colors.scss
@@ -6,6 +6,7 @@ $secondary-button-focus: #384854;
 $button-drop-shadow: #003317;
 $grey: #999999;
 $lighter-grey: #CCCCCC;
+$shaded-background-color: #F0F4F5;
 
 $banner-header--draft: #dcc2c6;
 $banner-border--draft: #8c3a47;

--- a/ntbs-service/wwwroot/css/labResults.scss
+++ b/ntbs-service/wwwroot/css/labResults.scss
@@ -57,3 +57,11 @@
     flex-basis: 100%;
   }
 }
+
+.unmatched-results-container {
+  background: #F0F4F5;
+  width: 100%;
+  overflow: auto;
+  padding-top: 24px;
+  margin-bottom: 24px;
+}

--- a/ntbs-service/wwwroot/css/labResults.scss
+++ b/ntbs-service/wwwroot/css/labResults.scss
@@ -1,3 +1,5 @@
+@import "./_colors.scss";
+
 .lab-results-radio-container {
   width: 60px;
   display: flex;
@@ -59,7 +61,7 @@
 }
 
 .unmatched-results-container {
-  background: #F0F4F5;
+  background: $shaded-background-color;
   width: 100%;
   overflow: auto;
   padding-top: 24px;

--- a/ntbs-service/wwwroot/css/search.scss
+++ b/ntbs-service/wwwroot/css/search.scss
@@ -1,4 +1,5 @@
 @import "./breakpoints";
+@import "./_colors.scss";
 
 .clear-search-button-container {
     display: flex;
@@ -113,7 +114,7 @@
 }
 
 .search-results-section {
-    background: #F0F4F5;
+    background: $shaded-background-color;
     width: 100%;
     overflow: auto;
     padding-top: 24px;

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -230,3 +230,11 @@ body {
 .nhsuk-panel-with-label__label {
   background-color: #002776;
 }
+
+.draft-notifications-container {
+  background: #F0F4F5;
+  width: 100%;
+  overflow: auto;
+  padding-top: 24px;
+  margin-bottom: 24px;
+}

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -232,7 +232,7 @@ body {
 }
 
 .draft-notifications-container {
-  background: #F0F4F5;
+  background: $shaded-background-color;
   width: 100%;
   overflow: auto;
   padding-top: 24px;

--- a/ntbs-service/wwwroot/css/table.scss
+++ b/ntbs-service/wwwroot/css/table.scss
@@ -1,6 +1,8 @@
+@import "./_colors.scss";
+
 .table-row-form {
     padding-top: 20px;
-    background: #f0f4f5;
+    background: $shaded-background-color;
     width: 100%;
     margin-bottom: 20px;
 }

--- a/ntbs-service/wwwroot/css/testResults.scss
+++ b/ntbs-service/wwwroot/css/testResults.scss
@@ -1,12 +1,11 @@
 @import "./breakpoints";
 @import "./colors.scss";
 
-
 .notification-lab-results-summary {
     padding: 10px 5px 10px 5px;
     border: 2px solid black;
     margin-bottom: 20px;
-    background-color: #f0f4f5;
+    background-color: $shaded-background-color;
 }
 
 .notification-specimen-summary {
@@ -27,7 +26,7 @@
 }
 
 .section-header-with-background {
-    background: #f0f4f5;
+    background: $shaded-background-color;
     width: 100%;
     padding-top: 5px;
     padding-bottom: 5px;


### PR DESCRIPTION
## Description
Adjust selectors to be more page specific and add styling for a full width container for the draft section on the landing page.

## Checklist:
- [X] Automated tests are passing locally.
### Accessibility testing
- [X] Test in small window (imitating small screen)
- [X] Check the feature looks and works correctly in IE11
- [X] Zoom page to 400% - content still visible?
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
