### PR TITLE
Ntbs 1064 fix setting is legacy during import

### DIFF
--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -169,7 +169,7 @@
         public const string CharacterValidationWithNumbers = @"[0-9a-zA-z \-,.']+";
         public const string CharacterValidationWithNumbersForwardSlashAndNewLine = @"[0-9a-zA-Z \/\-,.'\n\r]+";
         public const string CharacterValidationWithNumbersForwardSlashExtended = @"[0-9a-zA-Z \/\-,.'`#&+;:$_()\\\[\]=\*\?]+";
-        public const string CharacterValidationWithNumbersForwardSlashExtendedWithNewLine = @"[0-9a-zA-Z \/\-,.'`#&+;:$_()\\\[\]=\*\?\n\r]+";
+        public const string CharacterValidationWithNumbersForwardSlashExtendedWithNewLine = @"[0-9a-zA-Z \/\-,.'`#&+;:$_()<>\\\[\]=\*\?\n\r]+";
         public const string NumbersValidation = @"[0-9]+";
         public const string NumbersHyphenAndSpaceValidation = @"[0-9\- ]+";
         // Taken from https://stackoverflow.com/a/164994/2363767


### PR DESCRIPTION
There `IsLegacy` attribute helps control validation for items where we've relaxed it a little bit for legacy items.
It is set by `SetValidationContext`, which works properly in the case of editing pages, but it actually hasn't been called for models during the validation for import. This attempts to fix that.