### PR TITLE
NTBS-772: Use a coalesced view property for risk factors

### DIFF
--- a/ntbs-service/Models/Entities/RiskFactorDetails.cs
+++ b/ntbs-service/Models/Entities/RiskFactorDetails.cs
@@ -1,4 +1,5 @@
-﻿using EFAuditer;
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using EFAuditer;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Enums;
 
@@ -19,6 +20,45 @@ namespace ntbs_service.Models.Entities
         public bool? IsCurrent { get; set; }
         public bool? InPastFiveYears { get; set; }
         public bool? MoreThanFiveYearsAgo { get; set; }
+
+        [NotMapped]
+        public bool IsCurrentView
+        {
+            get
+            {
+                return IsCurrent ?? false;
+            }
+            set
+            {
+                IsCurrent = value;
+            }
+        }
+        
+        [NotMapped]
+        public bool InPastFiveYearsView
+        {
+            get
+            {
+                return InPastFiveYears ?? false;
+            }
+            set
+            {
+                InPastFiveYears = value;
+            }
+        }
+        
+        [NotMapped]
+        public bool MoreThanFiveYearsAgoView
+        {
+            get
+            {
+                return MoreThanFiveYearsAgo ?? false;
+            }
+            set
+            {
+                MoreThanFiveYearsAgo = value;
+            }
+        }
 
         string IOwnedEntity.RootEntityType => RootEntities.Notification;
     }

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml
@@ -37,7 +37,7 @@
     <div>
         @{
             var drugsModelIsValid = !Model.IsValid("SocialRiskFactors.RiskFactorDrugs");
-            var drugsViewData = new ViewDataDictionary(this.ViewData) {
+            var drugsViewData = new ViewDataDictionary(ViewData) {
                 { "propertyName", "RiskFactorDrugs" },
                 { "errorState", drugsModelIsValid },
                 { "questionText", "Patient has a history of drug misuse" }

--- a/ntbs-service/Pages/Notifications/Edit/_RiskFactorPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_RiskFactorPartial.cshtml
@@ -28,16 +28,16 @@
                             </nhs-fieldset-legend>
                             <nhs-checkboxes>
                                 <nhs-checkboxes-item>
-                                    <input nhs-input-type="Checkboxes" asp-for="IsCurrent"/>
-                                    <label nhs-label-type="Checkboxes" asp-for="IsCurrent">Current</label>
+                                    <input nhs-input-type="Checkboxes" asp-for="IsCurrentView"/>
+                                    <label nhs-label-type="Checkboxes" asp-for="IsCurrentView">Current</label>
                                 </nhs-checkboxes-item>
                                 <nhs-checkboxes-item>
-                                    <input nhs-input-type="Checkboxes" asp-for="InPastFiveYears"/>
-                                    <label nhs-label-type="Checkboxes" asp-for="InPastFiveYears">In the past 5 years</label>
+                                    <input nhs-input-type="Checkboxes" asp-for="InPastFiveYearsView"/>
+                                    <label nhs-label-type="Checkboxes" asp-for="InPastFiveYearsView">In the past 5 years</label>
                                 </nhs-checkboxes-item>
                                 <nhs-checkboxes-item>
-                                    <input nhs-input-type="Checkboxes" asp-for="MoreThanFiveYearsAgo"/>
-                                    <label nhs-label-type="Checkboxes" asp-for="MoreThanFiveYearsAgo">More than 5 years ago</label>
+                                    <input nhs-input-type="Checkboxes" asp-for="MoreThanFiveYearsAgoView"/>
+                                    <label nhs-label-type="Checkboxes" asp-for="MoreThanFiveYearsAgoView">More than 5 years ago</label>
                                 </nhs-checkboxes-item>
                             </nhs-checkboxes>
                         </nhs-fieldset>


### PR DESCRIPTION
## Description
Backing value now being nullable could not be represented by a checkbox.
Resulting behaviour is tricky to explain concisely, but it was very non-working. Not sure how it got past my manual testing, but it did.
Adding the coalesced property is the neatest solution we could come up with.

## Checklist:
- [X] Automated tests are passing locally.
- [X] Check the feature looks and works correctly in IE11
