### PR TITLE
NTBS-936 show treatment outcomes with correct logic regarding age

### DIFF
--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -152,6 +152,9 @@ namespace ntbs_service.Models.Entities
                                                     (DenotificationDetails?.Reason == DenotificationReason.Other ? $" - {DenotificationDetails?.OtherDescription}" : "");
         public bool IsMdr => ClinicalDetails.IsMDRTreatment == true || DrugResistanceProfile.DrugResistanceProfileString == "RR/MDR/XDR";
         public bool IsMBovis => string.Equals("M. bovis", DrugResistanceProfile.Species, StringComparison.InvariantCultureIgnoreCase);
+        public bool AgeEligibleFor12MonthOutcome => DateTime.Now > (ClinicalDetails.TreatmentStartDate ?? NotificationDate).Value.AddYears(1);
+        public bool AgeEligibleFor24MonthOutcome => DateTime.Now > (ClinicalDetails.TreatmentStartDate ?? NotificationDate).Value.AddYears(2);
+        public bool AgeEligibleFor36MonthOutcome => DateTime.Now > (ClinicalDetails.TreatmentStartDate ?? NotificationDate).Value.AddYears(3);
         
         private string GetNotificationStatusString()
         {

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -21,24 +21,24 @@
 {
      <div class="notification-overview-details-container">
         <div class="event-outcome-at-dates">
-            @if (@Model.OutcomeAt12Month != null)
+            @if (Model.Notification.AgeEligibleFor12MonthOutcome)
             {
                 <div>
-                    <strong> Outcome at 12 months </strong> @Model.OutcomeAt12Month.TreatmentOutcomeType.GetDisplayName() 
+                    <strong> Outcome at 12 months </strong> @(Model.OutcomeAt12Month?.TreatmentOutcomeType.GetDisplayName() ?? "No outcome recorded")
                 </div>
             }
             
-            @if (@Model.OutcomeAt24Month != null)
+            @if (Model.Notification.AgeEligibleFor24MonthOutcome)
             {
                 <div>
-                    <strong> Outcome at 24 months </strong> @Model.OutcomeAt24Month.TreatmentOutcomeType.GetDisplayName()
+                    <strong> Outcome at 24 months </strong> @(Model.OutcomeAt24Month?.TreatmentOutcomeType.GetDisplayName() ?? "No outcome recorded")
                 </div>
             }
             
-            @if (@Model.OutcomeAt36Month != null)
+            @if (Model.Notification.AgeEligibleFor36MonthOutcome)
             {
                 <div>
-                    <strong> Outcome at 36 months </strong> @Model.OutcomeAt36Month.TreatmentOutcomeType.GetDisplayName() 
+                    <strong> Outcome at 36 months </strong> @(Model.OutcomeAt36Month?.TreatmentOutcomeType.GetDisplayName() ?? "No outcome recorded")
                 </div>
             }
         </div>


### PR DESCRIPTION

## Description
Fix how treatment outcomes are shown on overview page (show if age eligible)

## Checklist:
- [X] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
