### PR TITLE
NTBS-1439: Display both ets and ltbr Id as legacy ids

### DIFF
--- a/ntbs-service/Pages/Notifications/OverviewPartials/_PatientOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_PatientOverviewPartial.cshtml
@@ -97,8 +97,19 @@
     </nhs-grid-row>
     <nhs-grid-row>
         <nhs-grid-column grid-column-width="OneQuarter">
-            <div class="notification-details-label"> Legacy ID </div>
-            <div class="cell-min-height"> @Model.Notification.LegacyId </div>
+            <div class="notification-details-label"> Legacy IDs </div>
+            <div class="cell-min-height"> 
+                <span>
+                    @if (!String.IsNullOrEmpty(@Model.Notification.LTBRID))
+                    {
+                        <span>LTBS: @Model.Notification.LTBRID,</span> 
+                    } 
+                    @if (!String.IsNullOrEmpty(@Model.Notification.ETSID))
+                    {
+                        <span>ETS: @Model.Notification.ETSID</span>
+                    }
+                </span>
+            </div>
         </nhs-grid-column>
         <nhs-grid-column grid-column-width="OneQuarter">
             <div class="notification-details-label"> Local Patient ID </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
