### PR TITLE
NTBS-957: Use EnumToStringConverter for Audit logs

### DIFF
--- a/EFAuditer/EFAuditServiceExtensions.cs
+++ b/EFAuditer/EFAuditServiceExtensions.cs
@@ -55,15 +55,18 @@ namespace EFAuditer
             audit.AuditDateTime = DateTime.Now;
             audit.AuditUser = GetCustomKey(ev, CustomFields.AppUser) ?? ev.Environment.UserName;
 
+            var serializerSettings = Audit.Core.Configuration.JsonSettings;
+            serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());
+            
             switch (audit.EventType)
             {
                 case "Insert":
                     audit.AuditData =
-                        JsonConvert.SerializeObject(entry.ColumnValues, Audit.Core.Configuration.JsonSettings);
+                        JsonConvert.SerializeObject(entry.ColumnValues, serializerSettings);
                     break;
                 case "Update":
                     audit.AuditData =
-                        JsonConvert.SerializeObject(entry.Changes, Audit.Core.Configuration.JsonSettings);
+                        JsonConvert.SerializeObject(entry.Changes, serializerSettings);
                     break;
             }
 


### PR DESCRIPTION
Audit logs save enums as strings


## Description
<!--- High level changes overview -->

## Checklist:
- [x] Automated tests are passing locally.