### PR TITLE
NTBS-400 persist TbServiceCode and CaseManagerUsername on treatment events

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -61,7 +61,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             if (RowId != null)
             {
                 TreatmentEvent = Notification.TreatmentEvents.SingleOrDefault(r => r.TreatmentEventId == RowId.Value);
-                if (TreatmentEvent == null)
+                if (TreatmentEvent == null || !TreatmentEvent.IsEditable)
                 {
                     return NotFound();
                 }

--- a/ntbs-service/Pages/Notifications/Edit/Items/_TreatmentEvent.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_TreatmentEvent.cshtml
@@ -14,6 +14,8 @@
 
         <form method="post" autocomplete="off">
             <input type="hidden" asp-for="TreatmentEvent.TreatmentOutcomeId" />
+            <input type="hidden" asp-for="TreatmentEvent.CaseManagerUsername" />
+            <input type="hidden" asp-for="TreatmentEvent.TbServiceCode" />
 
             <nhs-grid-row>
                 <nhs-grid-column grid-column-width="Full">


### PR DESCRIPTION
Added hidden inputs for TbServiceCode and CaseManagerUsername on treatment event page so that the data is persisted through saves.

## Checklist:
- [X] Automated tests are passing locally.