### PR TITLE
NTBS-1007 clear travel visitor data bug

### DIFF
--- a/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TravelPageTests.cs
@@ -109,6 +109,32 @@ namespace ntbs_integration_tests.NotificationPages
             resultDocument.AssertErrorMessage("visitor-length3", "Total duration of visits must not exceed 24 months");
         }
 
+        [Fact]
+        public async Task PostNotified_WithLeftOverDataInHiddenInputs_IsValid()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_ID;
+            var url = GetCurrentPathForId(id);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+                // These would normally make the models invalid...
+                ["TravelDetails.StayLengthInMonths1"] = "30", 
+                ["VisitorDetails.StayLengthInMonths1"] = "30", 
+                // ... but the user says they are not providing these details
+                ["TravelDetails.HasTravel"] = "false", 
+                ["VisitorDetails.HasVisitor"] = "false"
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(initialDocument, formData, url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
+        }
+
         [Theory]
         [InlineData("HasTravel")]
         [InlineData("HasVisitor")]

--- a/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/TravelAndVisitorDeatilsTest.cs
@@ -16,6 +16,12 @@ namespace ntbs_service_unit_tests.Models.Entities
             yield return new object[] {new VisitorDetails {ShouldValidateFull = false, HasVisitor = true}};
             yield return new object[] {new VisitorDetails {ShouldValidateFull = true, HasVisitor = true}};
         }
+        
+        public static IEnumerable<object[]> NotifiedBaseDetails()
+        {
+            yield return new object[] {new TravelDetails {ShouldValidateFull = true, HasTravel = true}};
+            yield return new object[] {new VisitorDetails {ShouldValidateFull = true, HasVisitor = true}};
+        }
 
         [Theory, MemberData(nameof(BaseDetails))]
         public void SelectingYes_AndLeavingRestBlank_IsValidInDraftAndFullModes(ITravelOrVisitorDetails details)
@@ -46,7 +52,7 @@ namespace ntbs_service_unit_tests.Models.Entities
         }
 
         [Theory, MemberData(nameof(BaseDetails))]
-        public void ProvidingTotalNumberOfCountriesAlon_IsValid(ITravelOrVisitorDetails details)
+        public void ProvidingTotalNumberOfCountriesAlone_IsValid(ITravelOrVisitorDetails details)
         {
             // Arrange
             var validationResults = new List<ValidationResult>();
@@ -57,6 +63,74 @@ namespace ntbs_service_unit_tests.Models.Entities
 
             // Assert
             Assert.True(isValid, "Expected details to be valid");
+        }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void TotalNumberOfCountriesIsLessThanInputCountries_IsInvalid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.TotalNumberOfCountries = 1;
+            details.Country1Id = 1;
+            details.Country2Id = 2;
+    
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.False(isValid, "Expected details to be invalid");
+        }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void SumOfDurationsIsOver24_IsInvalid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.TotalNumberOfCountries = 3;
+            details.Country1Id = 1;
+            details.StayLengthInMonths1 = 10;
+            details.Country2Id = 2;
+            details.StayLengthInMonths2 = 10;
+            details.Country3Id = 3;
+            details.StayLengthInMonths3 = 10;
+            
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.False(isValid, "Expected details to be invalid");
+        }
+
+        [Theory, MemberData(nameof(BaseDetails))]
+        public void ProvidingDuplicateCountries_IsInvalid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.TotalNumberOfCountries = 2;
+            details.Country1Id = 1;
+            details.Country2Id = 1;
+            
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.False(isValid, "Expected details to be invalid");
+        }
+
+        [Theory, MemberData(nameof(NotifiedBaseDetails))]
+        public void ProvidingCountriesWithGaps_IsInvalid(ITravelOrVisitorDetails details)
+        {
+            // Arrange
+            var validationResults = new List<ValidationResult>();
+            details.TotalNumberOfCountries = 2;
+            details.Country1Id = 1;
+            details.Country3Id = 3;
+            
+            // Act
+            var isValid = Validator.TryValidateObject(details, new ValidationContext(details), validationResults, true);
+
+            // Assert
+            Assert.False(isValid, "Expected details to be invalid");
         }
 
         [Theory, MemberData(nameof(BaseDetails))]

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
@@ -74,11 +74,25 @@ namespace ntbs_service.Pages.Notifications.Edit
         {
             if (TravelDetails.HasTravel != true)
             {
+                ModelState.ClearValidationState($"{nameof(TravelDetails)}.{nameof(TravelDetails.TotalDurationOfTravel)}");
+                ModelState.ClearValidationState($"{nameof(TravelDetails)}.{nameof(TravelDetails.Country1Id)}");
+                ModelState.ClearValidationState($"{nameof(TravelDetails)}.{nameof(TravelDetails.Country2Id)}");
+                ModelState.ClearValidationState($"{nameof(TravelDetails)}.{nameof(TravelDetails.Country3Id)}");
+                ModelState.ClearValidationState($"{nameof(TravelDetails)}.{nameof(TravelDetails.StayLengthInMonths1)}");
+                ModelState.ClearValidationState($"{nameof(TravelDetails)}.{nameof(TravelDetails.StayLengthInMonths2)}");
+                ModelState.ClearValidationState($"{nameof(TravelDetails)}.{nameof(TravelDetails.StayLengthInMonths3)}");
                 Service.ClearTravelOrVisitorFields(TravelDetails);
             }
 
             if (VisitorDetails.HasVisitor != true)
             {
+                ModelState.ClearValidationState($"{nameof(VisitorDetails)}.{nameof(VisitorDetails.TotalDurationOfVisit)}");
+                ModelState.ClearValidationState($"{nameof(VisitorDetails)}.{nameof(VisitorDetails.Country1Id)}");
+                ModelState.ClearValidationState($"{nameof(VisitorDetails)}.{nameof(VisitorDetails.Country2Id)}");
+                ModelState.ClearValidationState($"{nameof(VisitorDetails)}.{nameof(VisitorDetails.Country3Id)}");
+                ModelState.ClearValidationState($"{nameof(VisitorDetails)}.{nameof(VisitorDetails.StayLengthInMonths1)}");
+                ModelState.ClearValidationState($"{nameof(VisitorDetails)}.{nameof(VisitorDetails.StayLengthInMonths2)}");
+                ModelState.ClearValidationState($"{nameof(VisitorDetails)}.{nameof(VisitorDetails.StayLengthInMonths3)}");
                 Service.ClearTravelOrVisitorFields(VisitorDetails);
             }
         }


### PR DESCRIPTION
I've taken this opportunity to shift some of the validation tests from integration to unit.
I think this is a reasonable scheme to follow going forwards:
- unit tests for different validation cases that the models should support
- one test in integration suit to ensure errors get wired up correctly in the html
- otherwise integration tests covering only areas that unit tests can't, such as direct controller behaviour (e.g. here, clearing the validation state correctly)

@ffarmanov let me know what you think! :)

P.S. The shift of tests and the actual bug fix (together with its new test) are in separate commits!