### PR TITLE
NTBS-1062: Display Notification Not found information when ntbs id is not found

### DIFF
--- a/ntbs-integration-tests/NotificationPages/NotificationSummaryTests.cs
+++ b/ntbs-integration-tests/NotificationPages/NotificationSummaryTests.cs
@@ -37,7 +37,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
-            Assert.Contains("The NTBS ID must be an integer", result);
+            Assert.Contains("Notification Id must be an integer", result);
         }
 
         [Fact]

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -114,7 +114,7 @@
         public const string RelationshipToCaseIsRequired = "Please supply details of the relationship to case";
         public const string NotifiedToPheStatusIsRequired = "Please specify whether case was notified to PHE";
         public const string RelatedNotificationIdCannotBeSameAsNotificationId = "The NTBS ID cannot be the same as the current notification";
-        public const string RelatedNotificationIdMustBeInteger = "The NTBS ID must be an integer";
+        public const string RelatedNotificationIdMustBeInteger = "Notification Id must be an integer";
         #endregion
 
         #region TreatmentEvent

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -34,6 +34,7 @@
         public const string DateShouldBeLaterThanNotification = "{0} must be after the date of notification";
         public const string BeforeCurrentYear = "{0} must be the current year or earlier";
         public const string IdDoesNotMatchNtbsRecord = "The NTBS ID does not match an existing ID in the system";
+        public const string IdNotAvailableInNtbs = "Details not available in NTBS";
   
         #endregion
 

--- a/ntbs-service/Pages/Admin/CloneNotification.cshtml
+++ b/ntbs-service/Pages/Admin/CloneNotification.cshtml
@@ -23,7 +23,7 @@
             var hasRelatedNotificationError = !Model.IsValid($"{nameof(Model.NotificationId)}");
             var relatedNotificationGroupState = hasRelatedNotificationError ? Error : Standard;
         }
-        <validate-related-notification allow-draft="true" inline-template>
+        <validate-related-notification allow-draft="true" allow-legacy-notifications="false" inline-template>
             <nhs-form-group
                 id="@($"{nameof(Model.NotificationId)}")"
                 nhs-form-group-type="@relatedNotificationGroupState"
@@ -39,9 +39,11 @@
                     asp-validation-for="NotificationId">
                 </span>
                 <input
-                    nhs-input-type="Number"
+                    nhs-input-type="Standard"
                     ref="inputField"
                     v-on:blur="validate"
+                    pattern="[0-9]*"
+                    title="Must contain only digits"
                     is-error-input="@hasRelatedNotificationError"
                     fixed-width="Ten"
                     asp-for="NotificationId">

--- a/ntbs-service/Pages/NotificationSummary.cshtml.cs
+++ b/ntbs-service/Pages/NotificationSummary.cshtml.cs
@@ -22,7 +22,7 @@ namespace ntbs_service.Pages
         }
 
         // ReSharper disable once UnusedMember.Global
-        public async Task<ContentResult> OnGetAsync(string notificationId, bool allowDraft = false)
+        public async Task<ContentResult> OnGetAsync(string notificationId, bool allowDraft = false, bool allowLegacyNotifications = false)
         {
             if (string.IsNullOrEmpty(notificationId))
             {
@@ -38,9 +38,12 @@ namespace ntbs_service.Pages
             }
 
             var notification = await _notificationRepository.GetNotificationAsync(parsedId);
+
             if (notification == null || (!allowDraft && !notification.HasBeenNotified))
             {
-                return CreateJsonResponse(new { validationMessage = ValidationMessages.IdDoesNotMatchNtbsRecord });
+                return allowLegacyNotifications 
+                    ? CreateJsonResponse(new { warningMessage = "Details not available in NTBS" }) 
+                    : CreateJsonResponse(new { validationMessage = ValidationMessages.IdDoesNotMatchNtbsRecord });
             }
             var info = NotificationInfo.CreateFromNotification(notification);
             return CreateJsonResponse(new { relatedNotification = info });

--- a/ntbs-service/Pages/NotificationSummary.cshtml.cs
+++ b/ntbs-service/Pages/NotificationSummary.cshtml.cs
@@ -42,7 +42,7 @@ namespace ntbs_service.Pages
             if (notification == null || (!allowDraft && !notification.HasBeenNotified))
             {
                 return allowLegacyNotifications 
-                    ? CreateJsonResponse(new { warningMessage = "Details not available in NTBS" }) 
+                    ? CreateJsonResponse(new { warningMessage = ValidationMessages.IdNotAvailableInNtbs }) 
                     : CreateJsonResponse(new { validationMessage = ValidationMessages.IdDoesNotMatchNtbsRecord });
             }
             var info = NotificationInfo.CreateFromNotification(notification);

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
@@ -99,7 +99,7 @@
                                         var hasRelatedNotificationError = !Model.IsValid($"{nameof(Model.MBovisExposureToKnownCase)}.{nameof(Model.MBovisExposureToKnownCase.ExposureNotificationId)}");
                                         var relatedNotificationGroupState = hasRelatedNotificationError ? Error : Standard;
                                     }
