### PR TITLE
Ntbs 747 allow 3 3 4 format for search

### DIFF
--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -53,7 +53,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -102,7 +102,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -131,7 +131,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.LATE_DOB_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -168,7 +168,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var siteExpanders = document.QuerySelectorAll(".disease-sites");
@@ -184,7 +184,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(Utilities.CLINICAL_NOTIFICATION_EXTRA_PULMONARY_ID);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var siteExpanders = document.QuerySelectorAll(".disease-sites");
@@ -198,7 +198,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -228,7 +228,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -252,7 +252,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -279,7 +279,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -347,7 +347,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -526,7 +526,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.MDR_DETAILS_EXIST);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -552,7 +552,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -598,7 +598,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ComorbidityPageTests.cs
@@ -21,7 +21,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -56,7 +56,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -83,7 +83,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -111,7 +111,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string description = "Other Therapy";
             var formData = new Dictionary<string, string>
@@ -171,7 +171,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -197,7 +197,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/DeletePageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DeletePageTests.cs
@@ -54,7 +54,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DELETE_NO_DESCRIPTION;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -78,7 +78,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DELETE_WITH_DESCRIPTION;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -103,7 +103,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DELETE_WITH_DESCRIPTION;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {

--- a/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
@@ -62,7 +62,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DENOTIFY_NO_DESCRIPTION;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string denotifyDateDay = "1";
             const string denotifyDateMonth = "1";
@@ -97,7 +97,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DENOTIFY_WITH_DESCRIPTION;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string denotifyDateDay = "1";
             const string denotifyDateMonth = "1";
@@ -134,7 +134,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string denotifyDateDay = "0";
             const string denotifyDateMonth = "1";
@@ -166,7 +166,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string denotifyDateDay = "1";
             const string denotifyDateMonth = "1";
@@ -198,7 +198,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string denotifyDateDay = "1";
             const string denotifyDateMonth = "1";
@@ -229,7 +229,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string denotifyDateDay = "1";
             const string denotifyDateMonth = "1";
@@ -259,7 +259,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string denotifyDateDay = "1";
             const string denotifyDateMonth = "1";

--- a/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
@@ -43,7 +43,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -68,7 +68,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -94,7 +94,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -116,7 +116,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -141,7 +141,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -166,7 +166,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -189,7 +189,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -212,7 +212,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -240,7 +240,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -266,7 +266,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -289,7 +289,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -312,7 +312,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_WITH_TBSERVICE);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -356,7 +356,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -386,7 +386,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/MDRDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/MDRDetailsPageTests.cs
@@ -20,7 +20,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -44,7 +44,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -71,7 +71,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -102,7 +102,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -137,7 +137,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -170,7 +170,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DRAFT_ID);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -277,7 +277,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -304,7 +304,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/ManualTestResultEditPagesTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ManualTestResultEditPagesTests.cs
@@ -60,7 +60,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.DRAFT_ID;
             var url = GetPathForId(NotificationSubPaths.AddManualTestResult, notificationId);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -132,7 +132,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_MANUAL_TESTS;
             var editUrl = GetCurrentPathForId(notificationId) + TEST_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -170,7 +170,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_MANUAL_TESTS;
             var editUrl = GetCurrentPathForId(notificationId) + TEST_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -197,7 +197,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_MANUAL_TESTS;
             var editUrl = GetCurrentPathForId(notificationId) + TEST_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -227,7 +227,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_MANUAL_TESTS;
             var editUrl = GetCurrentPathForId(notificationId) + TEST_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -270,7 +270,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_MANUAL_TESTS;
             var editUrl = GetCurrentPathForId(notificationId) + TEST_TO_DELETE_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string> { };

--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -148,7 +148,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             var dismissPageRoute = "/Alerts/20001/Dismiss?Page=Overview";
             Assert.NotNull(document.QuerySelector("#alert-20001"));
 
@@ -158,7 +158,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Assert
             Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
             Assert.Contains(GetRedirectLocation(result), url);
-            var reloadedDocument = await GetDocumentForUrl(GetRedirectLocation(result));
+            var reloadedDocument = await GetDocumentForUrlAsync(GetRedirectLocation(result));
             Assert.Null(reloadedDocument.QuerySelector("#alert-20001"));
         }
 
@@ -167,7 +167,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFICATION_DATE_TODAY);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             
             // Assert
             Assert.Null(document.QuerySelector("#new-linked-notification-button"));
