### PR TITLE
NTBS-1054 Surface reason for edit restrictions

### DIFF
--- a/ntbs-service/Helpers/NotificationExtensionMethods.cs
+++ b/ntbs-service/Helpers/NotificationExtensionMethods.cs
@@ -17,7 +17,8 @@ namespace ntbs_service.Helpers
         {
             return notifications.Select(async n =>
                 {
-                    var fullAccess = await authorizationService.GetPermissionLevelForNotificationAsync(user, n) == PermissionLevel.Edit;
+                    var (permissionLevel, _) = await authorizationService.GetPermissionLevelAsync(user, n);
+                    var fullAccess = permissionLevel == PermissionLevel.Edit;
                     return new NotificationBannerModel(
                         n,
                         showPadlock: !fullAccess,

--- a/ntbs-service/Pages/Alerts/TransferRejected.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRejected.cshtml.cs
@@ -40,7 +40,8 @@ namespace ntbs_service.Pages.Alerts
             await AuthorizeAndSetBannerAsync();
             
             // Check edit permission of user and redirect if they don't have permission or the alert does not exist
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != PermissionLevel.Edit || TransferRejectedAlert == null)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != PermissionLevel.Edit || TransferRejectedAlert == null)
             {
                 return RedirectToPage("/Notifications/Overview", new { NotificationId });
             }

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -70,7 +70,7 @@ namespace ntbs_service.Pages.Alerts
             await AuthorizeAndSetBannerAsync();
             
             // Check edit permission of user and redirect if not allowed
-            if (!await AuthorizationService.IsUserAuthorizedToManageAlert(User, TransferAlert))
+            if (!await _authorizationService.IsUserAuthorizedToManageAlert(User, TransferAlert))
             {
                 return RedirectToPage("/Notifications/Overview", new { NotificationId });
             }

--- a/ntbs-service/Pages/LabResults/Index.cshtml.cs
+++ b/ntbs-service/Pages/LabResults/Index.cshtml.cs
@@ -116,7 +116,8 @@ namespace ntbs_service.Pages.LabResults
                 return new JsonResult(new {errorMessage = ValidationMessages.LabResultNotificationDoesNotExist});
             }
 
-            if (await _authorizationService.GetPermissionLevelForNotificationAsync(User, notification) != PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 return new JsonResult(new {errorMessage = ValidationMessages.LabResultNotificationMatchNoPermission});
             }
@@ -184,7 +185,8 @@ namespace ntbs_service.Pages.LabResults
                     "When performing a specimen match via `/LabResults`, a candidate match was not found in the ntbs database.");
             }
 
-            if (await _authorizationService.GetPermissionLevelForNotificationAsync(User, notification) != PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 ModelState.AddModelError(candidateMatchModelStateKey,
                     ValidationMessages.LabResultNotificationMatchNoPermission);
@@ -207,7 +209,9 @@ namespace ntbs_service.Pages.LabResults
                 ModelState.AddModelError(manualMatchModelStateKey,
                     ValidationMessages.LabResultNotificationDoesNotExist);
             }
-            else if (await _authorizationService.GetPermissionLevelForNotificationAsync(User, notification) != PermissionLevel.Edit)
+            
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 ModelState.AddModelError(manualMatchModelStateKey,
                     ValidationMessages.LabResultNotificationMatchNoPermission);

--- a/ntbs-service/Pages/Messages.cs
+++ b/ntbs-service/Pages/Messages.cs
@@ -3,5 +3,8 @@ namespace ntbs_service.Pages
     public static class Messages
     {
         public const string UnauthorizedWarning = "You do not have permission to view the full details of this record";
+        public const string NoEditPermission = "You do not have permission to edit this notification";
+        public const string ClosedNoEdit = "You cannot edit this notification because it is closed";
+        public const string Closed = "This notification is closed";
     }
 }

--- a/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
@@ -61,7 +61,9 @@ namespace ntbs_service.Pages.Notifications
         public async Task<IActionResult> OnPostConfirmAsync()
         {
             Notification = await NotificationRepository.GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != PermissionLevel.Edit)
