### PR TITLE
NTBS-983 & NTBS-982: Fix LINQ warnings

### DIFF
--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -11,7 +11,7 @@ namespace ntbs_service.DataAccess
 {
     public interface INotificationRepository
     {
-        IQueryable<Notification> GetBannerReadyNotificationsIQueryable();
+        IQueryable<Notification> GetBaseNotificationsIQueryable();
         IQueryable<Notification> GetQueryableNotificationByStatus(IList<NotificationStatus> statuses);
         IQueryable<Notification> GetRecentNotificationsIQueryable();
         IQueryable<Notification> GetDraftNotificationsIQueryable();
@@ -219,8 +219,6 @@ namespace ntbs_service.DataAccess
                 .Include(n => n.SocialContextVenues).ThenInclude(s => s.VenueType)
                 .Include(n => n.Alerts)
                 .Include(n => n.TreatmentEvents)
-                    .ThenInclude(t => t.TreatmentOutcome)
-                .Include(n => n.TreatmentEvents)
                     .ThenInclude(t => t.TbService)
                 .Include(n => n.TreatmentEvents)
                     .ThenInclude(t => t.CaseManager)
@@ -265,7 +263,7 @@ namespace ntbs_service.DataAccess
 
         // Adds enough information to display notification banner, which makes it a good
         // base for most notification queries. Can be expanded upon for further pages as needed.
-        public IQueryable<Notification> GetBannerReadyNotificationsIQueryable()
+        private IQueryable<Notification> GetBannerReadyNotificationsIQueryable()
         {
             return GetNotificationsWithBasicInformationIQueryable()
                 .Include(n => n.PatientDetails.Country)
@@ -288,7 +286,7 @@ namespace ntbs_service.DataAccess
                 .Include(n => n.HospitalDetails.CaseManager);
         }
 
-        private IQueryable<Notification> GetBaseNotificationsIQueryable()
+        public IQueryable<Notification> GetBaseNotificationsIQueryable()
         {
             return _context.Notification
                 .Where(n => n.NotificationStatus != NotificationStatus.Deleted);

--- a/ntbs-service/Pages/Search/Index.cshtml.cs
+++ b/ntbs-service/Pages/Search/Index.cshtml.cs
@@ -78,7 +78,7 @@ namespace ntbs_service.Pages.Search
                 PageSize = 50, PageIndex = pageIndex ?? 1, LegacyOffset = legacyOffset, NtbsOffset = ntbsOffset
             };
 
-            var ntbsQueryable = _notificationRepository.GetBannerReadyNotificationsIQueryable();
+            var ntbsQueryable = _notificationRepository.GetBaseNotificationsIQueryable();
 
             var ntbsFilteredSearchBuilder = (INtbsSearchBuilder)FilterBySearchParameters(new NtbsSearchBuilder(ntbsQueryable));
             var legacyFilteredSearchBuilder = (ILegacySearchBuilder)FilterBySearchParameters(new LegacySearchBuilder(_referenceDataRepository));

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using EFAuditer;
+using Microsoft.EntityFrameworkCore;
 using ntbs_service.DataAccess;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
@@ -297,7 +298,7 @@ namespace ntbs_service.Services
 
         public async Task UpdateSitesAsync(int notificationId, IEnumerable<NotificationSite> notificationSites)
         {
-            var currentSites = _context.NotificationSite.Where(ns => ns.NotificationId == notificationId);
+            var currentSites = await _context.NotificationSite.Where(ns => ns.NotificationId == notificationId).ToListAsync();
 
             foreach (var newSite in notificationSites)
             {

--- a/ntbs-service/Services/SearchService.cs
+++ b/ntbs-service/Services/SearchService.cs
@@ -12,8 +12,10 @@ namespace ntbs_service.Services
 {
     public interface ISearchService
     {
-        Task<(IList<int> notificationIds, int count)> OrderAndPaginateQueryableAsync(INtbsSearchBuilder firstQueryable,
-            PaginationParameters paginationParameters, ClaimsPrincipal user);
+        Task<(IList<int> notificationIds, int count)> OrderAndPaginateQueryableAsync(
+            INtbsSearchBuilder firstQueryable,
+            PaginationParameters paginationParameters, 
+            ClaimsPrincipal user);
     }
 
     public class SearchService : ISearchService


### PR DESCRIPTION
## Description
Use base queryable for retrieving NTBS notification ids - as the include statements are completely redundant if the final select statement is `n => n.NotificationId`.

Explicitly locally load notification sites as some of the expressions are not translatable, so are running locally anyway.

## Checklist:
- [X] Automated tests are passing locally.