@@ -178,7 +178,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFICATION_DATE_OVER_YEAR_AGO);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             
             // Assert
             Assert.NotNull(document.QuerySelector("#new-linked-notification-button"));
@@ -189,7 +189,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             
             Assert.NotNull(document.QuerySelector("#print-notification-overview-button"));
         }
@@ -199,7 +199,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.DENOTIFIED_ID);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             Assert.Contains("Other - a great reason", document.QuerySelector("#overview-denotification-reason").TextContent);
         }
         
@@ -208,7 +208,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             Assert.Null(document.QuerySelector("#overview-denotification-reason"));
         }
         
@@ -237,7 +237,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(Utilities.NOTIFIED_ID);
             
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             
             // Assert
             Assert.NotNull(document.QuerySelector($"#{expectedAnchorString}"));

--- a/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PatientPageTests.cs
@@ -71,7 +71,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -106,7 +106,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -132,7 +132,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -165,7 +165,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             const string givenName = "Test";
             const string familyName = "User";
@@ -283,7 +283,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(pageNotificationId);
 
             // Act
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             // Assert
             Assert.False(initialDocument.GetElementById("nhs-number-warning").ClassList.Contains("hidden"));
@@ -407,7 +407,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -440,7 +440,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/PreviousHistoryPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/PreviousHistoryPageTests.cs
@@ -22,7 +22,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -46,7 +46,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -72,7 +72,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/SocialContextAddressEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/SocialContextAddressEditPageTests.cs
@@ -58,7 +58,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.DRAFT_ID;
             var url = GetPathForId(NotificationSubPaths.AddSocialContextAddress, notificationId);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -134,7 +134,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_ADDRESSES;
             var editUrl = GetCurrentPathForId(notificationId) + ADDRESS_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -166,7 +166,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_ADDRESSES;
             var editUrl = GetCurrentPathForId(notificationId) + ADDRESS_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -208,7 +208,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_ADDRESSES;
             var editUrl = GetCurrentPathForId(notificationId) + ADDRESS_TO_DELETE_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string> { };
