### PR TITLE
NTBS-1045: Allow to save MdrDetails and Mbovis with valid related notification ID but in NTBS

### DIFF
--- a/ntbs-integration-tests/NotificationPages/MBovisExposureToKnownCasesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/MBovisExposureToKnownCasesPageTests.cs
@@ -149,10 +149,6 @@ namespace ntbs_integration_tests.NotificationPages
                 "exposure-setting",
                 "Please select Exposure setting");
             resultDocument.AssertErrorSummaryMessage(
-                "MBovisExposureToKnownCase-ExposureNotificationId",
-                "related-notification",
-                "The NTBS ID does not match an existing ID in the system");
-            resultDocument.AssertErrorSummaryMessage(
                 "MBovisExposureToKnownCase-OtherDetails",
                 "other-details",
                 "Other details can only contain letters, numbers and the symbols ' - . , /");

--- a/ntbs-integration-tests/NotificationPages/NotificationSummaryTests.cs
+++ b/ntbs-integration-tests/NotificationPages/NotificationSummaryTests.cs
@@ -37,7 +37,7 @@ namespace ntbs_integration_tests.NotificationPages
 
             // Assert
             var result = await response.Content.ReadAsStringAsync();
-            Assert.Contains("Notification Id must be an integer", result);
+            Assert.Contains("Notification ID should consist of numbers only", result);
         }
 
         [Fact]

--- a/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
+++ b/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
@@ -29,7 +29,7 @@ namespace ntbs_service.Models.Entities
         [RequiredIf(@"NotifiedToPheStatus == Enums.Status.Yes", ErrorMessage = ValidationMessages.FieldRequired)]
         [AssertThat(nameof(ExposureNotificationIdIsDifferentToNotificationId),
             ErrorMessage = ValidationMessages.RelatedNotificationIdCannotBeSameAsNotificationId)]
-        [Display(Name = "NTBS ID")]
+        [Display(Name = "Contact's Notification ID")]
         public int? ExposureNotificationId { get; set; }
         
         [Required(ErrorMessage = ValidationMessages.FieldRequired)]

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -114,8 +114,8 @@
         #region MDR Details
         public const string RelationshipToCaseIsRequired = "Please supply details of the relationship to case";
         public const string NotifiedToPheStatusIsRequired = "Please specify whether case was notified to PHE";
-        public const string RelatedNotificationIdCannotBeSameAsNotificationId = "The NTBS ID cannot be the same as the current notification";
-        public const string RelatedNotificationIdMustBeInteger = "Notification Id must be an integer";
+        public const string RelatedNotificationIdCannotBeSameAsNotificationId = "Contact's Notification ID cannot be the same as the current notification";
+        public const string RelatedNotificationIdMustBeInteger = "Notification ID should consist of numbers only";
         #endregion
 
         #region TreatmentEvent

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
@@ -112,7 +112,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         {
             return ValidationService.GetPropertyValidationResult<MBovisExposureToKnownCase>(key, value, shouldValidateFull);
         }
-        
+
         private async Task ValidateExposureNotification()
         {
             if (MBovisExposureToKnownCase.ExposureNotificationId != null)
@@ -121,16 +121,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
                 {
                     ModelState.AddModelError(
                         $"{nameof(MBovisExposureToKnownCase)}.{nameof(MBovisExposureToKnownCase.ExposureNotificationId)}",
-                        ValidationMessages.RelatedNotificationIdCannotBeSameAsNotificationId);   
-                }
-
-                var exposureNotification = await NotificationRepository.GetNotificationAsync(
-                    MBovisExposureToKnownCase.ExposureNotificationId.Value);
-                if (exposureNotification == null)
-                {
-                    ModelState.AddModelError(
-                        $"{nameof(MBovisExposureToKnownCase)}.{nameof(MBovisExposureToKnownCase.ExposureNotificationId)}",
-                        ValidationMessages.IdDoesNotMatchNtbsRecord);
+                        ValidationMessages.RelatedNotificationIdCannotBeSameAsNotificationId);
                 }
             }
         }

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
@@ -118,8 +118,6 @@
                                                 nhs-input-type="Standard"
                                                 ref="inputField"
                                                 v-on:blur="validate"
-                                                pattern="[0-9]*"
-                                                title="Must contain only digits"
                                                 is-error-input="@hasRelatedNotificationError"
                                                 fixed-width="Ten"
                                                 asp-for="MBovisExposureToKnownCase.ExposureNotificationId">

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
@@ -123,8 +123,6 @@
                                                                 nhs-input-type="Standard"
                                                                 ref="inputField"
                                                                 v-on:blur="validate"
-                                                                pattern="[0-9]*"
-                                                                title="Must contain only digits"
                                                                 is-error-input="@hasRelatedNotificationError"
                                                                 fixed-width="Ten"
                                                                 asp-for="MDRDetails.RelatedNotificationId">

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -83,7 +83,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             }
             
             UpdateFlags();
-            await ValidateRelatedNotification();
+            await ValidateRelatedNotificationId();
             MDRDetails.SetValidationContext(Notification);
 
             if (TryValidateModel(MDRDetails, nameof(MDRDetails)))
@@ -92,16 +92,15 @@ namespace ntbs_service.Pages.Notifications.Edit
             }
         }
 
-        private async Task ValidateRelatedNotification()
+        private async Task ValidateRelatedNotificationId()
         {
             if (MDRDetails.RelatedNotificationId != null)
             {
-                var relatedNotification =
-                    await NotificationRepository.GetNotificationAsync(MDRDetails.RelatedNotificationId.Value);
-                if (relatedNotification == null || !relatedNotification.HasBeenNotified)
+                if (MDRDetails.RelatedNotificationId == NotificationId)
                 {
-                    ModelState.AddModelError("MDRDetails.RelatedNotificationId",
-                        ValidationMessages.IdDoesNotMatchNtbsRecord);
+                    ModelState.AddModelError(
+                        $"MDRDetails.RelatedNotificationId",
+                        ValidationMessages.RelatedNotificationIdCannotBeSameAsNotificationId);
                 }
             }
         }

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
@@ -39,7 +39,7 @@
                 {
                      @Model.Notification.MDRDetails.RelatedNotificationId
                 }
-                else
+                else if (Model.Notification.MDRDetails.NotifiedToPheStatus != null)
                 {
                     @:Case not notified to PHE
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
