### PR TITLE
NTBS-454 order treatment events on the same day 

### DIFF
--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -254,7 +254,8 @@ namespace ntbs_service.DataAccess
                 .ToListAsync())
                 .Where(n =>
                 {
-                    var lastTreatmentEvent = n.TreatmentEvents.OrderByDescending(t => t.EventDate).FirstOrDefault();
+                    var lastTreatmentEvent = n.TreatmentEvents.OrderByDescending(t => t.EventDate)
+                        .ThenBy(t => t.TreatmentEventTypeIsOutcome).FirstOrDefault();
                     if (lastTreatmentEvent != null)
                     {
                         return lastTreatmentEvent.TreatmentEventTypeIsOutcome

--- a/ntbs-service/Services/TreatmentOutcomeService.cs
+++ b/ntbs-service/Services/TreatmentOutcomeService.cs
@@ -80,7 +80,8 @@ namespace ntbs_service.Services
             return notification.TreatmentEvents?.Where(t =>
                     t.EventDate < (notification.ClinicalDetails.TreatmentStartDate ?? notification.NotificationDate)?.AddYears(numberOfYears)
                     && t.EventDate >= (notification.ClinicalDetails.TreatmentStartDate ?? notification.NotificationDate)?.AddYears(numberOfYears - 1))
-                .OrderBy(t => t.EventDate);
+                .OrderBy(t => t.EventDate)
+                .ThenByDescending(t => t.TreatmentEventTypeIsOutcome);
         }
     }
 }


### PR DESCRIPTION
## Description
Order treatment events on the same day so that non outcomes are more recent than outcome events.

## Checklist:
- [X] Automated tests are passing locally.
- [X] Sanity checked new EF-generated queries for performance.
