### PR TITLE
NTBS-940 show draft alert on draft edit pages

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -69,6 +69,8 @@ namespace ntbs_integration_tests.Helpers
         public const int NOTIFICATION_ID_WITH_MBOVIS_ANIMAL_ENTITIES = 10136;
         public const int NOTIFICATION_ID_WITH_MBOVIS_ANIMAL_NO_ENTITIES = 10137;
 
+        public const int DRAFT_NOTIFICATION_WITH_DRAFT_ALERT = 10140;
+
         public const int ALERT_ID = 20001;
         public const int TRANSFER_ALERT_ID = 20002;
         public const int TRANSFER_ALERT_ID_TO_ACCEPT = 20003;
@@ -76,6 +78,8 @@ namespace ntbs_integration_tests.Helpers
         public const int TRANSFER_ALERT_ID_TO_REJECT = 20004;
         public const int TRANSFER_REJECTED_ID = 20005;
         public const int TRANSFER_ALERT_ID_TO_ACCEPT_2 = 20006;
+
+        public const int DRAFT_DATA_QUALITY_ALERT = 20007;
 
         public const int PATIENT_NOTIFICATION_GROUP_ID = 30001;
             
@@ -128,8 +132,11 @@ namespace ntbs_integration_tests.Helpers
             context.Notification.AddRange(MBovisUnpasteurisedMilkConsumptionPageTests.GetSeedingNotifications());
             context.Notification.AddRange(MBovisOccupationExposurePageTests.GetSeedingNotifications());
             context.Notification.AddRange(MBovisAnimalExposurePageTests.GetSeedingNotifications());
+            context.Notification.AddRange(DraftEditPageTests.GetSeedingNotifications());
 
             context.TreatmentOutcome.AddRange(TreatmentEventEditPageTests.GetSeedingOutcomes());
+
+            context.Alert.AddRange(DraftEditPageTests.GetSeedingAlerts());
 
             context.SaveChanges();
         }

--- a/ntbs-integration-tests/NotificationPages/DraftEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DraftEditPageTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_service;
+using ntbs_service.Helpers;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Enums;
+using Xunit;
+
+namespace ntbs_integration_tests.NotificationPages
+{
+    public class DraftEditPageTests : TestRunnerNotificationBase
+    {
+        public DraftEditPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
+
+        public static IEnumerable<Notification> GetSeedingNotifications()
+        {
+            return new List<Notification>()
+            {
+                new Notification
+                {
+                    NotificationId = Utilities.DRAFT_NOTIFICATION_WITH_DRAFT_ALERT,
+                    NotificationStatus = NotificationStatus.Draft
+                }
+            };
+        }
+
+        public static IEnumerable<Alert> GetSeedingAlerts()
+        {
+            return new List<Alert>
+            {
+                new DataQualityDraftAlert { NotificationId = Utilities.DRAFT_NOTIFICATION_WITH_DRAFT_ALERT }
+            };
+        }
+
+        [Fact]
+        public async Task Get_ReturnsEditPageWithAlert_IfDraftHasDraftAlert()
+        {
+            // Arrange
+            const int id = Utilities.DRAFT_NOTIFICATION_WITH_DRAFT_ALERT;
+            var patientEditPageUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.EditPatientDetails);
+
+            // Act
+            var patientEditPage = await GetDocumentForUrlAsync(patientEditPageUrl);
+
+            // Assert
+            Assert.NotNull(patientEditPage.GetElementById("draft-alert-details"));
+        }
+    }
+}

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -76,7 +76,7 @@ namespace ntbs_service.DataAccess
             return (DataQualityDraftAlert) await _context.Alert
                 .Where(n => n.AlertStatus != AlertStatus.Closed)
                 .Where(n => n.NotificationId == notificationId)
-                .Where(n => n.AlertType == AlertType.DataQualityDraft)
+                .OfType<DataQualityDraftAlert>()
                 .SingleOrDefaultAsync();
         }
 

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -16,6 +16,7 @@ namespace ntbs_service.DataAccess
         Task<IList<Alert>> GetAlertsForNotificationAsync(int notificationId);
         Task<IList<Alert>> GetAlertsByTbServiceCodesAsync(IEnumerable<string> tbServices);
         Task<IList<UnmatchedLabResultAlert>> GetAllOpenUnmatchedLabResultAlertsAsync();
+        Task<DataQualityDraftAlert> GetOpenDraftAlertForNotificationAsync(int notificationId);
         Task AddAlertAsync(Alert alert);
         Task AddAlertRangeAsync(IEnumerable<Alert> alerts);
 
@@ -68,6 +69,15 @@ namespace ntbs_service.DataAccess
             return await GetBaseAlertIQueryable()
                 .OfType<UnmatchedLabResultAlert>()
                 .ToListAsync();
+        }
+
+        public async Task<DataQualityDraftAlert> GetOpenDraftAlertForNotificationAsync(int notificationId)
+        {
+            return (DataQualityDraftAlert) await _context.Alert
+                .Where(n => n.AlertStatus != AlertStatus.Closed)
+                .Where(n => n.NotificationId == notificationId)
+                .Where(n => n.AlertType == AlertType.DataQualityDraft)
+                .SingleOrDefaultAsync();
         }
 
         public async Task<IList<Alert>> GetAlertsForNotificationAsync(int notificationId)

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -48,7 +48,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             IReferenceDataRepository referenceDataRepository,
             IAlertService alertService,
             IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
-            IItemRepository<TreatmentEvent> treatmentEventRepository) : base(service, authorizationService, notificationRepository)
+            IItemRepository<TreatmentEvent> treatmentEventRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
             _alertService = alertService;

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -45,11 +45,11 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
+            IAlertRepository alertRepository,
             IReferenceDataRepository referenceDataRepository,
             IAlertService alertService,
             IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
-            IItemRepository<TreatmentEvent> treatmentEventRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IItemRepository<TreatmentEvent> treatmentEventRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
             _alertService = alertService;

--- a/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
@@ -33,7 +33,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         public ComorbiditiesModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditComorbidities;
         }

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
@@ -12,7 +12,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         public ContactTracingModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditContactTracing;
         }

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -37,12 +37,12 @@ namespace ntbs_service.Pages.Notifications.Edit
         public HospitalDetailsModel(
             INotificationService notificationService,
             INotificationRepository notificationRepository,
+            IAlertRepository alertRepository,
             IReferenceDataRepository referenceDataRepository,
             IAuthorizationService authorizationService,
             IUserService userService,
             IItemRepository<TreatmentEvent> treatmentEventRepository,
-            NtbsContext context,
-            IAlertRepository alertRepository) : base(notificationService, authorizationService, notificationRepository, alertRepository)
+            NtbsContext context) : base(notificationService, authorizationService, notificationRepository, alertRepository)
         {
             _context = context;
             _userService = userService;

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -41,7 +41,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             IUserService userService,
             IItemRepository<TreatmentEvent> treatmentEventRepository,
-            NtbsContext context) : base(notificationService, authorizationService, notificationRepository)
+            NtbsContext context,
+            IAlertRepository alertRepository) : base(notificationService, authorizationService, notificationRepository, alertRepository)
         {
             _context = context;
             _userService = userService;

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisAnimalExposure.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisAnimalExposure.cshtml.cs
@@ -27,7 +27,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
-            IItemRepository<MBovisAnimalExposure> mBovisAnimalExposureRepository) : base(service, authorizationService, notificationRepository)
+            IItemRepository<MBovisAnimalExposure> mBovisAnimalExposureRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
             _mBovisAnimalExposureRepository = mBovisAnimalExposureRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
@@ -24,7 +24,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IItemRepository<MBovisExposureToKnownCase> mBovisExposureToKnownCasesRepository) : base(service, authorizationService, notificationRepository)
+            IItemRepository<MBovisExposureToKnownCase> mBovisExposureToKnownCasesRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _mBovisExposureToKnownCasesRepository = mBovisExposureToKnownCasesRepository;
         }

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisOccupationExposure.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisOccupationExposure.cshtml.cs
@@ -27,7 +27,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
-            IItemRepository<MBovisOccupationExposure> mBovisOccupationExposureRepository) : base(service, authorizationService, notificationRepository)
+            IItemRepository<MBovisOccupationExposure> mBovisOccupationExposureRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
             _mBovisOccupationExposureRepository = mBovisOccupationExposureRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisUnpasteurisedMilkConsumption.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisUnpasteurisedMilkConsumption.cshtml.cs
@@ -27,7 +27,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
-            IItemRepository<MBovisUnpasteurisedMilkConsumption> mBovisUnpasteurisedMilkConsumptionRepository) : base(service, authorizationService, notificationRepository)
+            IItemRepository<MBovisUnpasteurisedMilkConsumption> mBovisUnpasteurisedMilkConsumptionRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
             _mBovisUnpasteurisedMilkConsumptionRepository = mBovisUnpasteurisedMilkConsumptionRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -33,8 +33,9 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