-                                    <validate-related-notification model="@nameof(Model.MBovisExposureToKnownCase)" inline-template>
+                                    <validate-related-notification model="@nameof(Model.MBovisExposureToKnownCase)" allow-draft="false" allow-legacy-notifications="true" inline-template>
                                         <nhs-form-group
                                             id="@($"{nameof(MBovisExposureToKnownCase)}-{nameof(MBovisExposureToKnownCase.ExposureNotificationId)}")"
                                             nhs-form-group-type="@relatedNotificationGroupState"
@@ -115,13 +115,16 @@
                                                 asp-validation-for="MBovisExposureToKnownCase.ExposureNotificationId">
                                             </span>
                                             <input
-                                                nhs-input-type="Number"
+                                                nhs-input-type="Standard"
                                                 ref="inputField"
                                                 v-on:blur="validate"
+                                                pattern="[0-9]*"
+                                                title="Must contain only digits"
                                                 is-error-input="@hasRelatedNotificationError"
                                                 fixed-width="Ten"
                                                 asp-for="MBovisExposureToKnownCase.ExposureNotificationId">
                                             <notification-info v-if="isValid" v-bind:notification-info="relatedNotification"></notification-info>
+                                            <notification-warning v-if="hasWarningMessage" v-bind:warning-message="warningMessage"></notification-warning>
                                         </nhs-form-group>
                                     </validate-related-notification>
                                 </div>

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
@@ -93,7 +93,7 @@
                                         <span nhs-span-type="ErrorMessage" id="notified-to-phe-error"
                                             ref="errorField" asp-validation-for="MDRDetails.NotifiedToPheStatus" has-error="@pheNotifiedError">
                                         </span>
-                                        <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios" v-on:focusout="validate">
+                                        <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios" v-on:change="validate">
                                             <div class="nhsuk-radios__item">
                                                 <input asp-for="MDRDetails.NotifiedToPheStatus" id="notified-yes" class="nhsuk-radios__input" type="radio" value="@Status.Yes" data-aria-controls="conditional-related-notification">
                                                 <label class="nhsuk-label nhsuk-radios__label" for="notified-yes">
@@ -104,7 +104,7 @@
                                                         var hasRelatedNotificationError = !Model.IsValid("MDRDetails.RelatedNotificationId");
                                                         var relatedNotificationGroupState = hasRelatedNotificationError ? Error : Standard;
                                                     }
-                                                    <validate-related-notification allow-draft="true" inline-template>
+                                                    <validate-related-notification allow-draft="true" allow-legacy-notifications="true" inline-template>
                                                         <nhs-form-group
                                                             id="@($"{nameof(Model.MDRDetails.RelatedNotificationId)}")"
                                                             nhs-form-group-type="@relatedNotificationGroupState"
@@ -120,13 +120,16 @@
                                                                 asp-validation-for="MDRDetails.RelatedNotificationId">
                                                             </span>
                                                             <input
-                                                                nhs-input-type="Number"
+                                                                nhs-input-type="Standard"
                                                                 ref="inputField"
                                                                 v-on:blur="validate"
+                                                                pattern="[0-9]*"
+                                                                title="Must contain only digits"
                                                                 is-error-input="@hasRelatedNotificationError"
                                                                 fixed-width="Ten"
                                                                 asp-for="MDRDetails.RelatedNotificationId">
                                                             <notification-info v-if="isValid" v-bind:notification-info="relatedNotification"></notification-info>
+                                                            <notification-warning v-if="hasWarningMessage" v-bind:warning-message="warningMessage"></notification-warning>
                                                         </nhs-form-group>
                                                     </validate-related-notification>
                                                 </div>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
@@ -33,7 +33,7 @@
         </nhs-grid-column>
         
         <nhs-grid-column grid-column-width="OneQuarter">