@@ -253,7 +253,7 @@ namespace ntbs_integration_tests.NotificationPages
             const int id = Utilities.NOTIFIED_ID;
             var notificationSubPath = NotificationSubPaths.EditSocialContextAddresses;
             var url = GetPathForId(notificationSubPath, id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Act
             var result = await Client.SendPostFormWithData(document, null, url);
@@ -272,7 +272,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetPathForId(notificationSubPath, id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, notificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/SocialContextVenueEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/SocialContextVenueEditPageTests.cs
@@ -58,7 +58,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.DRAFT_ID;
             var url = GetPathForId(NotificationSubPaths.AddSocialContextVenue, notificationId);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -135,7 +135,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_VENUES;
             var editUrl = GetCurrentPathForId(notificationId) + VENUE_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -177,7 +177,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_VENUES;
             var editUrl = GetCurrentPathForId(notificationId) + VENUE_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -223,7 +223,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_VENUES;
             var editUrl = GetCurrentPathForId(notificationId) + VENUE_TO_DELETE_ID;
-            var editDocument = await GetDocumentForUrl(editUrl);
+            var editDocument = await GetDocumentForUrlAsync(editUrl);
 
             // Act
             var formData = new Dictionary<string, string> { };
@@ -268,7 +268,7 @@ namespace ntbs_integration_tests.NotificationPages
             const int id = Utilities.NOTIFIED_ID;
             var notificationSubPath = NotificationSubPaths.EditSocialContextVenues;
             var url = GetPathForId(notificationSubPath, id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Act
             var result = await Client.SendPostFormWithData(document, null, url);
@@ -287,7 +287,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetPathForId(notificationSubPath, id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, notificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/SocialRiskFactorPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/SocialRiskFactorPageTests.cs
@@ -22,7 +22,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -45,7 +45,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/TestResultsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TestResultsPageTests.cs
@@ -54,7 +54,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -78,7 +78,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
@@ -21,7 +21,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.DRAFT_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -44,7 +44,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -67,7 +67,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -106,7 +106,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -165,7 +165,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -211,7 +211,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -251,7 +251,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -333,7 +333,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -358,7 +358,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(id);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var overviewLink = RouteHelper.GetNotificationOverviewPathWithSectionAnchor(id, NotificationSubPath);

--- a/ntbs-integration-tests/NotificationPages/TreatmentEventsEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TreatmentEventsEditPageTests.cs
@@ -133,7 +133,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(Utilities.NOTIFICATION_WITH_TREATMENT_EVENTS);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var treatmentTable = document.QuerySelector("#treatment-events");
@@ -160,7 +160,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_FOR_ADD_TREATMENT_RESTART;
             var url = GetPathForId(NotificationSubPaths.AddTreatmentEvent, notificationId);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             const string noteText = "Hello is it me you're looking for";
 
             // Act
@@ -176,7 +176,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             result.AssertRedirectTo(GetPathForId(NotificationSubPaths.EditTreatmentEvents, notificationId));
-            var treatmentEventsDocument = await GetDocumentForUrl(GetRedirectLocation(result));
+            var treatmentEventsDocument = await GetDocumentForUrlAsync(GetRedirectLocation(result));
             var treatmentEventRows = treatmentEventsDocument.QuerySelectorAll("#treatment-events tbody tr");
             var row = treatmentEventRows.First();
 
@@ -192,7 +192,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_FOR_ADD_TREATMENT_OUTCOME;
             var url = GetPathForId(NotificationSubPaths.AddTreatmentEvent, notificationId);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             const string noteText = "I can see it in your smile";
 
             // Act
@@ -210,7 +210,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             result.AssertRedirectTo(GetPathForId(NotificationSubPaths.EditTreatmentEvents, notificationId));
-            var treatmentEventsDocument = await GetDocumentForUrl(GetRedirectLocation(result));
+            var treatmentEventsDocument = await GetDocumentForUrlAsync(GetRedirectLocation(result));
             var treatmentEventRows = treatmentEventsDocument.QuerySelectorAll("#treatment-events tbody tr");
             Assert.Single(treatmentEventRows);
             var row = treatmentEventRows.First();
@@ -233,7 +233,7 @@ namespace ntbs_integration_tests.NotificationPages
             const string noteTargetValue = "I can see it in your eyes";
 
             var url = GetPathForId(NotificationSubPaths.EditTreatmentEvent(treatmentEventId), notificationId);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
             var preEditRow = document.QuerySelector($"#treatment-event-{EDIT_TREATMENT_EVENT_ID}");
             Assert.NotNull(preEditRow);
             Assert.DoesNotContain(noteTargetValue, preEditRow.TextContent);
@@ -252,7 +252,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             result.AssertRedirectTo(GetPathForId(NotificationSubPaths.EditTreatmentEvents, notificationId));
-            var treatmentEventsDocument = await GetDocumentForUrl(GetRedirectLocation(result));
+            var treatmentEventsDocument = await GetDocumentForUrlAsync(GetRedirectLocation(result));
 
             var treatmentRestartWithNoteRow = treatmentEventsDocument.QuerySelector($"#treatment-event-{treatmentEventId}");
             Assert.NotNull(treatmentRestartWithNoteRow);
@@ -269,7 +269,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFICATION_WITH_TREATMENT_EVENTS;
             var url = GetPathForId(NotificationSubPaths.EditTreatmentEvent(DELETE_TREATMENT_EVENT_ID), notificationId);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Act
             var formData = new Dictionary<string, string> { };
@@ -277,7 +277,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             result.AssertRedirectTo(GetPathForId(NotificationSubPaths.EditTreatmentEvents, notificationId));
-            var treatmentEventsDocument = await GetDocumentForUrl(GetRedirectLocation(result));
+            var treatmentEventsDocument = await GetDocumentForUrlAsync(GetRedirectLocation(result));
 
             Assert.Null(treatmentEventsDocument.GetElementById($"social-context-venue-{DELETE_TREATMENT_EVENT_ID}"));
         }
@@ -288,7 +288,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFIED_ID;
             var url = GetPathForId(NotificationSubPaths.AddTreatmentEvent, notificationId);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -321,7 +321,7 @@ namespace ntbs_integration_tests.NotificationPages
             // Arrange
             const int notificationId = Utilities.NOTIFIED_ID;
             var url = GetPathForId(NotificationSubPaths.AddTreatmentEvent, notificationId);
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Act
             var formData = new Dictionary<string, string>
@@ -395,7 +395,7 @@ namespace ntbs_integration_tests.NotificationPages
             var url = GetCurrentPathForId(Utilities.NOTIFICATION_WITH_TREATMENT_EVENTS);
 
             // Act
-            var document = await GetDocumentForUrl(url);
+            var document = await GetDocumentForUrlAsync(url);
 
             // Assert
             var treatmentTable = document.QuerySelector("#treatment-events");

--- a/ntbs-integration-tests/SearchPage/SearchPageTests.cs
+++ b/ntbs-integration-tests/SearchPage/SearchPageTests.cs
@@ -39,7 +39,7 @@ namespace ntbs_integration_tests.SearchPage
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
-            resultDocument.AssertErrorMessage("id", "Id filter can only contain digits 0-9 and the symbol -");
+            resultDocument.AssertErrorMessage("id", "Id filter can only contain digits 0-9, the symbol - and spaces");
             resultDocument.AssertErrorMessage("family-name", "Family name can only contain letters and the symbols ' - . ,");
             resultDocument.AssertErrorMessage("given-name", "Given name can only contain letters and the symbols ' - . ,");
             resultDocument.AssertErrorMessage("postcode", "Postcode can only contain letters, numbers and the symbols ' - . ,");

--- a/ntbs-integration-tests/TestRunnerBase.cs
+++ b/ntbs-integration-tests/TestRunnerBase.cs
@@ -21,7 +21,7 @@ namespace ntbs_integration_tests
             Client = Factory.CreateClientWithoutRedirects();
         }
 
-        protected async Task<IHtmlDocument> GetDocumentForUrl(string url)
+        protected async Task<IHtmlDocument> GetDocumentForUrlAsync(string url)
         {
             var initialPage = await Client.GetAsync(url);
             return await GetDocumentAsync(initialPage);

--- a/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
@@ -55,7 +56,7 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -77,7 +78,7 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             // Act
             var result = await Client.SendPostFormWithData(initialDocument, null, url);
@@ -93,7 +94,7 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             Assert.Equal("  ", initialDocument.QuerySelector("#banner-tb-service").TextContent);
             Assert.Equal("  ", initialDocument.QuerySelector("#banner-case-manager").TextContent);
@@ -112,7 +113,7 @@ namespace ntbs_integration_tests.TransferPage
             // Assert
             Assert.NotNull(resultDocument.QuerySelector("#return-to-notification"));
             var overviewUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.Overview);
-            var overviewPage = await GetDocumentForUrl(overviewUrl);
+            var overviewPage = await GetDocumentForUrlAsync(overviewUrl);
             Assert.Contains("Abingdon Community Hospital", overviewPage.QuerySelector("#banner-tb-service").TextContent);
             Assert.Contains("TestCase TestManager", overviewPage.QuerySelector("#banner-case-manager").TextContent);
             Assert.Contains("ABINGDON COMMUNITY HOSPITAL", overviewPage.QuerySelector("#overview-hospital-name").TextContent);
@@ -125,12 +126,11 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFICATION_WITH_TRANSFER_REQUEST_TO_ACCEPT;
             var treatmentEventsUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.EditTreatmentEvents);
-            var initialTreatmentEventsPage = await GetDocumentForUrl(treatmentEventsUrl);
-            Assert.Null(initialTreatmentEventsPage.QuerySelector("#treatment-event-1"));
-            Assert.Null(initialTreatmentEventsPage.QuerySelector("#treatment-event-2"));
+            var initialTreatmentEventsPage = await GetDocumentForUrlAsync(treatmentEventsUrl);
+            Assert.Null(initialTreatmentEventsPage.QuerySelector("#treatment-events"));
             
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -140,11 +140,12 @@ namespace ntbs_integration_tests.TransferPage
             // Act
             await Client.SendPostFormWithData(initialDocument, formData, url);
             
-            var reloadedTreatmentEventsPage = await GetDocumentForUrl(treatmentEventsUrl);
+            var reloadedTreatmentEventsPage = await GetDocumentForUrlAsync(treatmentEventsUrl);
             
             // Assert
-            Assert.NotNull(reloadedTreatmentEventsPage.QuerySelector("#treatment-event-1"));
-            Assert.NotNull(reloadedTreatmentEventsPage.QuerySelector("#treatment-event-2"));
+            var reloadedTreatmentEventsTable = reloadedTreatmentEventsPage.QuerySelector("#treatment-events");
+            Assert.Contains("Transfer in", reloadedTreatmentEventsTable.InnerHtml);
+            Assert.Contains("Transfer out", reloadedTreatmentEventsTable.InnerHtml);
         }
         
         [Fact]
