### PR TITLE
Add Sentry and configure it cooperating with Serilog

### DIFF
--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -19,7 +19,6 @@ namespace ntbs_service
             SetUpLogger();
             try
             {
-
                 Log.Information("Building web host");
                 var host = CreateWebHostBuilder(args).Build();
                 using (var scope = host.Services.CreateScope())
@@ -61,7 +60,15 @@ namespace ntbs_service
         public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseSerilog();
+                .UseSentry()
+                .UseSerilog((context, configuration) =>
+                {
+                    configuration.WriteTo.Sentry(s =>
+                    {
+                        s.MinimumBreadcrumbLevel = LogEventLevel.Debug;
+                        s.MinimumEventLevel = LogEventLevel.Warning;
+                    });
+                });
 
         private static void MigrateAppDb(IServiceProvider services)
         {

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -8,9 +8,9 @@
     "ServiceGroupAdPrefix": "Global.NIS.NTBS.Service",
     "BaseDomain": "DC=ntbs,DC=phe,DC=com"
   },
-  "AppConfig" : {
-    "AuditingEnabled" : true,
-    "LegacySearchEnabled" : true
+  "AppConfig": {
+    "AuditingEnabled": true,
+    "LegacySearchEnabled": true
   },
   "LdapConnectionSettings": {
     "AdAddressName": "adds-ntbs.uksouth.cloudapp.azure.com",
@@ -20,5 +20,15 @@
   },
   "MigrationConfig": {
     "DateRangeJobIntervalInMonths": 2
+  },
+  "Sentry": {
+    "Dsn": "https://b3c915cf2d2e4c769073f587052bd39b@sentry.io/2703466",
+    "IncludeRequestPayload": true,
+    "SendDefaultPii": true,
+    "MinimumBreadcrumbLevel": "Debug",
+    "MinimumEventLevel": "Warning",
+    "AttachStackTrace": true,
+    "Debug": true,
+    "DiagnosticsLevel": "Error"
   }
 }

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -27,6 +27,8 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Novell.Directory.Ldap.NETStandard2_0" Version="3.1.0" />
+    <PackageReference Include="Sentry.AspNetCore" Version="2.0.3" />
+    <PackageReference Include="Sentry.Serilog" Version="2.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add a sentry project integration to capture issues long term and not have to rely on logs being present in the containers.
Verified to capture issues in hangfire jobs, too