### PR TITLE
NTBS-865 fix declining transfer alerts for non case managers

### DIFF
--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -26,6 +26,7 @@ namespace ntbs_service.DataAccess
         Task<IList<PHEC>> GetAllPhecs();
         Task<IList<User>> GetAllCaseManagers();
         Task<User> GetCaseManagerByUsernameAsync(string username);
+        Task<User> GetUserByUsernameAsync(string username);
         Task<IList<Hospital>> GetHospitalsByTbServiceCodesAsync(IEnumerable<string> tbServices);
         Task<Hospital> GetHospitalByGuidAsync(Guid guid);
         Task<IList<User>> GetCaseManagersByTbServiceCodesAsync(IEnumerable<string> tbServiceCodes);
@@ -149,6 +150,14 @@ namespace ntbs_service.DataAccess
                 .Include(c => c.CaseManagerTbServices)
                 .ThenInclude(ct => ct.TbService)
                 .Where(u => u.IsCaseManager)
+                .SingleOrDefaultAsync(c => c.Username == username);
+        }
+        
+        public async Task<User> GetUserByUsernameAsync(string username)
+        {
+            return await _context.User
+                .Include(c => c.CaseManagerTbServices)
+                .ThenInclude(ct => ct.TbService)
                 .SingleOrDefaultAsync(c => c.Username == username);
         }
 

--- a/ntbs-service/Migrations/20200217110606_RenameCaseManagerTbServiceString.Designer.cs
+++ b/ntbs-service/Migrations/20200217110606_RenameCaseManagerTbServiceString.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Enums;
@@ -10,9 +11,10 @@ using ntbs_service.Models.Enums;
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20200217110606_RenameCaseManagerTbServiceString")]
+    partial class RenameCaseManagerTbServiceString
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20200217110606_RenameCaseManagerTbServiceString.cs
+++ b/ntbs-service/Migrations/20200217110606_RenameCaseManagerTbServiceString.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class RenameCaseManagerTbServiceString : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "CaseManagerTbServiceString",
+                table: "Alert",
+                newName: "DecliningUserAndTbServiceString");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DecliningUserAndTbServiceString",
+                table: "Alert",
+                newName: "CaseManagerTbServiceString");
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/TransferRejectedAlert.cs
+++ b/ntbs-service/Models/Entities/TransferRejectedAlert.cs
@@ -21,7 +21,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Rejection reason")]
         public string RejectionReason { get; set; }
         [MaxLength(200)]
-        public string CaseManagerTbServiceString { get; set; }
+        public string DecliningUserAndTbServiceString { get; set; }
         public override string Action => "Transfer request rejected";
         public override string ActionLink => RouteHelper.GetNotificationPath(NotificationId.Value, NotificationSubPaths.TransferDeclined);
         public override bool NotDismissable => true;

--- a/ntbs-service/Pages/Alerts/TransferRejected.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRejected.cshtml
@@ -13,9 +13,9 @@
     
     <br>
     
-    @if(Model.TransferRejectedAlert.CaseManagerTbServiceString != null)
+    @if(Model.TransferRejectedAlert.DecliningUserAndTbServiceString != null)
     {
-        <div> @Model.TransferRejectedAlert.CaseManagerTbServiceString: </div>
+        <div> @Model.TransferRejectedAlert.DecliningUserAndTbServiceString: </div>
         <br/>
     }
 

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -150,13 +150,13 @@ namespace ntbs_service.Pages.Alerts
 
         public async Task RejectTransferAndDismissAlertAsync()
         {
-            var user = await _referenceDataRepository.GetCaseManagerByUsernameAsync(User.FindFirstValue(ClaimTypes.Email));
-            var transferRejectedAlert = new TransferRejectedAlert()
+            var user = await _referenceDataRepository.GetUserByUsernameAsync(User.FindFirstValue(ClaimTypes.Email));
+            var transferRejectedAlert = new TransferRejectedAlert
             {
                 CaseManagerUsername = Notification.HospitalDetails.CaseManagerUsername,
                 NotificationId = NotificationId,
-                RejectionReason = DeclineTransferReason,
-                CaseManagerTbServiceString = $"{user.DisplayName}, {TransferAlert.TbServiceName}",
+                RejectionReason = DeclineTransferReason ?? "No reason was given when declining this transfer",
+                DecliningUserAndTbServiceString = $"{user.DisplayName}, {TransferAlert.TbServiceName}",
                 TbServiceCode = Notification.HospitalDetails.TBServiceCode
             };
 

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -155,7 +155,7 @@ namespace ntbs_service.Pages.Alerts
             {
                 CaseManagerUsername = Notification.HospitalDetails.CaseManagerUsername,
                 NotificationId = NotificationId,
-                RejectionReason = DeclineTransferReason ?? "No reason was given when declining this transfer",
+                RejectionReason = DeclineTransferReason ?? "No reason was given when declining this transfer.",
                 DecliningUserAndTbServiceString = $"{user.DisplayName}, {TransferAlert.TbServiceName}",
                 TbServiceCode = Notification.HospitalDetails.TBServiceCode
             };


### PR DESCRIPTION
## Description
Add a function to search userByUsername, fix transfer rejection alerts to use current user (and not current case manager as the user isn't necessarily a case manager).

## Checklist:
- [X] Automated tests are passing locally.
- [X] Sanity checked new EF-generated queries for performance.
### Accessibility testing
- [X] Check the feature looks and works correctly in IE11
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