+            
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisAnimalExposure.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisAnimalExposure.cshtml.cs
@@ -87,7 +87,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         public async Task<IActionResult> OnPostDeleteAsync()
         {
             Notification = await GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != Models.Enums.PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != Models.Enums.PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
@@ -90,7 +90,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         public async Task<IActionResult> OnPostDeleteAsync()
         {
             Notification = await GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != Models.Enums.PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisOccupationExposure.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisOccupationExposure.cshtml.cs
@@ -87,7 +87,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         public async Task<IActionResult> OnPostDeleteAsync()
         {
             Notification = await GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != Models.Enums.PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != Models.Enums.PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisUnpasteurisedMilkConsumption.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisUnpasteurisedMilkConsumption.cshtml.cs
@@ -88,8 +88,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         public async Task<IActionResult> OnPostDeleteAsync()
         {
             Notification = await GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) !=
-                Models.Enums.PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != Models.Enums.PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -84,7 +84,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         public async Task<IActionResult> OnPostDeleteAsync()
         {
             Notification = await GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
@@ -69,7 +69,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         public async Task<IActionResult> OnPostDeleteAsync()
         {
             Notification = await GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -136,7 +136,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         public async Task<IActionResult> OnPostDeleteAsync()
         {
             Notification = await GetNotificationAsync(NotificationId);
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != PermissionLevel.Edit)
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
@@ -40,7 +40,7 @@ namespace ntbs_service.Pages.Notifications
             // Deleted notifications should have their group ID removed so they should not appear here
             LinkedNotifications = Notification.Group.Notifications
                 .Where(n => n.NotificationId != NotificationId)
-                .CreateNotificationBanners(User, AuthorizationService).ToList();
+                .CreateNotificationBanners(User, _authorizationService).ToList();
 
             return Page();
         }

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -78,7 +78,9 @@ namespace ntbs_service.Pages.Notifications
             {
                 return NotFound();
             }
-            if (await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification) != PermissionLevel.Edit)
+
+            var (permissionLevel, _) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            if (permissionLevel != PermissionLevel.Edit)
             {
                 return ForbiddenResult();
             }

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -17,7 +17,7 @@ namespace ntbs_service.Pages.Notifications
     public abstract class NotificationModelBase : PageModel, IWithNotificationBanner
     {
         protected INotificationService Service;
-        protected IAuthorizationService AuthorizationService;
+        protected IAuthorizationService _authorizationService;
         protected INotificationRepository NotificationRepository;
 
         protected NotificationModelBase(
@@ -26,7 +26,7 @@ namespace ntbs_service.Pages.Notifications
             INotificationRepository notificationRepository = null)
         {
             Service = service;
-            AuthorizationService = authorizationService;
+            _authorizationService = authorizationService;
             NotificationRepository = notificationRepository;
         }
         public int NumberOfLinkedNotifications { get; set; }
@@ -35,8 +35,8 @@ namespace ntbs_service.Pages.Notifications
         public NotificationBannerModel NotificationBannerModel { get; set; }
         public IList<Alert> Alerts { get; set; }
         public DataQualityDraftAlert DraftAlert { get; set; }
-
         public PermissionLevel PermissionLevel { get; set; }
+        public string PermissionReason { get; set; }
 
         [BindProperty(SupportsGet = true)]
         public int NotificationId { get; set; }
@@ -48,7 +48,9 @@ namespace ntbs_service.Pages.Notifications
 
         protected async Task AuthorizeAndSetBannerAsync()
         {
-            PermissionLevel = await AuthorizationService.GetPermissionLevelForNotificationAsync(User, Notification);
+            var (permissionLevel,  reason) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
+            PermissionLevel = permissionLevel;
+            PermissionReason = reason;
             NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel != PermissionLevel.Edit);
         }
 

--- a/ntbs-service/Pages/Notifications/Overview.cshtml
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml
@@ -9,13 +9,6 @@
     ViewData["CurrentPage"] = NotificationSubPaths.Overview;
 }
 
-@if (!string.IsNullOrEmpty(Model.PermissionReason))
-{
-    <div class="notification-overview-details-container no-print" >
-        <nhs-inset-text classes="nhs-inset-text--ntbs">@Model.PermissionReason</nhs-inset-text>
-    </div>
-}
-
 <partial name="./OverviewPartials/_ClusterInformationOverviewPartial" for="Notification"/>
 
 <partial name="./OverviewPartials/_PatientOverviewPartial"/>

--- a/ntbs-service/Pages/Notifications/Overview.cshtml
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml
@@ -11,7 +11,7 @@
 
 @if (!string.IsNullOrEmpty(Model.PermissionReason))
 {
-    <div class="notification-overview-details-container">
+    <div class="notification-overview-details-container no-print" >
         <nhs-inset-text classes="nhs-inset-text--ntbs">@Model.PermissionReason</nhs-inset-text>
     </div>
 }

--- a/ntbs-service/Pages/Notifications/Overview.cshtml
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml
@@ -1,6 +1,5 @@
 @page "/Notifications/{NotificationId:int}/{handler?}"
 @using ntbs_service.Helpers
-@using ntbs_service.Models.Enums
 @model OverviewModel
 
 @{
@@ -10,10 +9,10 @@
     ViewData["CurrentPage"] = NotificationSubPaths.Overview;
 }
 
-@if (Model.Notification.NotificationStatus == NotificationStatus.Closed)
+@if (!string.IsNullOrEmpty(Model.PermissionReason))
 {
     <div class="notification-overview-details-container">
-        <p>This notification is closed</p>
+        <nhs-inset-text classes="nhs-inset-text--ntbs">@Model.PermissionReason</nhs-inset-text>
     </div>
 }
 

--- a/ntbs-service/Pages/Notifications/UnauthorizedWarning.cshtml
+++ b/ntbs-service/Pages/Notifications/UnauthorizedWarning.cshtml
@@ -1,5 +1,4 @@
 @model NotificationModelBase
-@using ntbs_service.Pages
 @using ntbs_service.Helpers
 
 @{
@@ -7,9 +6,3 @@
     ViewData["CurrentPage"] = NotificationSubPaths.Overview;
     ViewData["Title"] = "Unauthorised";
 }
-
-<nhs-width-container container-width="Standard">
-    <div id="unauthorized-warning">
-        <p>@(Messages.UnauthorizedWarning)</p>
-    </div>
-</nhs-width-container>

--- a/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
@@ -28,6 +28,12 @@
         </nhs-grid-column>
 
         <nhs-grid-column grid-column-width="Full">
+            @if (!string.IsNullOrEmpty(Model.PermissionReason))
+            {
+                <div class="notification-overview-details-container no-print" >
+                    <nhs-inset-text classes="nhs-inset-text--ntbs">@Model.PermissionReason</nhs-inset-text>
+                </div>
+            }
             @RenderBody()
         </nhs-grid-column>
 

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -6,6 +6,7 @@ using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
+using ntbs_service.Pages;
 
 namespace ntbs_service.Services
 {
@@ -66,16 +67,13 @@ namespace ntbs_service.Services
                 return (PermissionLevel.Edit,
                         // National team members are allowed to modify even closed notifications, but it is useful
                         // for them to be able to tell when they are closed.
-                        notification.NotificationStatus == NotificationStatus.Closed
-                            ? "This notification is closed"
-                            : null
-                    );
+                        notification.NotificationStatus == NotificationStatus.Closed ? Messages.Closed : null);
             }
 
             if (UserHasDirectRelationToNotification(notification)) 
             {
                 return notification.NotificationStatus == NotificationStatus.Closed
-                    ? (PermissionLevel.ReadOnly, "You cannot edit this notification because it is closed")
+                    ? (PermissionLevel.ReadOnly, Messages.ClosedNoEdit)
                     : (PermissionLevel.Edit, null);
             }
 
@@ -83,10 +81,10 @@ namespace ntbs_service.Services
                 || UserHasDirectRelationToLinkedNotification(notification)
                 || UserPreviouslyHadDirectionRelationToNotification(notification))
             {
-                return (PermissionLevel.ReadOnly, "You do not have permission to edit this notification");
+                return (PermissionLevel.ReadOnly, Messages.NoEditPermission);
             }
 
-            return (PermissionLevel.None, null);
+            return (PermissionLevel.None, Messages.UnauthorizedWarning);
         }
         
         private async Task<bool> CanEditBannerModelAsync(

--- a/ntbs-service/wwwroot/css/notification.scss
+++ b/ntbs-service/wwwroot/css/notification.scss
@@ -152,3 +152,9 @@
   }
 
 }
+
+.nhs-inset-text--ntbs {
+  border-color: $phe-red;
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/ntbs.sln.DotSettings
+++ b/ntbs.sln.DotSettings
@@ -10,4 +10,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migrator/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Mortem/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Parameterless/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=phec/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unmatch/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
(Commit-by-commit might be useful, as one of them is quite noisy!)
## Checklist:
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE