### PR TITLE
Ntbs 961 integration tests clean up

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -190,6 +190,15 @@ namespace ntbs_integration_tests.Helpers
                     AdGroups = "Global.NIS.NTBS.Service_Abingdon",
                     IsActive = true,
                     IsCaseManager = true
+                },
+                new User
+                {
+                    Username = "Developer@ntbs.phe.com",
+                    GivenName = "BaseTestCase",
+                    FamilyName = "BaseTestManager",
+                    AdGroups = "Global.NIS.NTBS.NTA",
+                    IsActive = true,
+                    IsCaseManager = true
                 }
             };
         }

--- a/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
@@ -41,7 +41,7 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public async Task Get_ReturnsOk_ForNhsUserWithPermission()
+        public void Get_ReturnsOk_ForNhsUserWithPermission()
         {
             // Arrange
             using (var client = Factory.WithUser<NhsUserForAbingdonAndPermitted>()
@@ -61,7 +61,7 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public async Task Get_ReturnsRedirect_ForNhsUserWithoutPermission()
+        public void Get_ReturnsRedirect_ForNhsUserWithoutPermission()
         {
             // Arrange
             using (var client = Factory.WithUser<NhsUserForAbingdonAndPermitted>()
@@ -81,7 +81,7 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public async Task Get_ReturnsOk_ForPheUserWithMatchingServicePermission()
+        public void Get_ReturnsOk_ForPheUserWithMatchingServicePermission()
         {
             // Arrange
             using (var client = Factory.WithUser<PheUserWithPermittedPhecCode>()
@@ -101,7 +101,7 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public async Task Get_ReturnsRedirectToOverview_ForPheUserWithMatchingPostcodePermission()
+        public void Get_ReturnsRedirectToOverview_ForPheUserWithMatchingPostcodePermission()
         {
             // Arrange
             using (var client = Factory.WithUser<PheUserWithPermittedPhecCode>()
@@ -110,7 +110,7 @@ namespace ntbs_integration_tests.NotificationPages
             {
                 EditSubPaths.ForEach( subPath =>
                 {
-                    // Act
+                    // ActAccessToDisposedClosure
                     var response = client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID)).Result;
 
                     _output.WriteLine("Testing subpath {0}", subPath);
@@ -123,7 +123,7 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public async Task Get_ReturnsRedirect_ForPheUserWithoutMatchingServicePermission()
+        public void Get_ReturnsRedirect_ForPheUserWithoutMatchingServicePermission()
         {
             // Arrange
             using (var client = Factory.WithUser<PheUserWithPermittedPhecCode>()
@@ -143,7 +143,7 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public async Task Get_ReturnsRedirect_ForPheUserWithoutMatchingPostcodePermission()
+        public void Get_ReturnsRedirect_ForPheUserWithoutMatchingPostcodePermission()
         {
             // Arrange
             using (var client = Factory.WithUser<PheUserWithPermittedPhecCode>()

--- a/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
@@ -153,22 +153,29 @@ namespace ntbs_integration_tests.TransferPage
         {
             // Arrange
             const int id = Utilities.NOTIFIED_ID_WITH_TRANSFER_REQUEST_TO_REJECT;
+
+            var overviewUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.Overview);
+            var overviewPage = await GetDocumentForUrlAsync(overviewUrl);
+            Assert.NotNull(overviewPage.QuerySelector("#alert-20004"));
+            
             var url = GetCurrentPathForId(id);
             var initialDocument = await GetDocumentForUrlAsync(url);
 
             var formData = new Dictionary<string, string>
             {
                 ["AcceptTransfer"] = "false",
-                ["DeclineTransferReason"] = "nah",
+                ["DeclineTransferReason"] = "nah"
             };
 
             // Act
-            var result = await Client.SendPostFormWithData(initialDocument, formData, url);
+            await Client.SendPostFormWithData(initialDocument, formData, url);
 
             // Assert
-            var overviewUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.Overview);
-            var overviewPage = await GetDocumentForUrlAsync(overviewUrl);
-            Assert.NotNull(overviewPage.QuerySelector(".overview-alerts-container"));
+            var reloadedOverviewUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.Overview);
+            var reloadedOverviewPage = await GetDocumentForUrlAsync(reloadedOverviewUrl);
+            var alertsContainer = reloadedOverviewPage.QuerySelector(".overview-alerts-container");
+            Assert.Null(alertsContainer.QuerySelector("#alert-20004"));
+            Assert.Contains("Transfer request rejected", alertsContainer.InnerHtml);
         }
     }
 }

--- a/ntbs-integration-tests/TransferPages/RejectTransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/RejectTransferPageTests.cs
@@ -20,6 +20,7 @@ namespace ntbs_integration_tests.TransferPage
             var overviewUrl = RouteHelper.GetNotificationPath(id, NotificationSubPaths.Overview);
             var initialOverviewPage = await GetDocumentForUrlAsync(overviewUrl);
             Assert.NotNull(initialOverviewPage.QuerySelector("#alert-20005"));
+            
             var url = GetCurrentPathForId(id);
             var initialDocument = await GetDocumentForUrlAsync(url);
 


### PR DESCRIPTION
## Description
I couldn't find any 'generated id' style flaws in our testing but did have a problem with a transfer rejection test - this has now been fixed.
Also changed some of the basicEditPages to not be async as they are no longer using await but .Result in a foreach loop.

## Checklist:
- [X] Automated tests are passing locally.