@@ -153,7 +154,7 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_TRANSFER_REQUEST_TO_REJECT;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -166,7 +167,7 @@ namespace ntbs_integration_tests.TransferPage
 
             // Assert
             var overviewUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.Overview);
-            var overviewPage = await GetDocumentForUrl(overviewUrl);
+            var overviewPage = await GetDocumentForUrlAsync(overviewUrl);
             Assert.NotNull(overviewPage.QuerySelector(".overview-alerts-container"));
         }
     }

--- a/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
@@ -88,7 +88,7 @@ namespace ntbs_integration_tests.TransferPage
         }
 
         [Fact]
-        public async Task AcceptTransferAlert_SuccessfullyChangesTbServiceOfNotificationAndDismissesAlert()
+        public async Task AcceptTransferAlert_SuccessfullyChangesTbServiceCaseManagerAndHospitalOfNotificationAndDismissesAlert()
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE;
@@ -100,7 +100,9 @@ namespace ntbs_integration_tests.TransferPage
 
             var formData = new Dictionary<string, string>
             {
-                ["AcceptTransfer"] = "true"
+                ["AcceptTransfer"] = "true",
+                ["TargetCaseManagerUsername"] = Utilities.CASEMANAGER_ABINGDON_EMAIL,
+                ["TargetHospitalId"] = Utilities.HOSPITAL_ABINGDON_COMMUNITY_HOSPITAL_ID
             };
 
             // Act
