### PR TITLE
Ntbs 936 death event and ordering

### DIFF
--- a/ntbs-service/Helpers/TreatmentEventsExtensionMethods.cs
+++ b/ntbs-service/Helpers/TreatmentEventsExtensionMethods.cs
@@ -20,7 +20,9 @@ namespace ntbs_service.Helpers
         
         public static Dictionary<int, List<TreatmentEvent>> GroupByEpisode(this IEnumerable<TreatmentEvent> treatmentEvents)
         {
-            var orderedTreatmentEvents = treatmentEvents.OrderBy(t => t.EventDate).ThenBy(t => t.TreatmentEventTypeIsOutcome);
+            var orderedTreatmentEvents = treatmentEvents
+                .OrderBy(t => t.EventDate)
+                .ThenByDescending(t => t.TreatmentEventTypeIsOutcome);
             var groupedEpisodes = new Dictionary<int, List<TreatmentEvent>>();
             var episodeCount = 1;
             

--- a/ntbs-service/Models/Entities/TreatmentEvent.cs
+++ b/ntbs-service/Models/Entities/TreatmentEvent.cs
@@ -20,7 +20,7 @@ namespace ntbs_service.Models.Entities
         [Required(ErrorMessage = ValidationMessages.RequiredEnter)]
         [ValidClinicalDate]
         [AssertThat(@"EventDateAfterDob", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
-        [AssertThat(@"EventDateAfterNotificationDate", ErrorMessage = ValidationMessages.DateShouldBeLaterThanNotification)]
+        [AssertThat(@"EventDateAfterNotificationDate || (IsNotificationPostMortem && TreatmentEventIsDeathEvent)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanNotification)]
         public DateTime? EventDate { get; set; }
 
         [Display(Name = "Event")]
@@ -51,9 +51,12 @@ namespace ntbs_service.Models.Entities
         public DateTime? Dob { get; set; }
         [NotMapped]
         public DateTime? DateOfNotification { get; set; }
+        [NotMapped]
+        public bool IsNotificationPostMortem { get; set; }
         
         public bool TreatmentEventTypeIsOutcome => TreatmentEventType == Enums.TreatmentEventType.TreatmentOutcome;
         public bool TreatmentEventTypeIsNotRestart => TreatmentEventType != Enums.TreatmentEventType.TreatmentRestart;
+        public bool TreatmentEventIsDeathEvent => TreatmentOutcome?.TreatmentOutcomeType == TreatmentOutcomeType.Died;
         public bool EventDateAfterDob => Dob == null || EventDate >= Dob;
         public bool EventDateAfterNotificationDate => DateOfNotification == null || EventDate >= DateOfNotification;
         public string FormattedEventDate => EventDate.ConvertToString();

--- a/ntbs-service/Models/Entities/TreatmentEvent.cs
+++ b/ntbs-service/Models/Entities/TreatmentEvent.cs
@@ -19,8 +19,8 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Event Date")]
         [Required(ErrorMessage = ValidationMessages.RequiredEnter)]
         [ValidClinicalDate]
-        [AssertThat(@"EventDateAfterDob", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
-        [AssertThat(@"EventDateAfterNotificationDate || (IsNotificationPostMortem && TreatmentEventIsDeathEvent)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanNotification)]
+        [AssertThat(nameof(EventDateAfterDob), ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
+        [AssertThat(nameof(AfterNotificationDateUnlessPostMortem), ErrorMessage = ValidationMessages.DateShouldBeLaterThanNotification)]
         public DateTime? EventDate { get; set; }
 
         [Display(Name = "Event")]
@@ -57,6 +57,7 @@ namespace ntbs_service.Models.Entities
         public bool TreatmentEventTypeIsOutcome => TreatmentEventType == Enums.TreatmentEventType.TreatmentOutcome;
         public bool TreatmentEventTypeIsNotRestart => TreatmentEventType != Enums.TreatmentEventType.TreatmentRestart;
         public bool TreatmentEventIsDeathEvent => TreatmentOutcome?.TreatmentOutcomeType == TreatmentOutcomeType.Died;
+        public bool AfterNotificationDateUnlessPostMortem => EventDateAfterNotificationDate || (IsNotificationPostMortem && TreatmentEventIsDeathEvent);
         public bool EventDateAfterDob => Dob == null || EventDate >= Dob;
         public bool EventDateAfterNotificationDate => DateOfNotification == null || EventDate >= DateOfNotification;
         public string FormattedEventDate => EventDate.ConvertToString();

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -86,6 +86,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             TreatmentEvent.NotificationId = NotificationId;
             TreatmentEvent.CaseManagerUsername = Notification.HospitalDetails.CaseManagerUsername;
             TreatmentEvent.TbServiceCode = Notification.HospitalDetails.TBServiceCode;
+            TreatmentEvent.IsNotificationPostMortem = Notification.ClinicalDetails.IsPostMortem ?? false;
 
             // The required date will be marked as missing on the model, since we are setting it manually, rather than binding it
             ModelState.Remove("TreatmentEvent.EventDate");
@@ -178,6 +179,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             }
 
             TreatmentEvent.TreatmentOutcomeId = treatmentOutcome.TreatmentOutcomeId;
+            TreatmentEvent.TreatmentOutcome = treatmentOutcome;
         }
 
 

--- a/ntbs-service/Pages/Shared/_TreatmentEventTable.cshtml
+++ b/ntbs-service/Pages/Shared/_TreatmentEventTable.cshtml
@@ -4,7 +4,7 @@
 @{
     var header = Model.FirstOrDefault();
     var showEditLinks = (bool)(ViewData["ShowTreatmentEventEditLinks"] ?? false);
-    var orderedResults = Model.OrderByDescending(r => r.EventDate);
+    var orderedResults = Model.OrderByDescending(t => t.EventDate).ThenBy(t => t.TreatmentEventTypeIsOutcome);
 }
 
 @if (Model.Count != 0)


### PR DESCRIPTION
## Description
Fix ordering of treatment events again.
allow death events before notification date for post mortem cases

## Checklist:
- [X] Automated tests are passing locally.
- [X] Sanity checked new EF-generated queries for performance.