### PR TITLE
NTBS-1066 move reference data to own schema

### DIFF
--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -11,7 +11,7 @@ using ntbs_service.Models.ReferenceEntities;
 
 // Note: we've adopted a convention where reference data lives in a separate schema to the main tables.
 // This allows us to set different permissions easily, to avoid accidental reference data interference.
-// We define reference data as data not directly manipulatable by the application. It wants to be authored by the
+// We define reference data as data not directly manipulated by the application. It wants to be authored by the
 // business rules, rather than by the users.
 // In practice it mainly correlates with tables for which we seed code-first values through the HasData mechanism
 namespace ntbs_service.DataAccess

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -37,7 +37,6 @@ namespace ntbs_service.DataAccess
         public virtual DbSet<NotificationSite> NotificationSite { get; set; }
         public virtual DbSet<NotificationGroup> NotificationGroup { get; set; }
         public virtual DbSet<Site> Site { get; set; }
-        public virtual DbSet<Region> Region { get; set; }
         public virtual DbSet<Sex> Sex { get; set; }
         public virtual DbSet<PHEC> PHEC { get; set; }
         public virtual DbSet<PostcodeLookup> PostcodeLookup { get; set; }
@@ -440,12 +439,6 @@ namespace ntbs_service.DataAccess
                 entity.HasIndex(e => e.ETSID);
                 entity.HasIndex(e => e.LTBRPatientId);
                 entity.HasIndex(e => e.ClusterId);