@@ -113,6 +115,7 @@ namespace ntbs_integration_tests.TransferPage
             var overviewPage = await GetDocumentForUrl(overviewUrl);
             Assert.Contains("Abingdon Community Hospital", overviewPage.QuerySelector("#banner-tb-service").TextContent);
             Assert.Contains("TestCase TestManager", overviewPage.QuerySelector("#banner-case-manager").TextContent);
+            Assert.Contains("ABINGDON COMMUNITY HOSPITAL", overviewPage.QuerySelector("#overview-hospital-name").TextContent);
             Assert.Null(overviewPage.QuerySelector("#alert-20003"));
         }
 

--- a/ntbs-integration-tests/TransferPages/RejectTransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/RejectTransferPageTests.cs
@@ -18,16 +18,16 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var overviewUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.Overview);
-            var initialOverviewPage = await GetDocumentForUrl(overviewUrl);
+            var initialOverviewPage = await GetDocumentForUrlAsync(overviewUrl);
             Assert.NotNull(initialOverviewPage.QuerySelector("#alert-20005"));
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             // Act
             await Client.SendPostFormWithData(initialDocument, null, url);
 
             // Assert
-            var resultOverviewPage = await GetDocumentForUrl(overviewUrl);
+            var resultOverviewPage = await GetDocumentForUrlAsync(overviewUrl);
             Assert.Null(resultOverviewPage.QuerySelector("#alert-20005"));
         }
     }

--- a/ntbs-integration-tests/TransferPages/TransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/TransferPageTests.cs
@@ -19,7 +19,7 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_WITH_TBSERVICE;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -45,7 +45,7 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_WITH_TBSERVICE;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
@@ -67,7 +67,7 @@ namespace ntbs_integration_tests.TransferPage
             // Arrange
             const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrl(url);
+            var initialDocument = await GetDocumentForUrlAsync(url);
 
             Assert.NotNull(initialDocument.QuerySelector("#cancel-transfer-button"));
         }

--- a/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
+++ b/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
@@ -93,6 +93,15 @@ namespace ntbs_service_unit_tests.Services
             Assert.Single(result);
             Assert.Equal("1234567890", result.FirstOrDefault().PatientDetails.NhsNumber);
         }
+        
+        [Fact]
+        public void SearchByIdWithSpaces_ReturnsMatchOnNhsNumber()
+        {
+            var result = ((INtbsSearchBuilder)builder.FilterById("123 456 7890")).GetResult().ToList();
+
+            Assert.Single(result);
+            Assert.Equal("1234567890", result.FirstOrDefault().PatientDetails.NhsNumber);
+        }
 
         [Fact]
         public void SearchById_ReturnsEmptyList_WhenNoMatchFound()

