### PR TITLE
NTBS-1060: Allow navigate to draft notifications on LinkedNotifications page

### DIFF
--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml
@@ -7,7 +7,7 @@
     ViewData["Title"] = "Linked Notifications";
     ViewData["NotificationId"] = @Model.NotificationId;
     ViewData["CurrentPage"] = NotificationSubPaths.LinkedNotifications;
-    TempData["OnLinkedNotificationsPage"] = true;
+    ViewData["OnLinkedNotificationsPage"] = true;
 }
 
 <h2 id="top">Linked Notifications</h2>

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml
@@ -7,6 +7,7 @@
     ViewData["Title"] = "Linked Notifications";
     ViewData["NotificationId"] = @Model.NotificationId;
     ViewData["CurrentPage"] = NotificationSubPaths.LinkedNotifications;
+    TempData["OnLinkedNotificationsPage"] = true;
 }
 
 <h2 id="top">Linked Notifications</h2>

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
@@ -42,8 +42,6 @@ namespace ntbs_service.Pages.Notifications
                 .Where(n => n.NotificationId != NotificationId)
                 .CreateNotificationBanners(User, AuthorizationService).ToList();
 
-            NotificationBannerModel.ShowLink = true;
-
             return Page();
         }
     }

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
@@ -42,6 +42,8 @@ namespace ntbs_service.Pages.Notifications
                 .Where(n => n.NotificationId != NotificationId)
                 .CreateNotificationBanners(User, AuthorizationService).ToList();
 
+            NotificationBannerModel.ShowLink = true;
+
             return Page();
         }
     }

--- a/ntbs-service/Pages/Shared/_NotificationUnderBannerNav.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationUnderBannerNav.cshtml
@@ -7,7 +7,7 @@
 
     var isDraft = Model.Notification.NotificationStatus == NotificationStatus.Draft;
     var requiresSeparator = false;
-    var isOnLinkedNotificationsPage = (bool?) TempData["OnLinkedNotificationsPage"] ?? false;
+    var isOnLinkedNotificationsPage = (bool?) ViewData["OnLinkedNotificationsPage"] ?? false;
 }
 
 @if (!isDraft ||  isOnLinkedNotificationsPage)

--- a/ntbs-service/Pages/Shared/_NotificationUnderBannerNav.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationUnderBannerNav.cshtml
@@ -7,14 +7,16 @@
 
     var isDraft = Model.Notification.NotificationStatus == NotificationStatus.Draft;
     var requiresSeparator = false;
+    var isOnLinkedNotificationsPage = (bool?) TempData["OnLinkedNotificationsPage"] ?? false;
 }
 
-@if (!isDraft)
+@if (!isDraft ||  isOnLinkedNotificationsPage)
 {
     var linkClass = "notification-banner-link" + (currentPage == NotificationSubPaths.Overview ? " notification-banner-link--current" : "");
     <div class="@linkClass">
         <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.Overview)">
-            Notification details
+            @{ var notificationEditLinkText = isOnLinkedNotificationsPage ? "Edit draft" : "Notification details"; }
+            @notificationEditLinkText
         </a>
     </div>
     

--- a/ntbs-service/Pages/Shared/_NotificationUnderBannerNav.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationUnderBannerNav.cshtml
@@ -15,7 +15,7 @@
     var linkClass = "notification-banner-link" + (currentPage == NotificationSubPaths.Overview ? " notification-banner-link--current" : "");
     <div class="@linkClass">
         <a class="app-subnav__link govuk-link govuk-link--no-visited-state" href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.Overview)">
-            @{ var notificationEditLinkText = isOnLinkedNotificationsPage ? "Edit draft" : "Notification details"; }
+            @{ var notificationEditLinkText = isOnLinkedNotificationsPage && isDraft ? "Edit draft" : "Notification details"; }
             @notificationEditLinkText
         </a>
     </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