-            });
-
-            // TODO NTBS-1066 Remove this - it's not used anywhere!
-            modelBuilder.Entity<Region>(entity =>
-            {
-                entity.Property(e => e.Label).HasMaxLength(200);
             });
 
             modelBuilder.Entity<Sex>(entity =>

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -9,6 +9,11 @@ using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
 using ntbs_service.Models.ReferenceEntities;
 
+// Note: we've adopted a convention where reference data lives in a separate schema to the main tables.
+// This allows us to set different permissions easily, to avoid accidental reference data interference.
+// We define reference data as data not directly manipulatable by the application. It wants to be authored by the
+// business rules, rather than by the users.
+// In practice it mainly correlates with tables for which we seed code-first values through the HasData mechanism
 namespace ntbs_service.DataAccess
 {
     [AuditDbContext(IncludeEntityObjects = true)]
@@ -17,10 +22,7 @@ namespace ntbs_service.DataAccess
         // Max Length for fields with enum -> string conversion configured.
         // Without this defaults to NVARCHAR(MAX) as field length.
         private const int EnumMaxLength = 30;
-
-        public NtbsContext()
-        {
-        }
+        private const string ReferenceDataSchemaName = "ReferenceData";
 
         public NtbsContext(DbContextOptions<NtbsContext> options)
             : base(options)
@@ -81,65 +83,7 @@ namespace ntbs_service.DataAccess
         {
             modelBuilder.HasAnnotation("ProductVersion", "2.2.6-servicing-10079");
 
-            modelBuilder.Entity<Country>(entity =>
-            {
-                entity.Property(e => e.Name).HasMaxLength(200);
-                entity.HasIndex(e => new {e.IsLegacy, e.Name});
-            });
-
-
-            modelBuilder.Entity<Country>().HasData(
-                Models.SeedData.Countries.GetCountriesArray()
-            );
-
-            modelBuilder.Entity<Ethnicity>(entity =>
-            {
-                entity.Property(e => e.Code).HasMaxLength(50);
-
-                entity.Property(e => e.Label).HasMaxLength(200);
-            });
-
-            modelBuilder.Entity<Ethnicity>().HasData(
-                new Ethnicity { EthnicityId = 1, Code = "WW", Label = "White", Order = 1 },
-                new Ethnicity { EthnicityId = 8, Code = "H", Label = "Indian", Order = 2 },
-                new Ethnicity { EthnicityId = 9, Code = "J", Label = "Pakistani", Order = 3 },
-                new Ethnicity { EthnicityId = 10, Code = "K", Label = "Bangladeshi", Order = 4 },
-                new Ethnicity { EthnicityId = 11, Code = "L", Label = "Any other Asian background", Order = 5 },
-                new Ethnicity { EthnicityId = 13, Code = "N", Label = "Black African", Order = 6 },
-                new Ethnicity { EthnicityId = 12, Code = "M", Label = "Black Caribbean", Order = 7 },
-                new Ethnicity { EthnicityId = 14, Code = "P", Label = "Any other Black Background", Order = 8 },
-                new Ethnicity { EthnicityId = 16, Code = "R", Label = "Chinese", Order = 9 },
-                new Ethnicity { EthnicityId = 6, Code = "F", Label = "Mixed - White and Asian", Order = 10 },
-                new Ethnicity { EthnicityId = 5, Code = "E", Label = "Mixed - White and Black African", Order = 11 },
-                new Ethnicity { EthnicityId = 4, Code = "D", Label = "Mixed - White and Black Caribbean", Order = 12 },
-                new Ethnicity { EthnicityId = 7, Code = "G", Label = "Any other mixed background", Order = 13 },
-                new Ethnicity { EthnicityId = 15, Code = "S", Label = "Any other ethnic group", Order = 14 },
-                new Ethnicity { EthnicityId = Ethnicities.NotStatedId, Code = "Z", Label = "Not stated", Order = 15 }
-            );
-
-            modelBuilder.Entity<TBService>(entity =>
-            {
-                entity.Property(e => e.Code).HasMaxLength(16);
-                entity.HasKey(e => e.Code);
-                entity.Property(e => e.Name).HasMaxLength(200);
-                /*
-                    TB services have TB service AD group associated with them in a 1-1
-                    mapping. PHEC AD groups are defined on the PHEC model itself, which has a many-to-one mapping to TB Service through TBServiceToPHEC.
-                    AD groups have a length limit if 64 characters, see
-                    https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc756101(v=ws.10)?redirectedfrom=MSDN#fqdn-length-limitations
-                 */
-                entity.Property(e => e.ServiceAdGroup).HasMaxLength(64);
-                entity.HasIndex(e => e.ServiceAdGroup).IsUnique();
-                entity.HasIndex(e => e.Name);
-                entity.HasIndex(e => new {e.IsLegacy, e.Name});
-
-                entity.HasOne(e => e.PHEC)
-                    .WithMany()
-                    .HasForeignKey(tb => tb.PHECCode);
-                entity.HasData(GetTBServicesList());
-            });
-
-            modelBuilder.Entity<Hospital>().HasData(GetHospitalsList());
+            #region enum converters
 
             /*
              * Converters do not nicely handle null values, outputting 'NULL' string into the database.
@@ -168,15 +112,94 @@ namespace ntbs_service.DataAccess
             var animalTbStatusEnumConverter = new EnumToStringConverter<AnimalTbStatus>();
             var treatmentRegimentEnumConverter = new EnumToStringConverter<TreatmentRegimen>();
 
+            #endregion
+
+            modelBuilder.Entity<Country>(entity =>
+            {
+                entity.Property(e => e.Name).HasMaxLength(200);
+                entity.HasIndex(e => new {e.IsLegacy, e.Name});
+
+                entity.ToTable(nameof(Country), ReferenceDataSchemaName);
+
+                entity.HasData(Models.SeedData.Countries.GetCountriesArray());
+            });
+
+            modelBuilder.Entity<Ethnicity>(entity =>
+            {
+                entity.Property(e => e.Code).HasMaxLength(50);
+
+                entity.Property(e => e.Label).HasMaxLength(200);
+
+                entity.ToTable(nameof(Ethnicity), ReferenceDataSchemaName);
+
+                entity.HasData(
+                    new Ethnicity {EthnicityId = 1, Code = "WW", Label = "White", Order = 1},
+                    new Ethnicity {EthnicityId = 8, Code = "H", Label = "Indian", Order = 2},
+                    new Ethnicity {EthnicityId = 9, Code = "J", Label = "Pakistani", Order = 3},
+                    new Ethnicity {EthnicityId = 10, Code = "K", Label = "Bangladeshi", Order = 4},
+                    new Ethnicity {EthnicityId = 11, Code = "L", Label = "Any other Asian background", Order = 5},
+                    new Ethnicity {EthnicityId = 13, Code = "N", Label = "Black African", Order = 6},
+                    new Ethnicity {EthnicityId = 12, Code = "M", Label = "Black Caribbean", Order = 7},
+                    new Ethnicity {EthnicityId = 14, Code = "P", Label = "Any other Black Background", Order = 8},
+                    new Ethnicity {EthnicityId = 16, Code = "R", Label = "Chinese", Order = 9},
+                    new Ethnicity {EthnicityId = 6, Code = "F", Label = "Mixed - White and Asian", Order = 10},
+                    new Ethnicity {EthnicityId = 5, Code = "E", Label = "Mixed - White and Black African", Order = 11},
+                    new Ethnicity
+                    {
+                        EthnicityId = 4, Code = "D", Label = "Mixed - White and Black Caribbean", Order = 12
+                    },
+                    new Ethnicity {EthnicityId = 7, Code = "G", Label = "Any other mixed background", Order = 13},
+                    new Ethnicity {EthnicityId = 15, Code = "S", Label = "Any other ethnic group", Order = 14},
+                    new Ethnicity {EthnicityId = Ethnicities.NotStatedId, Code = "Z", Label = "Not stated", Order = 15}
+                );
+            });
+
+            modelBuilder.Entity<TBService>(entity =>
+            {
+                entity.Property(e => e.Code).HasMaxLength(16);
+                entity.HasKey(e => e.Code);
+                entity.Property(e => e.Name).HasMaxLength(200);
+                /*
+                    TB services have TB service AD group associated with them in a 1-1
+                    mapping. PHEC AD groups are defined on the PHEC model itself, which has a many-to-one mapping to TB Service through TBServiceToPHEC.
+                    AD groups have a length limit if 64 characters, see
+                    https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc756101(v=ws.10)?redirectedfrom=MSDN#fqdn-length-limitations
+                 */
+                entity.Property(e => e.ServiceAdGroup).HasMaxLength(64);
+                entity.HasIndex(e => e.ServiceAdGroup).IsUnique();
+                entity.HasIndex(e => e.Name);
+                entity.HasIndex(e => new {e.IsLegacy, e.Name});
+
+                entity.HasOne(e => e.PHEC)
+                    .WithMany()
+                    .HasForeignKey(tb => tb.PHECCode);
+
+                entity.ToTable(nameof(TbService), ReferenceDataSchemaName);
+
+                entity.HasData(GetTBServicesList());
+            });
+
+            modelBuilder.Entity<Hospital>(entity =>
+            {
+                entity.ToTable(nameof(Hospital), ReferenceDataSchemaName);
+                entity.HasData(GetHospitalsList());
+            });
+
             modelBuilder.Entity<PHEC>(entity =>
             {
                 entity.HasKey(e => e.Code);
+
+                entity.ToTable(nameof(PHEC), ReferenceDataSchemaName);
+
                 entity.HasData(GetPHECList());
             });
 
             modelBuilder.Entity<LocalAuthority>(entity =>
             {
                 entity.HasKey(e => e.Code);
+
+                entity.ToTable(nameof(LocalAuthority), ReferenceDataSchemaName);
+
                 entity.HasData(GetLocalAuthoritiesList());
             });
 
@@ -192,6 +215,8 @@ namespace ntbs_service.DataAccess
                     .WithOne()
                     .HasForeignKey<LocalAuthorityToPHEC>(la => la.PHECCode);
 
+                entity.ToTable(nameof(LocalAuthorityToPHEC), ReferenceDataSchemaName);
+
                 entity.HasData(GetPHECtoLA());
             });
 
