### PR TITLE
Increase integration tests client timeout

### DIFF
--- a/ntbs-integration-tests/Helpers/WebApplicationExtensions.cs
+++ b/ntbs-integration-tests/Helpers/WebApplicationExtensions.cs
@@ -35,10 +35,12 @@ namespace ntbs_integration_tests.Helpers
 
         public static HttpClient CreateClientWithoutRedirects(this WebApplicationFactory<Startup> factory)
         {
-            return factory.CreateClient(new WebApplicationFactoryClientOptions
+            var client = factory.CreateClient(new WebApplicationFactoryClientOptions
             {
                 AllowAutoRedirect = false
             });
+            client.Timeout = TimeSpan.FromMinutes(3);
+            return client;
         }
 
         private static void UpdateDatabase(IWebHostBuilder builder, Action<NtbsContext> updateMethod)


### PR DESCRIPTION
This is in response to integration tests getting flaky on the Jenkins build, following a suggestion on https://github.com/dotnet/aspnetcore/issues/12998#issuecomment-557330077

If this doesn't help, we might be facing some sort of deadlock between the tests..
(or jenkins just slow)