### PR TITLE
NTBS-1281: Set GroupId to null on cloned notification

### DIFF
--- a/ntbs-service/Services/NotificationCloningService.cs
+++ b/ntbs-service/Services/NotificationCloningService.cs
@@ -45,6 +45,7 @@ namespace ntbs_service.Services
             _context.Entry(notification.TravelDetails).State = EntityState.Detached;
             _context.Entry(notification.VisitorDetails).State = EntityState.Detached;
             notification.NotificationId = 0;
+            notification.GroupId = null;
             
             notification.NotificationSites.ForEach(site => _context.Entry(site).State = EntityState.Detached);
             


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
