### PR TITLE
Disable Sentry in CI

### DIFF
--- a/ntbs-integration-tests/NtbsWebApplicationFactory.cs
+++ b/ntbs-integration-tests/NtbsWebApplicationFactory.cs
@@ -19,7 +19,7 @@ namespace ntbs_integration_tests
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             builder.UseSerilog();
-            builder.UseEnvironment("Test");
+            builder.UseEnvironment("CI");
 
             builder.ConfigureServices(services =>
             {

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -55,7 +55,7 @@ namespace ntbs_service
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
-            if (!Env.IsEnvironment("Test"))
+            if (!Env.IsEnvironment("CI"))
             {
                 services.AddHangfire(config =>
                 {
@@ -261,7 +261,7 @@ namespace ntbs_service
 
             app.UseStaticFiles();
 
-            if (!Env.IsEnvironment("Test"))
+            if (!Env.IsEnvironment("CI"))
             {
                 /*
                 Making this conditional is the result of serilog not playing nicely with WebApplicationFactory
@@ -294,7 +294,7 @@ namespace ntbs_service
 
         private void ConfigureHangfire(IApplicationBuilder app)
         {
-            if (Env.IsEnvironment("Test"))
+            if (Env.IsEnvironment("CI"))
             {
                 return;
             }

--- a/ntbs-service/appsettings.CI.json
+++ b/ntbs-service/appsettings.CI.json
@@ -1,0 +1,12 @@
+{
+  "AppConfig": {
+    "AuditingEnabled": false,
+    "LegacySearchEnabled": false
+  },
+  "AdfsOptions": {
+    "UseDummyAuth": true
+  },
+  "Sentry": {
+    "Dsn": ""
+  }
+}

--- a/ntbs-service/appsettings.Test.json
+++ b/ntbs-service/appsettings.Test.json
@@ -1,9 +1,0 @@
-{
-  "AppConfig": {
-    "AuditingEnabled": false,
-    "LegacySearchEnabled": false
-  },
-  "AdfsOptions": {
-    "UseDummyAuth": true
-  }
-}

--- a/ntbs-ui-tests/SeleniumServerFactory.cs
+++ b/ntbs-ui-tests/SeleniumServerFactory.cs
@@ -37,7 +37,7 @@ namespace ntbs_ui_tests
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
-            builder.UseEnvironment("Test");
+            builder.UseEnvironment("CI");
 
             builder.ConfigureServices(services =>
             {
@@ -94,7 +94,7 @@ namespace ntbs_ui_tests
             RootUri = host.ServerFeatures.Get<IServerAddressesFeature>().Addresses.LastOrDefault(); //port 5001
 
             // This is a 'fake' server, needed to be returned by the method but will not actually be used.
-            return new TestServer(new WebHostBuilder().UseEnvironment("Test").UseStartup<TStartup>());
+            return new TestServer(new WebHostBuilder().UseEnvironment("CI").UseStartup<TStartup>());
         }
         
         public void ConfigureLogger(string testName)


### PR DESCRIPTION
Also rename the environment variable from Test to CI to make it clearly distinct from the running TEST environment