--- a/ntbs-service/Models/SearchParameters.cs
+++ b/ntbs-service/Models/SearchParameters.cs
@@ -9,7 +9,7 @@ namespace ntbs_service.Models
     public class SearchParameters
     {
         [Display(Name = "Id filter")]
-        [RegularExpression(ValidationRegexes.NumbersAndHyphenValidation, ErrorMessage = ValidationMessages.NumberAndHyphenFormat)]
+        [RegularExpression(ValidationRegexes.NumbersHyphenAndSpaceValidation, ErrorMessage = ValidationMessages.NumberHyphenAndSpaceFormat)]
         public string IdFilter { get; set; }
         public int? SexId { get; set; }
         public int? CountryId { get; set; }

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -20,7 +20,7 @@
         public const string MinTwoCharacters = "Enter at least 2 characters";
         public const string InvalidCharacter = "Invalid character found in {0}";
         public const string NumberFormat = "{0} can only contain digits 0-9";
-        public const string NumberAndHyphenFormat = "{0} can only contain digits 0-9 and the symbol -";
+        public const string NumberHyphenAndSpaceFormat = "{0} can only contain digits 0-9, the symbol - and spaces";
         public const string PositiveNumbersOnly = "Please enter a positive value";
         public const string YearIfMonthRequired = "Year and month must be provided if a day has been provided";
         public const string YearRequired = "A year must be provided";
@@ -158,7 +158,7 @@
         public const string CharacterValidationWithNumbersForwardSlashExtended = @"[0-9a-zA-Z \/\-,.'`#&+;:$_()\\\[\]=\*\?]+";
         public const string CharacterValidationWithNumbersForwardSlashExtendedWithNewLine = @"[0-9a-zA-Z \/\-,.'`#&+;:$_()\\\[\]=\*\?\n\r]+";
         public const string NumbersValidation = @"[0-9]+";
-        public const string NumbersAndHyphenValidation = @"[0-9\-]+";
+        public const string NumbersHyphenAndSpaceValidation = @"[0-9\- ]+";
         // Taken from https://stackoverflow.com/a/164994/2363767
         public const string PostcodeValidation = @"([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})";
     }

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
@@ -60,14 +60,14 @@
                     <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-radio-accept">
                         <nhs-grid-row>
                             <nhs-grid-column grid-column-width="OneHalf">
-                                <label asp-for="DeclineTransferReason" nhs-label-type="Standard">
+                                <label asp-for="TargetHospitalId" nhs-label-type="Standard">
                                     Hospital
                                 </label>
                                 <select nhs-select-type="Standard" asp-items="Model.Hospitals" asp-for="TargetHospitalId">
                                 </select>
                             </nhs-grid-column>
                             <nhs-grid-column grid-column-width="OneHalf">
-                                <label asp-for="DeclineTransferReason" nhs-label-type="Standard">
+                                <label asp-for="TargetCaseManagerUsername" nhs-label-type="Standard">
                                     Case manager
                                 </label>
                                 <select nhs-select-type="Standard" asp-items="Model.CaseManagers" asp-for="TargetCaseManagerUsername">

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
@@ -51,14 +51,35 @@
                 <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                     <div class="nhsuk-radios__item">
                         <input asp-for="AcceptTransfer" nhs-input-type="Radios" type="radio"
-                            value="true" id="accept-transfer-input" aria-describedby="action-error">
+                            value="true" id="accept-transfer-input" data-aria-controls="conditional-radio-accept" aria-describedby="action-error">
                         <label nhs-label-type="Radios" for="accept-transfer-input">
                             Accept transfer
                         </label>
                     </div>
+                    
+                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-radio-accept">
+                        <nhs-grid-row>
+                            <nhs-grid-column grid-column-width="OneHalf">
+                                <label asp-for="DeclineTransferReason" nhs-label-type="Standard">
+                                    Hospital
+                                </label>
+                                <select nhs-select-type="Standard" asp-items="Model.Hospitals" asp-for="TargetHospitalId">
+                                </select>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneHalf">
+                                <label asp-for="DeclineTransferReason" nhs-label-type="Standard">
+                                    Case manager
+                                </label>
+                                <select nhs-select-type="Standard" asp-items="Model.CaseManagers" asp-for="TargetCaseManagerUsername">
+                                    <option value="" selected> No Case Manager </option>
+                                </select>
+                            </nhs-grid-column>
+                        </nhs-grid-row>
+                    </div>
+                                        
                     <div class="nhsuk-radios__item">
                         <input asp-for="AcceptTransfer" nhs-input-type="Radios" type="radio"