-            IItemRepository<ManualTestResult> testResultsRepository)
-            : base(notificationService, authorizationService, notificationRepository)
+            IItemRepository<ManualTestResult> testResultsRepository,
+            IAlertRepository alertRepository)
+            : base(notificationService, authorizationService, notificationRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
             _testResultsRepository = testResultsRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextAddress.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextAddress.cshtml.cs
@@ -16,7 +16,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IItemRepository<SocialContextAddress> socialContextAddressRepository) : base(service, authorizationService, notificationRepository, socialContextAddressRepository)
+            IItemRepository<SocialContextAddress> socialContextAddressRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, socialContextAddressRepository, alertRepository)
         {
         }
 

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
@@ -28,7 +28,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IItemRepository<T> socialContextRepository) : base(service, authorizationService, notificationRepository)
+            IItemRepository<T> socialContextRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _socialContextRepository = socialContextRepository;
         }

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextVenue.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextVenue.cshtml.cs
@@ -21,7 +21,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
-            IItemRepository<SocialContextVenue> socialContextVenueRepository) : base(service, authorizationService, notificationRepository, socialContextVenueRepository)
+            IItemRepository<SocialContextVenue> socialContextVenueRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, socialContextVenueRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
         }

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -41,8 +41,9 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
-            IItemRepository<TreatmentEvent> treatmentEventRepository)
-            : base(service, authorizationService, notificationRepository)
+            IItemRepository<TreatmentEvent> treatmentEventRepository,
+            IAlertRepository alertRepository)
+            : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _referenceDataRepository = referenceDataRepository;
             _treatmentEventRepository = treatmentEventRepository;

