### PR TITLE
Ntbs 1061 fix postcode mapping issue

### DIFF
--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -222,8 +222,8 @@ namespace ntbs_service.DataAccess
                 entity.OwnsOne(e => e.PatientDetails, x =>
                 {
                     x.HasOne(pd => pd.PostcodeLookup)
-                    .WithOne()
-                    .HasForeignKey<PatientDetails>(ns => ns.PostcodeToLookup);
+                    .WithMany()
+                    .HasForeignKey(ns => ns.PostcodeToLookup);
 
                     x.ToTable("Patients");
                 });

--- a/ntbs-service/Migrations/20200326150653_FixRelationshipTypeToPostcodes.Designer.cs
+++ b/ntbs-service/Migrations/20200326150653_FixRelationshipTypeToPostcodes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Enums;
@@ -10,9 +11,10 @@ using ntbs_service.Models.Enums;
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20200326150653_FixRelationshipTypeToPostcodes")]
+    partial class FixRelationshipTypeToPostcodes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20200326150653_FixRelationshipTypeToPostcodes.cs
+++ b/ntbs-service/Migrations/20200326150653_FixRelationshipTypeToPostcodes.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class FixRelationshipTypeToPostcodes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Looks like this index doesn't exist, in spite of what EF is convinced off
+            // migrationBuilder.DropIndex(
+            //     name: "IX_Patients_PostcodeToLookup",
+            //     table: "Patients");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Patients_PostcodeToLookup",
+                table: "Patients",
+                column: "PostcodeToLookup");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Patients_PostcodeToLookup",
+                table: "Patients");
+
+            // migrationBuilder.CreateIndex(
+            //     name: "IX_Patients_PostcodeToLookup",
+            //     table: "Patients",
+            //     column: "PostcodeToLookup",
+            //     unique: true,
+            //     filter: "[PatientDetails_PostcodeToLookup] IS NOT NULL");
+        }
+    }
+}

--- a/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
@@ -53,7 +53,7 @@ namespace ntbs_service.Pages.Notifications
                 return RedirectToPage("/Notifications/Overview", new { NotificationId });
             }
 
-            await GetLinkedNotifications();
+            await GetLinkedNotificationsAsync();
 
             return Page();
         }

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
@@ -29,7 +29,7 @@ namespace ntbs_service.Pages.Notifications
                 return NotFound();
             }
 
-            var hasLinkedNotifications = await TryGetLinkedNotifications();
+            var hasLinkedNotifications = await TryGetLinkedNotificationsAsync();
             if (!hasLinkedNotifications)
             {
                 return NotFound();

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -161,7 +161,7 @@ namespace ntbs_service.Pages.Notifications
         protected async Task SetNotificationProperties(bool isBeingSubmitted)
         {
             Notification.SetValidationContext(Notification, isBeingSubmitted);
-            await GetLinkedNotifications();
+            await GetLinkedNotificationsAsync();
         }
 
         private async Task<bool> TryValidateAndSave()

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -50,13 +50,13 @@ namespace ntbs_service.Pages.Notifications
             NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel != PermissionLevel.Edit);
         }
 
-        protected async Task<bool> TryGetLinkedNotifications()
+        protected async Task<bool> TryGetLinkedNotificationsAsync()
         {
-            await GetLinkedNotifications();
+            await GetLinkedNotificationsAsync();
             return Notification.Group != null;
         }
 
-        protected async Task GetLinkedNotifications()
+        protected async Task GetLinkedNotificationsAsync()
         {
             if (Notification.Group == null)
             {

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -47,7 +47,7 @@ namespace ntbs_service.Pages.Notifications
             }
             NotificationId = Notification.NotificationId;
 
-            await GetLinkedNotifications();
+            await GetLinkedNotificationsAsync();
             await GetAlertsAsync();
             await AuthorizeAndSetBannerAsync();
             if (PermissionLevel == PermissionLevel.None)


### PR DESCRIPTION
NTBS-1061 Make notification->postcode mapping many to one

This was implicitly creating a uniqueness expectation, which was creating issues on notifications which shared the same postcode.