-            <div class="notification-details-label"> NTBS ID </div>
+            <div class="notification-details-label"> @Html.DisplayNameFor(x => x.Notification.MDRDetails.RelatedNotificationId) </div>
             <div class="cell-min-height">
                 @if (Model.Notification.MDRDetails.IsCountryUK && Model.Notification.MDRDetails.NotifiedToPheStatus == Status.Yes)
                 {

--- a/ntbs-service/wwwroot/source/Components/NotificationWarning.ts
+++ b/ntbs-service/wwwroot/source/Components/NotificationWarning.ts
@@ -1,0 +1,12 @@
+﻿import Vue from "vue";
+
+const NotificationWarning = Vue.extend({
+    props: ["warningMessage"],
+    template: `
+        <div id="notification-info" class="notification-info">
+            <p>{{warningMessage}}</p>
+        </div>
+    `
+});
+
+export default NotificationWarning;

--- a/ntbs-service/wwwroot/source/Components/ValidateRelatedNotification.ts
+++ b/ntbs-service/wwwroot/source/Components/ValidateRelatedNotification.ts
@@ -3,11 +3,13 @@ import { getHeaders, getValidationPath } from "../helpers";
 import axios from "axios";
 
 const ValidateRelatedNotification = Vue.extend({
-    props: ["model", "allowDraft"],
+    props: ["model", "allowDraft", "allowLegacyNotifications"],
     data: function() {
         return {
             relatedNotification: {},
-            isValid: false
+            warningMessage: "",
+            isValid: false,
+            hasWarningMessage: false
         }
     },
     mounted: function() {
@@ -28,7 +30,8 @@ const ValidateRelatedNotification = Vue.extend({
                 url: `/NotificationSummary/${id}`,
                 headers: getHeaders(),
                 params: {
-                    "allowDraft": this.$props.allowDraft
+                    "allowDraft": this.$props.allowDraft,
+                    "allowLegacyNotifications": this.$props.allowLegacyNotifications
                 }
             };
             axios.request(requestConfig)
@@ -42,14 +45,23 @@ const ValidateRelatedNotification = Vue.extend({
                         this.$refs["errorField"].textContent = responseContent.validationMessage;
                         this.relatedNotification = {};
                         this.isValid = false;
+                        this.warningMessage = "";
+                        this.hasWarningMessage = false;
                     } else {
                         // either blank or valid
                         this.$el.classList.remove("nhsuk-form-group--error");
                         this.$refs["errorField"].classList.add("hidden");
                         this.$refs["inputField"].classList.remove("nhsuk-input--error");
                         this.$refs["errorField"].textContent = '';
-                        this.isValid = responseContent.hasOwnProperty('relatedNotification');;
-                        this.relatedNotification = this.isValid ? responseContent.relatedNotification : {};
+                        this.isValid = responseContent.hasOwnProperty('relatedNotification');
+                        this.hasWarningMessage = responseContent.hasOwnProperty('warningMessage');
+                        
+                        if (this.hasWarningMessage) {
+                            this.warningMessage = responseContent.warningMessage;
+                        } else {
+                            this.relatedNotification = this.isValid ? responseContent.relatedNotification : {};
+                        }
+
                     }
                 })
                 .catch((error: any) => {

--- a/ntbs-service/wwwroot/source/app.ts
+++ b/ntbs-service/wwwroot/source/app.ts
@@ -42,6 +42,7 @@ import ConfirmComponent from "./Components/ConfirmComponent";
 import InactivityChecker from "./Components/InactivityChecker";
 import InactivityLeaveComponent from "./Components/InactivityLeaveComponent";
 import DateInput from "./Components/DateInput";
+import NotificationWarning from "./Components/NotificationWarning";
 
 // For compatibility with IE11. ArrayFromPolyfill required by vue-accessible-modal.
 require("es6-promise").polyfill();
@@ -75,6 +76,7 @@ Vue.component("cascading-dropdown", CascadingDropdown);
 Vue.component("tb-service-filtered-alerts", TbServiceFilteredAlerts);
 Vue.component("validate-related-notification", ValidateRelatedNotification);
 Vue.component("notification-info", NotificationInfo);
+Vue.component("notification-warning", NotificationWarning);
 Vue.component("hide-section-if-false", HideSectionIfFalse);
 Vue.component("fetch-specimen-potential-match", FetchSpecimenPotentialMatch);
 Vue.component("filtered-homepage-kpi", FilteredHomepageKpiDetails);


### PR DESCRIPTION
Display Notification Not found information when ntbs id is not found for related notification id.

<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