--- a/ntbs-service/Pages/Notifications/Edit/MBovisAnimalExposures.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisAnimalExposures.cshtml.cs
@@ -13,8 +13,9 @@ namespace ntbs_service.Pages.Notifications.Edit
         public MBovisAnimalExposuresModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(notificationService, authorizationService,
-            notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(notificationService, authorizationService,
+                notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisAnimalExposures;
         }

--- a/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml.cs
@@ -13,8 +13,9 @@ namespace ntbs_service.Pages.Notifications.Edit
         public MBovisExposureToKnownCasesModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(notificationService, authorizationService,
-            notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(notificationService, authorizationService,
+                notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisExposureToKnownCases;
         }

--- a/ntbs-service/Pages/Notifications/Edit/MBovisOccupationExposures.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisOccupationExposures.cshtml.cs
@@ -13,8 +13,9 @@ namespace ntbs_service.Pages.Notifications.Edit
         public MBovisOccupationExposuresModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(notificationService, authorizationService,
-            notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(notificationService, authorizationService,
+                notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisOccupationExposures;
         }

--- a/ntbs-service/Pages/Notifications/Edit/MBovisUnpasteurisedMilkConsumptions.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisUnpasteurisedMilkConsumptions.cshtml.cs
@@ -13,8 +13,9 @@ namespace ntbs_service.Pages.Notifications.Edit
         public MBovisUnpasteurisedMilkConsumptionsModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(notificationService, authorizationService,
-            notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(notificationService, authorizationService,
+                notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisUnpasteurisedMilkConsumptions;
         }

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -18,7 +18,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository)
+            IReferenceDataRepository referenceDataRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
             { 
                 NotUKCountries = new SelectList(
                     referenceDataRepository.GetAllCountriesApartFromUkAsync().Result,

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -37,7 +37,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             IPostcodeService postcodeService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository)
+            IReferenceDataRepository referenceDataRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _postcodeService = postcodeService;
             _referenceDataRepository = referenceDataRepository;

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -34,11 +34,11 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         public PatientDetailsModel(
             INotificationService service,
-            IPostcodeService postcodeService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IReferenceDataRepository referenceDataRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IPostcodeService postcodeService,
+            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             _postcodeService = postcodeService;
             _referenceDataRepository = referenceDataRepository;

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
@@ -13,7 +13,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         public PreviousHistoryModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditPreviousHistory;
         }

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml.cs
@@ -15,7 +15,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         public SocialContextAddressesModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditSocialContextAddresses;
         }

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml.cs
@@ -15,7 +15,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         public SocialContextVenuesModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditSocialContextVenues;
         }

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
@@ -15,7 +15,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         public SocialRiskFactorsModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditSocialRiskFactors;
         }

--- a/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
@@ -20,7 +20,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             ICultureAndResistanceService cultureAndResistanceService,
-            ISpecimenService specimenService) : base(notificationService, authorizationService, notificationRepository)
+            ISpecimenService specimenService,
+            IAlertRepository alertRepository) : base(notificationService, authorizationService, notificationRepository, alertRepository)
         {
             _cultureAndResistanceService = cultureAndResistanceService;
             _specimenService = specimenService;

--- a/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
@@ -19,9 +19,9 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService notificationService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
+            IAlertRepository alertRepository,
             ICultureAndResistanceService cultureAndResistanceService,
-            ISpecimenService specimenService,
-            IAlertRepository alertRepository) : base(notificationService, authorizationService, notificationRepository, alertRepository)
+            ISpecimenService specimenService) : base(notificationService, authorizationService, notificationRepository, alertRepository)
         {
             _cultureAndResistanceService = cultureAndResistanceService;
             _specimenService = specimenService;

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
@@ -23,8 +23,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IReferenceDataRepository referenceDataRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             HighTbIncidenceCountries = new SelectList(
                 referenceDataRepository.GetAllHighTbIncidenceCountriesAsync().Result,

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
@@ -23,7 +23,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository)
+            IReferenceDataRepository referenceDataRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
         {
             HighTbIncidenceCountries = new SelectList(
                 referenceDataRepository.GetAllHighTbIncidenceCountriesAsync().Result,

--- a/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml.cs
@@ -17,7 +17,8 @@ namespace ntbs_service.Pages.Notifications.Edit
         public TreatmentEventsModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(notificationService, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(notificationService, authorizationService, notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditTreatmentEvents;
         }

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -16,13 +16,16 @@ namespace ntbs_service.Pages.Notifications
     public abstract class NotificationEditModelBase : NotificationModelBase
     {
         protected readonly ValidationService ValidationService;
+        private readonly IAlertRepository _alertRepository;
 
         protected NotificationEditModelBase(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository)
         {
             ValidationService = new ValidationService(this);
+            _alertRepository = alertRepository;
         }
 
         [ViewData]
@@ -54,6 +57,11 @@ namespace ntbs_service.Pages.Notifications
             if (PermissionLevel != PermissionLevel.Edit)
             {
                 return RedirectForNotified();
+            }
+
+            if (Notification.NotificationStatus == NotificationStatus.Draft)
+            {
+                DraftAlert = await GetDraftAlertIfItExistsAsync();
             }
 
             return await PrepareAndDisplayPageAsync(isBeingSubmitted);
@@ -184,6 +192,11 @@ namespace ntbs_service.Pages.Notifications
         protected virtual IActionResult RedirectToCreate()
         {
             throw new NotImplementedException();
+        }
+
+        private async Task<DataQualityDraftAlert> GetDraftAlertIfItExistsAsync()
+        {
+            return await _alertRepository.GetOpenDraftAlertForNotificationAsync(NotificationId);
         }
     }
 }

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -31,6 +31,7 @@ namespace ntbs_service.Pages.Notifications
         public Notification Notification { get; set; }
         public NotificationBannerModel NotificationBannerModel { get; set; }
         public IList<Alert> Alerts { get; set; }
+        public DataQualityDraftAlert DraftAlert { get; set; }
 
         public PermissionLevel PermissionLevel { get; set; }
 

--- a/ntbs-service/Pages/Shared/_DraftSubmitDeleteButtons.cshtml
+++ b/ntbs-service/Pages/Shared/_DraftSubmitDeleteButtons.cshtml
@@ -8,6 +8,15 @@
 }
 
 <nhs-grid-row classes="flex-container">
+    @if (Model.DraftAlert != null)
+    {
+        <nhs-grid-column grid-column-width="TwoThirds">
+            <div class= "@cssClasses" id="draft-alert-details">
+                <b> @Model.DraftAlert.AlertType.GetDisplayName() </b>
+                <div> @Model.DraftAlert.Action </div>
+            </div>
+        </nhs-grid-column>
+    }
     <nhs-grid-column grid-column-width="OneThird" classes="submit-delete-buttons-container">
         <div class= "@cssClasses">
             <button nhs-button-type="Standard" classes="ntbsuk-button--primary" name="actionName" value="@ActionNameString.Submit" id="submit-button">


### PR DESCRIPTION
## Description
Add Draft alerts to edit pages when viewing a draft.
I have added AlertRepository to notificationEditModelBase which means that it needs to be injected into all the edit pages

## Checklist:
- [X] Automated tests are passing locally.
- [X] Sanity checked new EF-generated queries for performance.
- [X] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [X] Test functionality without javascript
- [X] Test in small window (imitating small screen)
- [X ] Check the feature looks and works correctly in IE11
- [X] Zoom page to 400% - content still visible?
- [X ] Test feature works with keyboard only operation
- [X] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [X] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
