### PR TITLE
NTBS-929 fix routing to not use anchor when submitting a notification

### DIFF
--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -117,7 +117,7 @@ namespace ntbs_service.Pages.Notifications
 
             await Service.SubmitNotificationAsync(Notification);
 
-            return RedirectAfterSaveForNotified();
+            return RedirectToPage("/Notifications/Overview", new { NotificationId });
         }           
 
         private IActionResult RedirectAfterSave(bool isBeingSubmitted)


### PR DESCRIPTION
Simple fix to not use RedirectAfterSaveForNotified for submission so that an anchor isn't added to the redirect.