### PR TITLE
NTBS-931: QA markups

### DIFF
--- a/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
+++ b/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
@@ -28,9 +28,15 @@ namespace ntbs_service.Models.Entities
         public ExposureSetting? ExposureSetting { get; set; }
         
         [Required]
+        [AssertThat(nameof(ExposureNotificationIdIsDifferentToNotificationId), ErrorMessage = ValidationMessages.RelatedNotificationIdCannotBeSameAsNotificationId)]
         [Display(Name = "NTBS ID")]
         public int? ExposureNotificationId { get; set; }
 
+        public bool ExposureNotificationIdIsDifferentToNotificationId => 
+            !ExposureNotificationId.HasValue 
+            || NotificationId == default 
+            || ExposureNotificationId.Value != NotificationId;
+        
         [MaxLength(150)]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashAndNewLine,

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -114,6 +114,7 @@
         public const string RelationshipToCaseIsRequired = "Please supply details of the relationship to case";
         public const string CaseInUKStatusIsRequired = "Please specify whether the contact was a case in the UK";
         public const string RelatedNotificationIdInvalid = "The NTBS ID does not match an existing ID in the system";
+        public const string RelatedNotificationIdCannotBeSameAsNotificationId = "The NTBS ID cannot be the same as the current notification";
         public const string RelatedNotificationIdMustBeInteger = "The NTBS ID must be an integer";
         #endregion
 

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "../../../Shared/_NotificationLayout.cshtml";
-    ViewData["Title"] = "Notification - M. Bovis - Edit exposure to known case";
+    ViewData["Title"] = "Notification - M. bovis - Edit exposure to known case";
 }
 
 <partial name="_MBovisExposureToKnownCase"/>

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using ntbs_service.DataAccess;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
@@ -99,6 +100,11 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             
             if (int.TryParse(value, out var notificationId))
             {
+                if (notificationId == NotificationId)
+                {
+                    return CreateJsonResponse(new { validationMessage = ValidationMessages.RelatedNotificationIdCannotBeSameAsNotificationId });
+                }
+                
                 var relatedNotification = await GetNotificationAsync(notificationId);
                 if (relatedNotification == null) 
                 {
@@ -120,6 +126,13 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         {
             if (MBovisExposureToKnownCase.ExposureNotificationId != null)
             {
+                if (MBovisExposureToKnownCase.ExposureNotificationId == NotificationId)
+                {
+                    ModelState.AddModelError(
+                        $"{nameof(MBovisExposureToKnownCase)}.{nameof(MBovisExposureToKnownCase.ExposureNotificationId)}",
+                        ValidationMessages.RelatedNotificationIdCannotBeSameAsNotificationId);   
+                }
+
                 var exposureNotification = await NotificationRepository.GetNotificationAsync(
                     MBovisExposureToKnownCase.ExposureNotificationId.Value);
                 if (exposureNotification == null)

--- a/ntbs-service/Pages/Notifications/Edit/Items/NewMBovisExposureToKnownCase.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/NewMBovisExposureToKnownCase.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "../../../Shared/_NotificationLayout.cshtml";
-    ViewData["Title"] = "Notification - M. Bovis - New exposure to known case";
+    ViewData["Title"] = "Notification - M. bovis - New exposure to known case";
 }
 
 <partial name="_MBovisExposureToKnownCase"/>

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
@@ -10,7 +10,7 @@
 
         <partial name="Notifications/Edit/_SinglePageErrorSummaryPartial"/>
 
-        <h2> M. Bovis - @(Model.RowId == null ? "Add new " : "Edit ") exposure to known case </h2>
+        <h2> M. bovis - @(Model.RowId == null ? "Add new " : "Edit ") exposure to known case </h2>
 
         <form method="post" autocomplete="off">
 

--- a/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml
@@ -5,13 +5,13 @@
 
 @{
     Layout = "../../Shared/_NotificationEditLayout.cshtml";
-    ViewData["Title"] = "Notification - M. Bovis - Exposure To Known Cases";
+    ViewData["Title"] = "Notification - M. bovis - Exposure To Known Cases";
     var fullValidation = Model.MBovisDetails.ShouldValidateFull ? "True" : "False";
 }
 
 <partial name="_SinglePageErrorSummaryPartial"/>
 
-<h2> M. Bovis - Exposure to Known Cases </h2>
+<h2> M. bovis - Exposure to Known Cases </h2>
 
 <div>
 

--- a/ntbs-service/Pages/Shared/_MBovisExposureToKnownCaseTable.cshtml
+++ b/ntbs-service/Pages/Shared/_MBovisExposureToKnownCaseTable.cshtml
@@ -41,21 +41,19 @@ else
                     var path = RouteHelper.GetNotificationPath(result.NotificationId, NotificationSubPaths.EditMBovisExposureToKnownCase(result.MBovisExposureToKnownCaseId));
                     <a href="@path" class="notification-edit-link govuk-link--no-visited-state"> Edit </a>
                 }
-
             </div>
+            
             <dl class="notification-overview-details-container">
                 <nhs-grid-row>
-                    <nhs-grid-column grid-column-width="OneHalf">
+                    <nhs-grid-column grid-column-width="OneQuarter">
                         <dt class="notification-details-label"> @Html.DisplayNameFor(_ => result.YearOfExposure) </dt>
                         <dd class="cell-min-height"> @result.YearOfExposure </dd>
                     </nhs-grid-column>
-                    <nhs-grid-column grid-column-width="OneHalf">
+                    <nhs-grid-column grid-column-width="OneQuarter">
                         <dt class="notification-details-label"> @Html.DisplayNameFor(_ => result.ExposureSetting) </dt>
                         <dd class="cell-min-height"> @result.ExposureSetting.GetDisplayName() </dd>
                     </nhs-grid-column>
-                </nhs-grid-row>
-                <nhs-grid-row>
-                    <nhs-grid-column grid-column-width="Full">
+                    <nhs-grid-column grid-column-width="OneHalf">
                         <dt class="notification-details-label"> @Html.DisplayNameFor(_ => result.OtherDetails) </dt>
                         <dd class="cell-min-height"> @result.OtherDetails </dd>
                     </nhs-grid-column>


### PR DESCRIPTION
## Description
Ensure casing of M. bovis is consistent (and to spec).
Collapse m. bovis other cases table into a single body row.
Add validation to prevent adding the current notification as the mbovis exposing notification.

## Checklist:
- [X] Automated tests are passing locally.
- [X] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
