### PR TITLE
NTBS-1265: Show Treatment outcome subtype in Notification Overview page

### DIFF
--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -70,7 +70,14 @@
                     {
                         <nhs-table-body-row>
                             <nhs-table-item>@treatmentEvent.FormattedEventDate</nhs-table-item>
-                            <nhs-table-item>@treatmentEvent.FormattedEventTypeAndOutcome</nhs-table-item>
+                            <nhs-table-item>
+                                @treatmentEvent.FormattedEventTypeAndOutcome
+                                @if (treatmentEvent.TreatmentOutcome?.TreatmentOutcomeSubType != null)
+                                {
+                                    <br/>
+                                    <span>@treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType.GetDisplayName()</span>
+                                }
+                            </nhs-table-item>
                             <nhs-table-item>@treatmentEvent.TbService?.Name</nhs-table-item>
                             <nhs-table-item>@treatmentEvent.CaseManager?.FullName</nhs-table-item>
                         </nhs-table-body-row>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