-                            value="false" id="decline-transfer-input" data-aria-controls="conditional-radio" aria-describedby="action-error">
+                            value="false" id="decline-transfer-input" data-aria-controls="conditional-radio-decline" aria-describedby="action-error">
                         <label nhs-label-type="Radios" for="decline-transfer-input">
                             Decline transfer
                         </label>
@@ -69,7 +90,7 @@
                         var commentFormGroupType = hasCommentError ? Error : Standard;
                     }
 
-                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-radio">
+                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-radio-decline">
                         <nhs-form-group nhs-form-group-type="@commentFormGroupType">
                             <label asp-for="DeclineTransferReason" nhs-label-type="Standard">
                                 Provide explanatory comment

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -85,10 +85,13 @@ namespace ntbs_service.Pages.Alerts
 
             var hospitals = await _referenceDataRepository.GetHospitalsByTbServiceCodesAsync(
                 new List<string> { TransferAlert.TbServiceCode });
-            Hospitals = new SelectList(hospitals, nameof(Hospital.HospitalId), nameof(Hospital.Name));
+            Hospitals = new SelectList(hospitals, 
+                nameof(Hospital.HospitalId), 
+                nameof(Hospital.Name));
             var caseManagers = await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(
                 new List<string> {TransferAlert.TbServiceCode});
-            CaseManagers = new SelectList(caseManagers, nameof(Models.Entities.User.Username),
+            CaseManagers = new SelectList(caseManagers, 
+                nameof(Models.Entities.User.Username),
                 nameof(Models.Entities.User.DisplayName));
             TargetCaseManagerUsername = TransferAlert.CaseManagerUsername;
             return Page();

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_HospitalDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_HospitalDetailsOverviewPartial.cshtml
@@ -26,7 +26,7 @@
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneQuarter">
             <div class="notification-details-label"> Hospital </div>
-            <div class="cell-min-height"> @Model.Notification.HospitalName </div>
+            <div class="cell-min-height" id="overview-hospital-name"> @Model.Notification.HospitalName </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneQuarter">
             <div class="notification-details-label"> Case Manager </div>

--- a/ntbs-service/Services/LegacySearchBuilder.cs
+++ b/ntbs-service/Services/LegacySearchBuilder.cs
@@ -28,8 +28,9 @@ namespace ntbs_service.Services
         {
             if (!string.IsNullOrEmpty(id))
             {
+                var idNoWhitespace = id.Replace(" ", "");
                 AppendCondition("(dmg.OldNotificationId = @id OR (n.GroupId = @id AND n.Source = 'LTBR') OR dmg.NhsNumber = @id)");
-                parameters.id = id;
+                parameters.id = idNoWhitespace;
             }
             return this;
         }

--- a/ntbs-service/Services/NtbsSearchBuilder.cs
+++ b/ntbs-service/Services/NtbsSearchBuilder.cs
@@ -24,12 +24,13 @@ namespace ntbs_service.Services
         {
             if (!string.IsNullOrEmpty(id))
             {
-                int.TryParse(id, out int parsedId);
+                var idNoWhitespace = id.Replace(" ", "");
+                int.TryParse(idNoWhitespace, out int parsedId);
                 notificationIQ = notificationIQ.Where(s => s.NotificationId.Equals(parsedId)
-                    || (s.ETSID != null && s.ETSID.Equals(id))
-                    || (s.LTBRID != null && s.LTBRID.Equals(id))
-                    || s.PatientDetails.NhsNumber.Equals(id)
-                    || (s.LTBRPatientId != null && s.LTBRPatientId.Equals(id)));
+                    || (s.ETSID != null && s.ETSID.Equals(idNoWhitespace))
+                    || (s.LTBRID != null && s.LTBRID.Equals(idNoWhitespace))
+                    || s.PatientDetails.NhsNumber.Equals(idNoWhitespace)
+                    || (s.LTBRPatientId != null && s.LTBRPatientId.Equals(idNoWhitespace)));
             }
             return this;
         }


### PR DESCRIPTION
## Description
Allow spaces when searching by id in the frontend but remove them before searching by ids/nhs number

## Checklist:
- [X] Automated tests are passing locally.
- [X] Sanity checked new EF-generated queries for performance.
