### PR TITLE
Ntbs 1017 qa markups

### DIFF
--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -475,17 +475,23 @@ namespace ntbs_service.DataMigration
         
         private static List<TreatmentEvent> ExtractTreatmentEvents(dynamic notification)
         {
-            var treatmentEvents = new List<TreatmentEvent> {new TreatmentEvent
+            var treatmentEvents = new List<TreatmentEvent>();
+            if (notification.IsPostMortem)
             {
-                EventDate = notification.DeathDate,
-                TreatmentEventType = TreatmentEventType.TreatmentOutcome,
-                TreatmentOutcome = new TreatmentOutcome
-                {
-                    TreatmentOutcomeId = TreatmentOutcomes.UnknownDeathEventOutcomeId,
-                    TreatmentOutcomeType = TreatmentOutcomeType.Died,
-                    TreatmentOutcomeSubType = TreatmentOutcomeSubType.Unknown
-                }
-            }};
+                treatmentEvents.Append(
+                    new TreatmentEvent
+                    {
+                        EventDate = notification.DeathDate,
+                        TreatmentEventType = TreatmentEventType.TreatmentOutcome,
+                        TreatmentOutcomeId = TreatmentOutcomes.UnknownDeathEventOutcomeId,
+                        TreatmentOutcome = new TreatmentOutcome
+                        {
+                            TreatmentOutcomeId = TreatmentOutcomes.UnknownDeathEventOutcomeId,
+                            TreatmentOutcomeType = TreatmentOutcomeType.Died,
+                            TreatmentOutcomeSubType = TreatmentOutcomeSubType.Unknown
+                        }
+                    });
+            }
             return treatmentEvents;
         }
 

--- a/ntbs-service/Models/SeedData/TreatmentOutcomes.cs
+++ b/ntbs-service/Models/SeedData/TreatmentOutcomes.cs
@@ -6,7 +6,6 @@ namespace ntbs_service.Models.SeedData
 {
     public class TreatmentOutcomes
     {
-        public static int UnknownDeathEventOutcomeId = 10;
         public static IEnumerable<TreatmentOutcome> GetTreatmentOutcomes()
         {
             return new List<TreatmentOutcome>
@@ -22,7 +21,7 @@ namespace ntbs_service.Models.SeedData
                 new TreatmentOutcome { TreatmentOutcomeId = 7, TreatmentOutcomeType = TreatmentOutcomeType.Died, TreatmentOutcomeSubType = TreatmentOutcomeSubType.TbCausedDeath },
                 new TreatmentOutcome { TreatmentOutcomeId = 8, TreatmentOutcomeType = TreatmentOutcomeType.Died, TreatmentOutcomeSubType = TreatmentOutcomeSubType.TbContributedToDeath },
                 new TreatmentOutcome { TreatmentOutcomeId = 9, TreatmentOutcomeType = TreatmentOutcomeType.Died, TreatmentOutcomeSubType = TreatmentOutcomeSubType.TbIncidentalToDeath },
-                new TreatmentOutcome { TreatmentOutcomeId = UnknownDeathEventOutcomeId, TreatmentOutcomeType = TreatmentOutcomeType.Died, TreatmentOutcomeSubType = TreatmentOutcomeSubType.Unknown },
+                new TreatmentOutcome { TreatmentOutcomeId = 10, TreatmentOutcomeType = TreatmentOutcomeType.Died, TreatmentOutcomeSubType = TreatmentOutcomeSubType.Unknown },
 
                 new TreatmentOutcome { TreatmentOutcomeId = 11, TreatmentOutcomeType = TreatmentOutcomeType.Lost, TreatmentOutcomeSubType = TreatmentOutcomeSubType.PatientLeftUk },
                 new TreatmentOutcome { TreatmentOutcomeId = 12, TreatmentOutcomeType = TreatmentOutcomeType.Lost, TreatmentOutcomeSubType = TreatmentOutcomeSubType.PatientNotLeftUk },


### PR DESCRIPTION
## Description
Fix adding death events for post-mortem legacy notifications

## Checklist:
- [X] Automated tests are passing locally.
- [X] Sanity checked new EF-generated queries for performance.