### PR TITLE
NTBS-888 add patient name to the notifications table on home page

### DIFF
--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -93,6 +93,7 @@ namespace ntbs_service.Models.Entities
         #region Display and Formatting methods/fields
 
         public string NotificationStatusString => GetNotificationStatusString();
+        [Display(Name = "Name")]
         public string FullName => string.Join(", ", new[] { PatientDetails.FamilyName?.ToUpper(), PatientDetails.GivenName }.Where(s => !String.IsNullOrEmpty(s)));
         public string SexLabel => PatientDetails.Sex?.Label;
         public string EthnicityLabel => PatientDetails.Ethnicity?.Label;

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -108,6 +108,9 @@
                     @Html.DisplayNameFor(model => model.DraftNotifications[0].NotificationId)
                 </nhs-table-item>
                 <nhs-table-item>
+                    @Html.DisplayNameFor(model => model.DraftNotifications[0].FullName)
+                </nhs-table-item>
+                <nhs-table-item>
                     @Html.DisplayNameFor(model => model.DraftNotifications[0].FormattedCreationDate)
                 </nhs-table-item>
                 <nhs-table-item>
@@ -125,6 +128,9 @@
                             <a href="@RouteHelper.GetNotificationPath(item.NotificationId, NotificationSubPaths.Overview)" class="govuk-link govuk-link--no-visited-state">
                                 @Html.DisplayFor(_ => item.NotificationId)
                             </a>
+                        </nhs-table-item>
+                        <nhs-table-item>
+                            @Html.DisplayFor(_ => item.FullName)
                         </nhs-table-item>
                         <nhs-table-item>
                             @Html.DisplayFor(_ => item.FormattedCreationDate)
@@ -150,6 +156,9 @@
                 @Html.DisplayNameFor(model => model.RecentNotifications[0].NotificationId)
             </nhs-table-item>
             <nhs-table-item>
+                @Html.DisplayNameFor(model => model.RecentNotifications[0].FullName)
+            </nhs-table-item>
+            <nhs-table-item>
                 @Html.DisplayNameFor(model => model.RecentNotifications[0].FormattedNotificationDate)
             </nhs-table-item>
             <nhs-table-item>
@@ -167,6 +176,9 @@
                         <a href="@RouteHelper.GetNotificationPath(item.NotificationId, NotificationSubPaths.Overview)" class="govuk-link--no-visited-state">
                             @Html.DisplayFor(modelItem => item.NotificationId)
                         </a>
+                    </nhs-table-item>
+                    <nhs-table-item>
+                        @Html.DisplayFor(modelItem => item.FullName)
                     </nhs-table-item>
                     <nhs-table-item>
                         @Html.DisplayFor(modelItem => item.FormattedNotificationDate)


### PR DESCRIPTION
## Description
Okay'd with Nancy to just add the column and not fiddle with any min-width styling on columns to stop any wrapping. Idea is to reduce the longer TB service names in the future

## Checklist:
- [X] Automated tests are passing locally.
### Accessibility testing
- [X] Test in small window (imitating small screen) NOTE: On mobile these tables aren't too happy and require scrolling left/right on the table themselves with longer names/tb service names etc. - behaves well on tablet
- [Z] Check the feature looks and works correctly in IE11
- [X] Zoom page to 400% - content still visible?
- [X] Test feature works with keyboard only operation
- [X] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
