### PR TITLE
NTBS-747 allow spaces when esraching by id and nhs number

### DIFF
--- a/ntbs-integration-tests/SearchPage/SearchPageTests.cs
+++ b/ntbs-integration-tests/SearchPage/SearchPageTests.cs
@@ -39,7 +39,7 @@ namespace ntbs_integration_tests.SearchPage
 
             // Assert
             var resultDocument = await GetDocumentAsync(result);
-            resultDocument.AssertErrorMessage("id", "Id filter can only contain digits 0-9 and the symbol -");
+            resultDocument.AssertErrorMessage("id", "Id filter can only contain digits 0-9, the symbol - and spaces");
             resultDocument.AssertErrorMessage("family-name", "Family name can only contain letters and the symbols ' - . ,");
             resultDocument.AssertErrorMessage("given-name", "Given name can only contain letters and the symbols ' - . ,");
             resultDocument.AssertErrorMessage("postcode", "Postcode can only contain letters, numbers and the symbols ' - . ,");

--- a/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
+++ b/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
@@ -93,6 +93,15 @@ namespace ntbs_service_unit_tests.Services
             Assert.Single(result);
             Assert.Equal("1234567890", result.FirstOrDefault().PatientDetails.NhsNumber);
         }
+        
+        [Fact]
+        public void SearchByIdWithSpaces_ReturnsMatchOnNhsNumber()
+        {
+            var result = ((INtbsSearchBuilder)builder.FilterById("123 456 7890")).GetResult().ToList();
+
+            Assert.Single(result);
+            Assert.Equal("1234567890", result.FirstOrDefault().PatientDetails.NhsNumber);
+        }
 
         [Fact]
         public void SearchById_ReturnsEmptyList_WhenNoMatchFound()

--- a/ntbs-service/Models/SearchParameters.cs
+++ b/ntbs-service/Models/SearchParameters.cs
@@ -9,7 +9,7 @@ namespace ntbs_service.Models
     public class SearchParameters
     {
         [Display(Name = "Id filter")]
-        [RegularExpression(ValidationRegexes.NumbersAndHyphenValidation, ErrorMessage = ValidationMessages.NumberAndHyphenFormat)]
+        [RegularExpression(ValidationRegexes.NumbersHyphenAndSpaceValidation, ErrorMessage = ValidationMessages.NumberHyphenAndSpaceFormat)]
         public string IdFilter { get; set; }
         public int? SexId { get; set; }
         public int? CountryId { get; set; }

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -20,7 +20,7 @@
         public const string MinTwoCharacters = "Enter at least 2 characters";
         public const string InvalidCharacter = "Invalid character found in {0}";
         public const string NumberFormat = "{0} can only contain digits 0-9";
-        public const string NumberAndHyphenFormat = "{0} can only contain digits 0-9 and the symbol -";
+        public const string NumberHyphenAndSpaceFormat = "{0} can only contain digits 0-9, the symbol - and spaces";
         public const string PositiveNumbersOnly = "Please enter a positive value";
         public const string YearIfMonthRequired = "Year and month must be provided if a day has been provided";
         public const string YearRequired = "A year must be provided";
@@ -158,7 +158,7 @@
         public const string CharacterValidationWithNumbersForwardSlashExtended = @"[0-9a-zA-Z \/\-,.'`#&+;:$_()\\\[\]=\*\?]+";
         public const string CharacterValidationWithNumbersForwardSlashExtendedWithNewLine = @"[0-9a-zA-Z \/\-,.'`#&+;:$_()\\\[\]=\*\?\n\r]+";
         public const string NumbersValidation = @"[0-9]+";
-        public const string NumbersAndHyphenValidation = @"[0-9\-]+";
+        public const string NumbersHyphenAndSpaceValidation = @"[0-9\- ]+";
         // Taken from https://stackoverflow.com/a/164994/2363767
         public const string PostcodeValidation = @"([Gg][Ii][Rr] 0[Aa]{2})|((([A-Za-z][0-9]{1,2})|(([A-Za-z][A-Ha-hJ-Yj-y][0-9]{1,2})|(([A-Za-z][0-9][A-Za-z])|([A-Za-z][A-Ha-hJ-Yj-y][0-9][A-Za-z]?))))\s?[0-9][A-Za-z]{2})";
     }

--- a/ntbs-service/Services/LegacySearchBuilder.cs
+++ b/ntbs-service/Services/LegacySearchBuilder.cs
@@ -28,8 +28,9 @@ namespace ntbs_service.Services
         {
             if (!string.IsNullOrEmpty(id))
             {
+                var idNoWhitespace = id.Replace(" ", "");
                 AppendCondition("(dmg.OldNotificationId = @id OR (n.GroupId = @id AND n.Source = 'LTBR') OR dmg.NhsNumber = @id)");
-                parameters.id = id;
+                parameters.id = idNoWhitespace;
             }
             return this;
         }

--- a/ntbs-service/Services/NtbsSearchBuilder.cs
+++ b/ntbs-service/Services/NtbsSearchBuilder.cs
@@ -24,12 +24,13 @@ namespace ntbs_service.Services
         {
             if (!string.IsNullOrEmpty(id))
             {
-                int.TryParse(id, out int parsedId);
+                var idNoWhitespace = id.Replace(" ", "");
+                int.TryParse(idNoWhitespace, out int parsedId);
                 notificationIQ = notificationIQ.Where(s => s.NotificationId.Equals(parsedId)
-                    || (s.ETSID != null && s.ETSID.Equals(id))
-                    || (s.LTBRID != null && s.LTBRID.Equals(id))
-                    || s.PatientDetails.NhsNumber.Equals(id)
-                    || (s.LTBRPatientId != null && s.LTBRPatientId.Equals(id)));
+                    || (s.ETSID != null && s.ETSID.Equals(idNoWhitespace))
+                    || (s.LTBRID != null && s.LTBRID.Equals(idNoWhitespace))
+                    || s.PatientDetails.NhsNumber.Equals(idNoWhitespace)
+                    || (s.LTBRPatientId != null && s.LTBRPatientId.Equals(idNoWhitespace)));
             }
             return this;
         }


### PR DESCRIPTION
Description
Allow spaces when searching by id in the frontend but remove them before searching by ids/nhs number

Checklist:
[X] Automated tests are passing locally.
[X] Sanity checked new EF-generated queries for performance.