### PR TITLE
NTBS-779 remove clinical date warnings for death date

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
@@ -393,7 +393,7 @@
                             var hasDeathDateError = !Model.IsValid("ClinicalDetails.DeathDate");
                             var deathDateGroupState = hasDeathDateError ? Error : Standard;
                         }
-                        <validate-date ref="date6" name="@Html.DisplayNameFor(m => m.ClinicalDetails.DeathDate)" model="ClinicalDetails" property="DeathDate" rank="6" v-model="dates[6]" inline-template>
+                        <validate-date name="@Html.DisplayNameFor(m => m.ClinicalDetails.DeathDate)" model="ClinicalDetails" property="DeathDate" inline-template>
                             <nhs-form-group nhs-form-group-type=@deathDateGroupState>
                                 <nhs-fieldset aria-describedby="postmortem-error" role="group">
                                     <nhs-fieldset-legend nhs-legend-size="Standard">

--- a/ntbs-service/wwwroot/source/Components/DateComparison.ts
+++ b/ntbs-service/wwwroot/source/Components/DateComparison.ts
@@ -13,7 +13,7 @@ const DateComparison = Vue.extend({
         // wait for children to mount
         this.$nextTick(function ()
         {
-            for (let i = this.dates.length; i >= 0; i--) {
+            for (let i = this.dates.length - 1; i >= 1; i--) {
                 this.datechanged(i);
             }
         })

--- a/ntbs-service/wwwroot/source/Components/DateComparison.ts
+++ b/ntbs-service/wwwroot/source/Components/DateComparison.ts
@@ -9,17 +9,26 @@ const DateComparison = Vue.extend({
             dateWarnings: []
         }
     },
+    mounted: function () {
+        // wait for children to mount
+        this.$nextTick(function ()
+        {
+            for (let i = this.dates.length; i >= 0; i--) {
+                this.datechanged(i);
+            }
+        })
+    },
     computed: {
         filteredDateWarnings: function () {
             return this.dateWarnings.filter((i: any) => i);
         }
-
     },
     methods: {
         datechanged: function (rank: any) {
-            var numberOfDates = this.dates.length;
-            var currentIndex = parseInt(rank, 10);
-            var currentDate = this.dates[currentIndex];
+            let i;
+            const numberOfDates = this.dates.length;
+            const currentIndex = parseInt(rank, 10);
+            const currentDate = this.dates[currentIndex];
 
             if (!currentDate) {
                 this.clearWarning(currentIndex, numberOfDates);
@@ -31,8 +40,8 @@ const DateComparison = Vue.extend({
                 return;
             }
 
-            var lowerDateIndex = currentIndex - 1;
-            for (var i = 0; i <= lowerDateIndex; i++) {
+            let lowerDateIndex = currentIndex - 1;
+            for (i = 0; i <= lowerDateIndex; i++) {
                 // We clear this so the warning is shown with respect to current date
                 this.unsetMatchingWarning(i, currentIndex);
             }
@@ -53,8 +62,8 @@ const DateComparison = Vue.extend({
                 lowerDateIndex--;
             }
 
-            var higherDateIndex = currentIndex + 1;
-            for (var i = higherDateIndex; i < numberOfDates; i++) {
+            let higherDateIndex = currentIndex + 1;
+            for (i = higherDateIndex; i < numberOfDates; i++) {
                 // We clear this so the warning is shown with respect to current date
                 this.unsetMatchingWarning(i, currentIndex);
             }
@@ -81,7 +90,7 @@ const DateComparison = Vue.extend({
             if (this.dateWarnings[currentIndex]) {
                 this.$set(this.dateWarnings, currentIndex, null);
             }
-            for (var i = 0; i < numberOfDates; i++) {
+            for (let i = 0; i < numberOfDates; i++) {
                 if (i === currentIndex) {
                     continue;
                 }

--- a/ntbs-service/wwwroot/source/Components/DateComparison.ts
+++ b/ntbs-service/wwwroot/source/Components/DateComparison.ts
@@ -13,7 +13,7 @@ const DateComparison = Vue.extend({
         // wait for children to mount
         this.$nextTick(function ()
         {
-            for (let i = this.dates.length - 1; i >= 1; i--) {
+            for (let i = 0; i < this.dates.length; i++) {
                 this.datechanged(i);
             }
         })


### PR DESCRIPTION
Also make the clinical date warnings display on mount

## Checklist:
- [X] Automated tests are passing locally.

### Accessibility testing
- [X] Check the feature looks and works correctly in IE11
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)) -- Currently there is no form label associated with the note at the bottom of the page (separate to this ticket). I think this was implemented by @ffarmanov but I can't quite remember, is this on purpose though?