@@ -201,6 +226,11 @@ namespace ntbs_service.DataAccess
                 entity.HasOne(e => e.LocalAuthority)
                     .WithMany(c => c.PostcodeLookups)
                     .HasForeignKey(ns => ns.LocalAuthorityCode);
+
+                entity.ToTable(nameof(PostcodeLookup), ReferenceDataSchemaName);
+                
+                // We don't use HasData to populate postcode lookup due to the size of this dataset - 
+                // it would completely clog up any EF actions. We've used manually created migrations instead.
             });
 
             modelBuilder.Entity<Notification>(entity =>
@@ -209,181 +239,193 @@ namespace ntbs_service.DataAccess
                     .WithMany(g => g.Notifications)
                     .HasForeignKey(e => e.GroupId);
 
-                entity.OwnsOne(e => e.HospitalDetails, hospitalDetails =>
-                {
-                    hospitalDetails.Property(e => e.CaseManagerUsername)
-                        .HasMaxLength(64);
+                entity.OwnsOne(e => e.HospitalDetails,
+                    hospitalDetails =>
+                    {
+                        hospitalDetails.Property(e => e.CaseManagerUsername)
+                            .HasMaxLength(64);
 
-                    hospitalDetails.HasOne(e => e.CaseManager);
+                        hospitalDetails.HasOne(e => e.CaseManager);
 
-                    hospitalDetails.ToTable("HospitalDetails");
-                });
+                        hospitalDetails.ToTable("HospitalDetails");
+                    });
 
-                entity.OwnsOne(e => e.PatientDetails, x =>
-                {
-                    x.HasOne(pd => pd.PostcodeLookup)
-                    .WithMany()
-                    .HasForeignKey(ns => ns.PostcodeToLookup);
+                entity.OwnsOne(e => e.PatientDetails,
+                    x =>
+                    {
+                        x.HasOne(pd => pd.PostcodeLookup)
+                            .WithMany()
+                            .HasForeignKey(ns => ns.PostcodeToLookup);
 
-                    x.ToTable("Patients");
-                });
+                        x.ToTable("Patients");
+                    });
 
-                entity.OwnsOne(e => e.ClinicalDetails, e =>
-                {
-                    e.Property(cd => cd.BCGVaccinationState)
-                       .HasConversion(statusEnumConverter)
-                       .HasMaxLength(EnumMaxLength);
-                    e.Property(c => c.DotStatus)
-                        .HasConversion(dotStatusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    e.Property(c => c.HomeVisitCarriedOut)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    e.Property(c => c.HealthcareSetting)
-                        .HasConversion(healthcareSettingEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    e.Property(c => c.EnhancedCaseManagementStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    e.Property(c => c.HIVTestState)
-                        .HasConversion(hivStatusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    e.Property(c => c.Notes)
-                        .HasMaxLength(1000);
-                    e.Property(c => c.TreatmentRegimen)
-                        .HasConversion(treatmentRegimentEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    e.Property(c => c.TreatmentRegimenOtherDescription)
-                        .HasMaxLength(100);
-                    e.Property(c => c.EnhancedCaseManagementLevel)
-                        .HasDefaultValue(0);
-                    e.ToTable("ClinicalDetails");
-                });
+                entity.OwnsOne(e => e.ClinicalDetails,
+                    e =>
+                    {
+                        e.Property(cd => cd.BCGVaccinationState)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        e.Property(c => c.DotStatus)
+                            .HasConversion(dotStatusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        e.Property(c => c.HomeVisitCarriedOut)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        e.Property(c => c.HealthcareSetting)
+                            .HasConversion(healthcareSettingEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        e.Property(c => c.EnhancedCaseManagementStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        e.Property(c => c.HIVTestState)
+                            .HasConversion(hivStatusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        e.Property(c => c.Notes)
+                            .HasMaxLength(1000);
+                        e.Property(c => c.TreatmentRegimen)
+                            .HasConversion(treatmentRegimentEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        e.Property(c => c.TreatmentRegimenOtherDescription)
+                            .HasMaxLength(100);
+                        e.Property(c => c.EnhancedCaseManagementLevel)
+                            .HasDefaultValue(0);
+                        e.ToTable("ClinicalDetails");
+                    });
 
                 entity.OwnsOne(e => e.PatientTBHistory).ToTable("PatientTBHistories");
 
                 entity.OwnsOne(e => e.ContactTracing).ToTable("ContactTracing");
 
-                entity.OwnsOne(e => e.SocialRiskFactors, x =>
-                {
-                    x.OwnsOne(c => c.RiskFactorDrugs, rf =>
+                entity.OwnsOne(e => e.SocialRiskFactors,
+                    x =>
                     {
-                        rf.Property(e => e.Status)
+                        x.OwnsOne(c => c.RiskFactorDrugs,
+                            rf =>
+                            {
+                                rf.Property(e => e.Status)
+                                    .HasConversion(statusEnumConverter)
+                                    .HasMaxLength(EnumMaxLength);
+                                rf.Property(e => e.Type)
+                                    .HasConversion(riskFactorEnumConverter)
+                                    .HasMaxLength(EnumMaxLength)
+                                    .HasDefaultValue(RiskFactorType.Drugs);
+                                rf.ToTable("RiskFactorDrugs");
+                            });
+
+                        x.OwnsOne(c => c.RiskFactorHomelessness,
+                            rh =>
+                            {
+                                rh.Property(e => e.Status)
+                                    .HasConversion(statusEnumConverter)
+                                    .HasMaxLength(EnumMaxLength);
+                                rh.Property(e => e.Type)
+                                    .HasConversion(riskFactorEnumConverter)
+                                    .HasMaxLength(EnumMaxLength)
+                                    .HasDefaultValue(RiskFactorType.Homelessness);
+                                rh.ToTable("RiskFactorHomelessness");
+                            });
+
+                        x.OwnsOne(c => c.RiskFactorImprisonment,
+                            rh =>
+                            {
+                                rh.Property(e => e.Status)
+                                    .HasConversion(statusEnumConverter)
+                                    .HasMaxLength(EnumMaxLength);
+                                rh.Property(e => e.Type)
+                                    .HasConversion(riskFactorEnumConverter)
+                                    .HasMaxLength(EnumMaxLength)
+                                    .HasDefaultValue(RiskFactorType.Imprisonment);
+                                rh.ToTable("RiskFactorImprisonment");
+                            });
+
+                        x.OwnsOne(c => c.RiskFactorSmoking,
+                            rf =>
+                            {
+                                rf.Property(e => e.Status)
+                                    .HasConversion(statusEnumConverter)
+                                    .HasMaxLength(EnumMaxLength);
+                                rf.Property(e => e.Type)
+                                    .HasConversion(riskFactorEnumConverter)
+                                    .HasMaxLength(EnumMaxLength)
+                                    .HasDefaultValue(RiskFactorType.Smoking);
+                                rf.ToTable("RiskFactorSmoking");
+                            });
+
+                        x.Property(e => e.AlcoholMisuseStatus)
                             .HasConversion(statusEnumConverter)
                             .HasMaxLength(EnumMaxLength);
-                        rf.Property(e => e.Type)
-                            .HasConversion(riskFactorEnumConverter)
-                            .HasMaxLength(EnumMaxLength)
-                            .HasDefaultValue(RiskFactorType.Drugs);
-                        rf.ToTable("RiskFactorDrugs");
-                    });
-
-                    x.OwnsOne(c => c.RiskFactorHomelessness, rh =>
-                    {
-                        rh.Property(e => e.Status)
+                        x.Property(e => e.MentalHealthStatus)
                             .HasConversion(statusEnumConverter)
                             .HasMaxLength(EnumMaxLength);
-                        rh.Property(e => e.Type)
-                            .HasConversion(riskFactorEnumConverter)
-                            .HasMaxLength(EnumMaxLength)
-                            .HasDefaultValue(RiskFactorType.Homelessness);
-                        rh.ToTable("RiskFactorHomelessness");
-                    });
-
-                    x.OwnsOne(c => c.RiskFactorImprisonment, rh =>
-                    {
-                        rh.Property(e => e.Status)
+                        x.Property(e => e.AsylumSeekerStatus)
                             .HasConversion(statusEnumConverter)
                             .HasMaxLength(EnumMaxLength);
-                        rh.Property(e => e.Type)
-                            .HasConversion(riskFactorEnumConverter)
-                            .HasMaxLength(EnumMaxLength)
-                            .HasDefaultValue(RiskFactorType.Imprisonment);
-                        rh.ToTable("RiskFactorImprisonment");
-                    });
-
-                    x.OwnsOne(c => c.RiskFactorSmoking, rf =>
-                    {
-                        rf.Property(e => e.Status)
+                        x.Property(e => e.ImmigrationDetaineeStatus)
                             .HasConversion(statusEnumConverter)
                             .HasMaxLength(EnumMaxLength);
-                        rf.Property(e => e.Type)
-                            .HasConversion(riskFactorEnumConverter)
-                            .HasMaxLength(EnumMaxLength)
-                            .HasDefaultValue(RiskFactorType.Smoking);
-                        rf.ToTable("RiskFactorSmoking");
+
+                        x.ToTable("SocialRiskFactors");
                     });
-
-                    x.Property(e => e.AlcoholMisuseStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    x.Property(e => e.MentalHealthStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    x.Property(e => e.AsylumSeekerStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    x.Property(e => e.ImmigrationDetaineeStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-
-                    x.ToTable("SocialRiskFactors");
-                });
 
                 entity.Property(e => e.NotificationStatus)
                     .HasConversion(notificationStatusEnumConverter)
                     .HasMaxLength(EnumMaxLength);
 
-                entity.OwnsOne(e => e.ImmunosuppressionDetails, i =>
-                {
-                    i.Property(e => e.Status)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    i.ToTable("ImmunosuppressionDetails");
-                });
+                entity.OwnsOne(e => e.ImmunosuppressionDetails,
+                    i =>
+                    {
+                        i.Property(e => e.Status)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        i.ToTable("ImmunosuppressionDetails");
+                    });
 
                 entity.OwnsOne(e => e.TravelDetails).ToTable("TravelDetails");
                 entity.OwnsOne(e => e.VisitorDetails).ToTable("VisitorDetails");
-                entity.OwnsOne(e => e.ComorbidityDetails, cd =>
-                {
-                    cd.Property(e => e.DiabetesStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    cd.Property(e => e.HepatitisBStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    cd.Property(e => e.HepatitisCStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    cd.Property(e => e.LiverDiseaseStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    cd.Property(e => e.RenalDiseaseStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
+                entity.OwnsOne(e => e.ComorbidityDetails,
+                    cd =>
+                    {
+                        cd.Property(e => e.DiabetesStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        cd.Property(e => e.HepatitisBStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        cd.Property(e => e.HepatitisCStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        cd.Property(e => e.LiverDiseaseStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        cd.Property(e => e.RenalDiseaseStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
 
-                    cd.ToTable("ComorbidityDetails");
-                });
+                        cd.ToTable("ComorbidityDetails");
+                    });
 
-                entity.OwnsOne(e => e.DenotificationDetails, i =>
-                {
-                    i.Property(e => e.Reason)
-                        .HasConversion(denotificationReasonEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    i.ToTable("DenotificationDetails");
-                });
+                entity.OwnsOne(e => e.DenotificationDetails,
+                    i =>
+                    {
+                        i.Property(e => e.Reason)
+                            .HasConversion(denotificationReasonEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        i.ToTable("DenotificationDetails");
+                    });
 
-                entity.OwnsOne(e => e.MDRDetails, i =>
-                {
-                    i.Property(e => e.ExposureToKnownCaseStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    i.Property(e => e.CaseInUKStatus)
-                        .HasConversion(statusEnumConverter)
-                        .HasMaxLength(EnumMaxLength);
-                    i.ToTable("MDRDetails");
-                });
-                
+                entity.OwnsOne(e => e.MDRDetails,
+                    i =>
+                    {
+                        i.Property(e => e.ExposureToKnownCaseStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        i.Property(e => e.CaseInUKStatus)
+                            .HasConversion(statusEnumConverter)
+                            .HasMaxLength(EnumMaxLength);
+                        i.ToTable("MDRDetails");
+                    });
+
                 entity.OwnsOne(e => e.DrugResistanceProfile)
                     .ToTable("DrugResistanceProfile");
 
@@ -400,22 +442,24 @@ namespace ntbs_service.DataAccess
                 entity.HasIndex(e => e.ClusterId);
             });
 
+            // TODO NTBS-1066 Remove this - it's not used anywhere!
             modelBuilder.Entity<Region>(entity =>
             {
                 entity.Property(e => e.Label).HasMaxLength(200);
             });
 
-
             modelBuilder.Entity<Sex>(entity =>
             {
                 entity.Property(e => e.Label).HasMaxLength(200);
-            });
 
-            modelBuilder.Entity<Sex>().HasData(
-                new Sex { SexId = 1, Label = "Male" },
-                new Sex { SexId = 2, Label = "Female" },
-                new Sex { SexId = Sexes.UnknownId, Label = "Unknown" }
-            );
+                entity.ToTable(nameof(Sex), ReferenceDataSchemaName);
+
+                entity.HasData(
+                    new Sex {SexId = 1, Label = "Male"},
+                    new Sex {SexId = 2, Label = "Female"},
+                    new Sex {SexId = Sexes.UnknownId, Label = "Unknown"}
+                );
+            });
 
             modelBuilder.Entity<NotificationSite>(entity =>
             {
@@ -426,35 +470,40 @@ namespace ntbs_service.DataAccess
                     .HasForeignKey(ns => ns.SiteId);
             });
 
-            modelBuilder.Entity<Site>().HasData(
-                new Site { SiteId = (int)SiteId.PULMONARY, Description = "Pulmonary" },
-                new Site { SiteId = (int)SiteId.BONE_SPINE, Description = "Spine" },
-                new Site { SiteId = (int)SiteId.BONE_OTHER, Description = "Bone/joint: Other" },
-                new Site { SiteId = (int)SiteId.CNS_MENINGITIS, Description = "Meningitis" },
-                new Site { SiteId = (int)SiteId.CNS_OTHER, Description = "CNS: Other" },
-                new Site { SiteId = (int)SiteId.OCULAR, Description = "Ocular" },
-                new Site { SiteId = (int)SiteId.CRYPTIC, Description = "Cryptic disseminated" },
-                new Site { SiteId = (int)SiteId.GASTROINTESTINAL, Description = "Gastrointestinal/peritoneal" },
-                new Site { SiteId = (int)SiteId.GENITOURINARY, Description = "Genitourinary" },
-                new Site { SiteId = (int)SiteId.LYMPH_INTRA, Description = "Intra-thoracic" },
-                new Site { SiteId = (int)SiteId.LYMPH_EXTRA, Description = "Extra-thoracic" },
-                new Site { SiteId = (int)SiteId.LARYNGEAL, Description = "Laryngeal" },
-                new Site { SiteId = (int)SiteId.MILIARY, Description = "Miliary" },
-                new Site { SiteId = (int)SiteId.PLEURAL, Description = "Pleural" },
-                new Site { SiteId = (int)SiteId.PERICARDIAL, Description = "Pericardial" },
-                new Site { SiteId = (int)SiteId.SKIN, Description = "Soft tissue/Skin" },
-                new Site { SiteId = (int)SiteId.OTHER, Description = "Other extra-pulmonary" }
-            );
+            modelBuilder.Entity<Site>(entity => 
+            {
+                entity.ToTable(nameof(Site), ReferenceDataSchemaName);
+                
+                entity.HasData(
+                    new Site {SiteId = (int)SiteId.PULMONARY, Description = "Pulmonary"},
+                    new Site {SiteId = (int)SiteId.BONE_SPINE, Description = "Spine"},
+                    new Site {SiteId = (int)SiteId.BONE_OTHER, Description = "Bone/joint: Other"},
+                    new Site {SiteId = (int)SiteId.CNS_MENINGITIS, Description = "Meningitis"},
+                    new Site {SiteId = (int)SiteId.CNS_OTHER, Description = "CNS: Other"},
+                    new Site {SiteId = (int)SiteId.OCULAR, Description = "Ocular"},
+                    new Site {SiteId = (int)SiteId.CRYPTIC, Description = "Cryptic disseminated"},
+                    new Site {SiteId = (int)SiteId.GASTROINTESTINAL, Description = "Gastrointestinal/peritoneal"},
+                    new Site {SiteId = (int)SiteId.GENITOURINARY, Description = "Genitourinary"},
+                    new Site {SiteId = (int)SiteId.LYMPH_INTRA, Description = "Intra-thoracic"},
+                    new Site {SiteId = (int)SiteId.LYMPH_EXTRA, Description = "Extra-thoracic"},
+                    new Site {SiteId = (int)SiteId.LARYNGEAL, Description = "Laryngeal"},
+                    new Site {SiteId = (int)SiteId.MILIARY, Description = "Miliary"},
+                    new Site {SiteId = (int)SiteId.PLEURAL, Description = "Pleural"},
+                    new Site {SiteId = (int)SiteId.PERICARDIAL, Description = "Pericardial"},
+                    new Site {SiteId = (int)SiteId.SKIN, Description = "Soft tissue/Skin"},
+                    new Site {SiteId = (int)SiteId.OTHER, Description = "Other extra-pulmonary"}
+                );
+            });                   
 
             modelBuilder.Entity<Occupation>(entity =>
             {
                 entity.Property(e => e.Role).HasMaxLength(40);
                 entity.Property(e => e.Sector).HasMaxLength(40);
-            });
 
-            modelBuilder.Entity<Occupation>().HasData(
-                Models.SeedData.Occupations.GetOccupations()
-            );
+                entity.ToTable(nameof(Occupation), ReferenceDataSchemaName);
+
+                entity.HasData(Models.SeedData.Occupations.GetOccupations());
+            });
 
             modelBuilder.Entity<User>(entity =>
             {
@@ -486,6 +535,8 @@ namespace ntbs_service.DataAccess
             {
                 entity.Property(e => e.Description).HasMaxLength(40);
 
+                entity.ToTable(nameof(ManualTestType), ReferenceDataSchemaName);
+
                 entity.HasData(Models.SeedData.ManualTestTypes.GetManualTestTypes());
             });
 
@@ -493,6 +544,8 @@ namespace ntbs_service.DataAccess
             {
                 entity.Property(e => e.Description).HasMaxLength(40);
                 entity.Property(e => e.Category).HasMaxLength(40);
+
+                entity.ToTable(nameof(SampleType), ReferenceDataSchemaName);
 
                 entity.HasData(Models.SeedData.SampleTypes.GetSampleTypes());
             });
@@ -508,6 +561,8 @@ namespace ntbs_service.DataAccess
                 entity.HasOne(e => e.SampleType)
                     .WithMany(sampleType => sampleType.ManualTestTypeSampleTypes)
                     .HasForeignKey(e => e.SampleTypeId);
+
+                entity.ToTable(nameof(ManualTestTypeSampleType), ReferenceDataSchemaName);
 
                 entity.HasData(Models.SeedData.ManualTestTypeSampleTypes.GetJoinDataManualTestTypeToSampleType());
             });
@@ -618,9 +673,12 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.SpecimenId).HasMaxLength(50);
             });
 
-            modelBuilder.Entity<VenueType>().HasData(
-                Models.SeedData.Venues.GetTypes()
-            );
+            modelBuilder.Entity<VenueType>(entity =>
+            {
+                entity.ToTable(nameof(VenueType), ReferenceDataSchemaName);
+
+                entity.HasData(Models.SeedData.Venues.GetTypes());
+            });
 
             modelBuilder.Entity<SocialContextVenue>(entity =>
             {
@@ -651,6 +709,8 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.TreatmentOutcomeSubType)
                     .HasConversion(treatmentOutcomeSubTypeEnumConverter)
                     .HasMaxLength(EnumMaxLength);
+
+                entity.ToTable(nameof(TreatmentOutcome), ReferenceDataSchemaName);
 
                 entity.HasData(Models.SeedData.TreatmentOutcomes.GetTreatmentOutcomes());
             });

--- a/ntbs-service/DataAccess/NtbsContextDesignTimeFactory.cs
+++ b/ntbs-service/DataAccess/NtbsContextDesignTimeFactory.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using System;
+using System.IO;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.Extensions.Configuration;
 
@@ -6,17 +8,18 @@ namespace ntbs_service.DataAccess
 {
     public class NtbsContextDesignTimeFactory : IDesignTimeDbContextFactory<NtbsContext>
     {
-        private readonly IConfiguration Configuration;
-
-        public NtbsContextDesignTimeFactory(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
-
         public NtbsContext CreateDbContext(string[] args)
         {
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json")
+                .AddJsonFile("appsettings.Development.json")
+                .Build();
+            
             var optionsBuilder = new DbContextOptionsBuilder<NtbsContext>();
-            optionsBuilder.UseSqlServer(Configuration.GetConnectionString("ntbsMigratorContext"));
+            var connectionString = configuration.GetConnectionString("ntbsMigratorContext");
+            Console.WriteLine(connectionString);
+            optionsBuilder.UseSqlServer(connectionString);
 
             return new NtbsContext(optionsBuilder.Options);
         }

--- a/ntbs-service/DataAccess/NtbsContextDesignTimeFactory.cs
+++ b/ntbs-service/DataAccess/NtbsContextDesignTimeFactory.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace ntbs_service.DataAccess
+{
+    public class NtbsContextDesignTimeFactory : IDesignTimeDbContextFactory<NtbsContext>
+    {
+        private readonly IConfiguration Configuration;
+
+        public NtbsContextDesignTimeFactory(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public NtbsContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<NtbsContext>();
+            optionsBuilder.UseSqlServer(Configuration.GetConnectionString("ntbsMigratorContext"));
+
+            return new NtbsContext(optionsBuilder.Options);
+        }
+    }
+}

--- a/ntbs-service/Migrations/20200402094217_moveReferenceDataToOwnSchema.Designer.cs
+++ b/ntbs-service/Migrations/20200402094217_moveReferenceDataToOwnSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Enums;
@@ -10,9 +11,10 @@ using ntbs_service.Models.Enums;
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20200402094217_moveReferenceDataToOwnSchema")]
+    partial class moveReferenceDataToOwnSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20200402094217_moveReferenceDataToOwnSchema.cs
+++ b/ntbs-service/Migrations/20200402094217_moveReferenceDataToOwnSchema.cs
@@ -6,10 +6,6 @@ namespace ntbs_service.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Patients_PostcodeToLookup",
-                table: "Patients");
-
             migrationBuilder.EnsureSchema(
                 name: "ReferenceData");
 
@@ -92,19 +88,10 @@ namespace ntbs_service.Migrations
                 name: "Country",
                 newName: "Country",
                 newSchema: "ReferenceData");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Patients_PostcodeToLookup",
-                table: "Patients",
-                column: "PostcodeToLookup");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_Patients_PostcodeToLookup",
-                table: "Patients");
-
             migrationBuilder.RenameTable(
                 name: "VenueType",
                 schema: "ReferenceData",
@@ -184,13 +171,6 @@ namespace ntbs_service.Migrations
                 name: "Country",
                 schema: "ReferenceData",
                 newName: "Country");
-
-            migrationBuilder.CreateIndex(
-                name: "IX_Patients_PostcodeToLookup",
-                table: "Patients",
-                column: "PostcodeToLookup",
-                unique: true,
-                filter: "[PatientDetails_PostcodeToLookup] IS NOT NULL");
         }
     }
 }

--- a/ntbs-service/Migrations/20200402094217_moveReferenceDataToOwnSchema.cs
+++ b/ntbs-service/Migrations/20200402094217_moveReferenceDataToOwnSchema.cs
@@ -1,0 +1,196 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class moveReferenceDataToOwnSchema : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Patients_PostcodeToLookup",
+                table: "Patients");
+
+            migrationBuilder.EnsureSchema(
+                name: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "VenueType",
+                newName: "VenueType",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "TreatmentOutcome",
+                newName: "TreatmentOutcome",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "TbService",
+                newName: "TbService",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "Site",
+                newName: "Site",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "Sex",
+                newName: "Sex",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "SampleType",
+                newName: "SampleType",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "PostcodeLookup",
+                newName: "PostcodeLookup",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "PHEC",
+                newName: "PHEC",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "Occupation",
+                newName: "Occupation",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "ManualTestTypeSampleType",
+                newName: "ManualTestTypeSampleType",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "ManualTestType",
+                newName: "ManualTestType",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "LocalAuthorityToPHEC",
+                newName: "LocalAuthorityToPHEC",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "LocalAuthority",
+                newName: "LocalAuthority",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "Hospital",
+                newName: "Hospital",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "Ethnicity",
+                newName: "Ethnicity",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.RenameTable(
+                name: "Country",
+                newName: "Country",
+                newSchema: "ReferenceData");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Patients_PostcodeToLookup",
+                table: "Patients",
+                column: "PostcodeToLookup");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Patients_PostcodeToLookup",
+                table: "Patients");
+
+            migrationBuilder.RenameTable(
+                name: "VenueType",
+                schema: "ReferenceData",
+                newName: "VenueType");
+
+            migrationBuilder.RenameTable(
+                name: "TreatmentOutcome",
+                schema: "ReferenceData",
+                newName: "TreatmentOutcome");
+
+            migrationBuilder.RenameTable(
+                name: "TbService",
+                schema: "ReferenceData",
+                newName: "TbService");
+
+            migrationBuilder.RenameTable(
+                name: "Site",
+                schema: "ReferenceData",
+                newName: "Site");
+
+            migrationBuilder.RenameTable(
+                name: "Sex",
+                schema: "ReferenceData",
+                newName: "Sex");
+
+            migrationBuilder.RenameTable(
+                name: "SampleType",
+                schema: "ReferenceData",
+                newName: "SampleType");
+
+            migrationBuilder.RenameTable(
+                name: "PostcodeLookup",
+                schema: "ReferenceData",
+                newName: "PostcodeLookup");
+
+            migrationBuilder.RenameTable(
+                name: "PHEC",
+                schema: "ReferenceData",
+                newName: "PHEC");
+
+            migrationBuilder.RenameTable(
+                name: "Occupation",
+                schema: "ReferenceData",
+                newName: "Occupation");
+
+            migrationBuilder.RenameTable(
+                name: "ManualTestTypeSampleType",
+                schema: "ReferenceData",
+                newName: "ManualTestTypeSampleType");
+
+            migrationBuilder.RenameTable(
+                name: "ManualTestType",
+                schema: "ReferenceData",
+                newName: "ManualTestType");
+
+            migrationBuilder.RenameTable(
+                name: "LocalAuthorityToPHEC",
+                schema: "ReferenceData",
+                newName: "LocalAuthorityToPHEC");
+
+            migrationBuilder.RenameTable(
+                name: "LocalAuthority",
+                schema: "ReferenceData",
+                newName: "LocalAuthority");
+
+            migrationBuilder.RenameTable(
+                name: "Hospital",
+                schema: "ReferenceData",
+                newName: "Hospital");
+
+            migrationBuilder.RenameTable(
+                name: "Ethnicity",
+                schema: "ReferenceData",
+                newName: "Ethnicity");
+
+            migrationBuilder.RenameTable(
+                name: "Country",
+                schema: "ReferenceData",
+                newName: "Country");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Patients_PostcodeToLookup",
+                table: "Patients",
+                column: "PostcodeToLookup",
+                unique: true,
+                filter: "[PatientDetails_PostcodeToLookup] IS NOT NULL");
+        }
+    }
+}

--- a/ntbs-service/Migrations/20200402095659_removeUnusedRegionModel.Designer.cs
+++ b/ntbs-service/Migrations/20200402095659_removeUnusedRegionModel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Enums;
@@ -10,9 +11,10 @@ using ntbs_service.Models.Enums;
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20200402095659_removeUnusedRegionModel")]
+    partial class removeUnusedRegionModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20200402095659_removeUnusedRegionModel.cs
+++ b/ntbs-service/Migrations/20200402095659_removeUnusedRegionModel.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class removeUnusedRegionModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Region");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Region",
+                columns: table => new
+                {
+                    RegionId = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn),
+                    Label = table.Column<string>(maxLength: 200, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Region", x => x.RegionId);
+                });
+        }
+    }
+}

--- a/ntbs-service/Models/ReferenceEntities/Region.cs
+++ b/ntbs-service/Models/ReferenceEntities/Region.cs
@@ -1,9 +1,0 @@
-﻿namespace ntbs_service.Models.ReferenceEntities
-{
-    public partial class Region
-    {
-        public int RegionId { get; set; }
-        public string Label { get; set; }
-
-    }
-}

--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -74,7 +74,9 @@ namespace ntbs_service
             try
             {
                 Log.Information("Starting app db migration");
-                var context = services.GetRequiredService<NtbsContext>();
+                // We're using DesignTimeFactory rather than NtbsContext directly in order to use a different login
+                var factory = services.GetRequiredService<NtbsContextDesignTimeFactory>();
+                var context = factory.CreateDbContext(new string[]{});
                 context.Database.Migrate();
             }
             catch (Exception ex)

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -111,6 +111,8 @@ namespace ntbs_service
             services.AddDbContext<NtbsContext>(options =>
                 options.UseSqlServer(Configuration.GetConnectionString("ntbsContext"))
             );
+            
+            services.AddSingleton<NtbsContextDesignTimeFactory>();
 
             var auditDbConnectionString = Configuration.GetConnectionString("auditContext");
 

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
     "ntbsContext": "data source=localhost;initial catalog=ntbsDev;trusted_connection=true;MultipleActiveResultSets=true",
+    "ntbsMigratorContext": "data source=localhost;initial catalog=ntbsDev;trusted_connection=true;MultipleActiveResultSets=true",
     "keysContext": "data source=localhost;initial catalog=ntbsDev;trusted_connection=true;MultipleActiveResultSets=true",
     "auditContext": "data source=localhost;initial catalog=ntbsAudit;trusted_connection=true;MultipleActiveResultSets=true"
   },

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -30,7 +30,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: int-connection-strings
-                key: keysDb
+                key: appDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -19,28 +19,33 @@ spec:
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:
-                name: int-db-connection-string
-                key: connectionString
+                name: int-connection-strings
+                key: appDb
+          - name: ConnectionStrings__ntbsMigratorContext
+            valueFrom:
+              secretKeyRef:
+                name: int-connection-strings
+                key: appDbMigration
           - name: ConnectionStrings__keysContext
             valueFrom:
               secretKeyRef:
-                name: int-db-connection-string
-                key: connectionString
+                name: int-connection-strings
+                key: keysDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:
-                name: int-audit-db-connection-string
-                key: connectionString
+                name: int-connection-strings
+                key: auditDb
           - name: ConnectionStrings__reporting
             valueFrom:
               secretKeyRef:
-                name: int-reporting-db-connection-string
-                key: connectionString
+                name: int-connection-strings
+                key: reportingDb
           - name: ConnectionStrings__specimenMatching
             valueFrom:
               secretKeyRef:
-                name: int-specimen-matching-connection-string
-                key: connectionString
+                name: int-connection-strings
+                key: specimenMatchingDb
           - name: ConnectionStrings__migration
             valueFrom:
               secretKeyRef:

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -30,7 +30,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: test-connection-strings
-                key: keysDb
+                key: appDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -19,28 +19,33 @@ spec:
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:
-                name: test-db-connection-string
-                key: connectionString
+                name: test-connection-strings
+                key: appDb
+          - name: ConnectionStrings__ntbsMigratorContext
+            valueFrom:
+              secretKeyRef:
+                name: test-connection-strings
+                key: appDbMigrator
           - name: ConnectionStrings__keysContext
             valueFrom:
               secretKeyRef:
-                name: test-db-connection-string
-                key: connectionString
+                name: test-connection-strings
+                key: keysDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:
-                name: test-audit-db-connection-string
-                key: connectionString
+                name: test-connection-strings
+                key: auditDb
           - name: ConnectionStrings__reporting
             valueFrom:
               secretKeyRef:
-                name: test-reporting-db-connection-string
-                key: connectionString
+                name: test-connection-strings
+                key: reportingDb
           - name: ConnectionStrings__specimenMatching
             valueFrom:
               secretKeyRef:
-                name: test-specimen-matching-connection-string
-                key: connectionString
+                name: test-connection-strings
+                key: specimenMatchingDb
           - name: ConnectionStrings__migration
             valueFrom:
               secretKeyRef:

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -19,28 +19,33 @@ spec:
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:
-                name: uat-db-connection-string
-                key: connectionString
+                name: uat-connection-strings
+                key: appDb
+          - name: ConnectionStrings__ntbsMigratorContext
+            valueFrom:
+              secretKeyRef:
+                name: uat-connection-strings
+                key: appDbMigrator
           - name: ConnectionStrings__keysContext
             valueFrom:
               secretKeyRef:
-                name: uat-db-connection-string
-                key: connectionString
+                name: uat-connection-strings
+                key: keysDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:
-                name: uat-audit-db-connection-string
-                key: connectionString
+                name: uat-connection-strings
+                key: auditDb
           - name: ConnectionStrings__reporting
             valueFrom:
               secretKeyRef:
-                name: uat-reporting-db-connection-string
-                key: connectionString
+                name: uat-connection-strings
+                key: reportingDb
           - name: ConnectionStrings__specimenMatching
             valueFrom:
               secretKeyRef:
-                name: test-specimen-matching-connection-string
-                key: connectionString
+                name: uat-connection-strings
+                key: specimenMatchingDb
           - name: ConnectionStrings__migration
             valueFrom:
               secretKeyRef:

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -30,7 +30,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 name: uat-connection-strings
-                key: keysDb
+                key: appDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:

--- a/ntbs.sln.DotSettings
+++ b/ntbs.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=adfs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bovis/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Denotification/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=denotified/@EntryIndexedValue">True</s:Boolean>
@@ -6,5 +7,6 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Hangfire/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Healthcare/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Immunosuppression/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mortem/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unmatch/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
This change is best described by the comment I added to the ntbsContext:
> Note: we've adopted a convention where reference data lives in a separate schema to the main tables.
This allows us to set different permissions easily, to avoid accidental reference data interference.
We define reference data as data not directly manipulated by the application. It wants to be authored by the
business rules, rather than by the users.
In practice it mainly correlates with tables for which we seed code-first values through the HasData mechanism

Whilst here I've also moved to a more manageable secrets model, where kubernetes will have a single secret object for all connection strings (per env), differentiated by keys.


## TODO:
- [x] Create new users in the db with read-only access to the reference data schema
- [x] Give migration and runtime different users to ensure app never changes reference data directly
- [x] Update secrets