### PR TITLE
Ntbs 1440 migration cleanup job

### DIFF
--- a/ntbs-migration-tests/NotificationImportTest.cs
+++ b/ntbs-migration-tests/NotificationImportTest.cs
@@ -11,7 +11,6 @@ using System.Threading.Tasks;
 using ntbs_service.Services;
 using Hangfire.Server;
 using Sentry;
-using Serilog;
 
 namespace ntbs_migration_tests
 {
@@ -21,6 +20,7 @@ namespace ntbs_migration_tests
         private readonly NotificationMapper _notificationMapper;
         private readonly Mock<INotificationRepository> _mockNotificationRepository;
         private readonly Mock<IMigrationRepository> _mockMigrationRepository;
+        private readonly Mock<IMigratedNotificationsMarker> _mockMigratedNotificationsMarker;
         private readonly Mock<IReferenceDataRepository> _mockReferenceDataRepository;
         private readonly Mock<ISpecimenService> _mockSpecimenService;
         private readonly Mock<INotificationImportRepository> _mockNotificationImportRepository;
@@ -48,6 +48,7 @@ namespace ntbs_migration_tests
             _notificationMapper = new NotificationMapper(_mockMigrationRepository.Object, _mockReferenceDataRepository.Object, _mockImportLogger.Object);
 
             _mockNotificationRepository = new Mock<INotificationRepository>();
+            _mockMigratedNotificationsMarker = new Mock<IMigratedNotificationsMarker>();
             _mockNotificationImportRepository = new Mock<INotificationImportRepository>();
             _mockLogger = new Mock<IImportLogger>();
             _mockPostcodeService = new Mock<IPostcodeService>();
@@ -60,6 +61,7 @@ namespace ntbs_migration_tests
                                                                     _mockLogger.Object,
                                                                     _mockSentryHub.Object,
                                                                     _mockMigrationRepository.Object,
+                                                                    _mockMigratedNotificationsMarker.Object,
                                                                     _mockSpecimenService.Object,
                                                                     _mockReferenceDataRepository.Object
                                                                     );

--- a/ntbs-service/DataMigration/MigratedNotificationsMarker.cs
+++ b/ntbs-service/DataMigration/MigratedNotificationsMarker.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.DataMigration
         ///
         /// Requires the NTBS and migration dbs to be hosted in a cross-queryable way.
         /// </summary>
-        Task BulkMarkNotificationsAsImported();
+        Task BulkMarkNotificationsAsImportedAsync();
     }
 
     public class MigratedNotificationsMarker : IMigratedNotificationsMarker
@@ -86,7 +86,7 @@ namespace ntbs_service.DataMigration
             }
         }
 
-        public async Task BulkMarkNotificationsAsImported()
+        public async Task BulkMarkNotificationsAsImportedAsync()
         {
             using (var connection = new SqlConnection(_connectionString))
             {

--- a/ntbs-service/DataMigration/MigratedNotificationsMarker.cs
+++ b/ntbs-service/DataMigration/MigratedNotificationsMarker.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Dapper;
+using Microsoft.Extensions.Configuration;
+using ntbs_service.DataMigration.Exceptions;
+using ntbs_service.Models.Entities;
+
+namespace ntbs_service.DataMigration
+{
+    /// <summary>
+    /// A specialized service for marking legacy notifications in the migration database as imported into this
+    /// instance of NTBS. This marking is important, as it allows the legacy search code to only surface legacy
+    /// notifications that have not been migrated over yet.
+    /// </summary>
+    public interface IMigratedNotificationsMarker
+    {
+        /// <summary>
+        /// Marks the legacy ids of passed notifications as already imported in the migration db. Typically called right
+        /// after the migration of these notifications. Sets import time to now.
+        /// </summary>
+        /// <param name="notifications">The notifications to be marked as imported</param>
+        Task MarkNotificationsAsImportedAsync(ICollection<Notification> notifications);
+
+        /// <summary>
+        /// Goes through the notifications held in the NTBS db and ensures they have all been marked as imported. Where
+        /// they have been, leaves the import time as originally recorded. Where the import record is missing, adds it
+        /// with import time set to now.
+        ///
+        /// Designed as a fallback when the marking of individual imported notifications fails. To be called after the
+        /// completion of mass migration, or as a periodical clean up.
+        ///
+        /// Requires the NTBS and migration dbs to be hosted in a cross-queryable way.
+        /// </summary>
+        Task BulkMarkNotificationsAsImported();
+    }
+
+    public class MigratedNotificationsMarker : IMigratedNotificationsMarker
+    {
+        private readonly string _connectionString;
+        private readonly INotificationImportHelper _importHelper;
+
+        public MigratedNotificationsMarker(IConfiguration _configuration, INotificationImportHelper importHelper)
+        {
+            _connectionString = _configuration.GetConnectionString("migration");
+            _importHelper = importHelper;
+        }
+
+        public async Task MarkNotificationsAsImportedAsync(ICollection<Notification> notifications)
+        {
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                try
+                {
+                    connection.Open();
+
+                    var importedAt = DateTime.Now.ToString("s");
+
+                    foreach (var notification in notifications) // TODO NTBS-1440 mark both ETS and LTBR ids.
+                    {
+                        await connection.ExecuteAsync(
+                            _importHelper.InsertImportedNotificationQuery,
+                            new {notification.LegacyId, ImportedAt = importedAt}
+                        );
+                    }
+                }
+                catch (Exception exception)
+                {
+                    throw new MarkingNotificationsAsImportedFailedException(notifications, exception);
+                }
+            }
+        }
+
+        public async Task BulkMarkNotificationsAsImported()
+        {
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                connection.Open();
+                await connection.ExecuteAsync(_importHelper.BulkInsertImportedNotificationsQuery);
+            }
+        }
+    }
+}

--- a/ntbs-service/DataMigration/MigratedNotificationsMarker.cs
+++ b/ntbs-service/DataMigration/MigratedNotificationsMarker.cs
@@ -59,6 +59,12 @@ namespace ntbs_service.DataMigration
 
                     foreach (var notification in notifications)
                     {
+                        if (String.IsNullOrEmpty(notification.ETSID) && String.IsNullOrEmpty(notification.LTBRID))
+                        {
+                            throw new ApplicationException(
+                                "The imported notification does not have either LTBR or ETS id");
+                        }
+                            
                         // For many notifications it will be overkill to create an imported record against both
                         // its ETS id and its LTBR id, but since NTBS doesn't collect information about which of the
                         // ids the migration code treated as the primary one, this is the safest way to do it.

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -29,7 +29,7 @@ namespace ntbs_service.DataMigration
         Task CreateTableIfNotExists();
         string InsertImportedNotificationQuery { get; }
         string BulkInsertImportedNotificationsQuery { get; }
-        string SelectImportedNotificationByIdQuery { get; }
+        string SelectImportedNotificationWhereIdEquals(string idSelector);
     }
 
     public class NotificationImportHelper : INotificationImportHelper
@@ -94,10 +94,10 @@ namespace ntbs_service.DataMigration
                 )
         ";
 
-        public string SelectImportedNotificationByIdQuery => $@"
+        public string SelectImportedNotificationWhereIdEquals(string idSelector) => $@"
             SELECT *
             FROM {_importedNotificationsTableName} impNtfc
-            WHERE impNtfc.LegacyId = n.PrimaryNotificationId";
+            WHERE impNtfc.LegacyId = {idSelector}";
 
 
         private string CreateTableQuery => $@"

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -41,7 +41,7 @@ namespace ntbs_service.DataMigration
         /// This is relatively safe as the parameter is passed from environment variable rather that user input
         /// </summary>
         private readonly string _importedNotificationsTableName;
-        private readonly string _appDb;
+        private readonly string _ntbsDb;
 
         public NotificationImportHelper(IConfiguration configuration, IOptions<MigrationConfig> migrationConfig, NtbsContext ntbsContext)
         {
@@ -49,9 +49,9 @@ namespace ntbs_service.DataMigration
             var tablePrefix = migrationConfig.Value.TablePrefix;
             _importedNotificationsTableName = $"{tablePrefix}ImportedNotifications";
             
-            // The BulkInsertImportedNotificationsQueryTemplate query needs the name of the app database
-            // - see its doc for more info
-            _appDb = ntbsContext.Database.GetDbConnection().Database;
+            // The BulkInsertImportedNotificationsQueryTemplate query needs the name of the app
+            // database - see its doc for more info
+            _ntbsDb = ntbsContext.Database.GetDbConnection().Database;
         }
 
         public async Task CreateTableIfNotExists()
@@ -79,11 +79,11 @@ namespace ntbs_service.DataMigration
         public string BulkInsertImportedNotificationsQuery => $@" 
             WITH ntbsNotifications AS (
 	            SELECT ETSID AS LegacyId
-	            FROM {_appDb}..Notification 
+	            FROM [{_ntbsDb}]..Notification 
 	            WHERE ETSID IS NOT NULL
 	            UNION
 	            SELECT DISTINCT LTBRID AS LegacyId
-	            FROM {_appDb}..Notification 
+	            FROM [{_ntbsDb}]..Notification 
 	            WHERE LTBRID IS NOT NULL
             )
             INSERT INTO {_importedNotificationsTableName}

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Extensions.Configuration;
 using System.Data.SqlClient;
 using Dapper;
@@ -10,6 +9,21 @@ using ntbs_service.Properties;
 
 namespace ntbs_service.DataMigration
 {
+    /// <summary>
+    /// The need for this helper arises from the fact that we are using the same migration db for multiple environments.
+    /// For the most part, NTBS treats the migration db as a read-only data repository, for the purposes of searching
+    /// through, and migrating in legacy notifications. This allows us to have this single migration db.
+    /// 
+    /// The only exception to this rule is marking which cases have already been migrated in, or "imported".
+    /// This is a duplication of info that exists in the ntbs db (since each imported notification also stores its
+    /// legacy ids) - we do this so that we can so that we can exclude already imported records from further searches
+    /// and import attempts.
+    ///
+    /// But, as the different environments import data independently, we need a separate store of this information for
+    /// each of them. So, we use separate tables - the down side is, this table's name must be dynamic, so each
+    /// environment has its own one. This helper attempts to shield the rest of the codebase from this complexity, by
+    /// being the only class that understands it and exposing ready to consume SQL strings.  
+    /// </summary>
     public interface INotificationImportHelper
     {
         Task CreateTableIfNotExists();
@@ -20,34 +34,49 @@ namespace ntbs_service.DataMigration
 
     public class NotificationImportHelper : INotificationImportHelper
     {
-        private readonly string connectionString;
-        private readonly string importedNotificationsTableName;
-
-        // Dapper does not support dynamic table names as parameters therefore we are using string format
-        // This is relatively safe as the parameter is passed from environment variable rather that user input
-        private readonly string createImportedNotificationsTableQuery = @"
-            IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{0}'))
-            CREATE TABLE {0} (
-                LegacyId varchar(255) NOT NULL PRIMARY KEY,
-                ImportedAt datetime NOT NULL
-            )";
-
+        private readonly string _connectionString;
+        /// <summary>
+        /// Dapper does not support dynamic table names as parameters therefore we are using string interpolation
+        /// to build these SQL queries.
+        /// This is relatively safe as the parameter is passed from environment variable rather that user input
+        /// </summary>
+        private readonly string _importedNotificationsTableName;
         private readonly string _appDb;
 
-        private const string InsertImportedNotificationTemplate = @"
-            INSERT INTO {0} (LegacyId, ImportedAt)
+        public NotificationImportHelper(IConfiguration configuration, IOptions<MigrationConfig> migrationConfig, NtbsContext ntbsContext)
+        {
+            _connectionString = configuration.GetConnectionString("migration");
+            var tablePrefix = migrationConfig.Value.TablePrefix;
+            _importedNotificationsTableName = $"{tablePrefix}ImportedNotifications";
+            
+            // The BulkInsertImportedNotificationsQueryTemplate query needs the name of the app database
+            // - see its doc for more info
+            _appDb = ntbsContext.Database.GetDbConnection().Database;
+        }
+
+        public async Task CreateTableIfNotExists()
+        {
+            using (var connection = new SqlConnection(_connectionString))
+            {
+                connection.Open();
+                await connection.QueryAsync(CreateTableQuery);
+            }
+        }
+
+        public string InsertImportedNotificationQuery => $@"
+            INSERT INTO {_importedNotificationsTableName} (LegacyId, ImportedAt)
             VALUES (@LegacyId, @ImportedAt);
         ";
-
+        
         /// <summary>
         /// This query does something not done elsewhere in the app, by referencing tables from both the app db and
         /// the migration db. As such, it relies on the fact that the two databases are hosted in such a way that
         /// cross-querying is possible. Therefore, it won't work in dev.
-        /// It also means that we need to feed it the app db name which, of course, differs by environment. This
-        /// complexity is typically handled by the EF context, so let's try to lean on that approach as far as
-        /// possible:      
+        /// It also means that we need to feed it the app db name which, of course, differs by environment. We get it
+        /// (in the constructor) from the ntbs context, so we are at least as far as possible leaning on the same
+        /// mechanism as the rest of the application.
         /// </summary>
-        private string BulkInsertImportedNotificationsQueryTemplate() => $@" 
+        public string BulkInsertImportedNotificationsQuery => $@" 
             WITH ntbsNotifications AS (
 	            SELECT ETSID AS LegacyId
 	            FROM {_appDb}..Notification 
@@ -57,44 +86,25 @@ namespace ntbs_service.DataMigration
 	            FROM {_appDb}..Notification 
 	            WHERE LTBRID IS NOT NULL
             )
-            INSERT INTO {0}
+            INSERT INTO {_importedNotificationsTableName}
 	            SELECT LegacyId, GETDATE() FROM ntbsNotifications
-	            WHERE NOT EXISTS (SELECT 1 FROM {0} where {0}.LegacyId = ntbsNotifications.LegacyId)
+	            WHERE NOT EXISTS (
+                    SELECT 1 FROM {_importedNotificationsTableName}
+                    WHERE {_importedNotificationsTableName}.LegacyId = ntbsNotifications.LegacyId
+                )
         ";
 
-        private const string SelectImportedNotificationByIdTemplate = @"
+        public string SelectImportedNotificationByIdQuery => $@"
             SELECT *
-            FROM {0} impNtfc
+            FROM {_importedNotificationsTableName} impNtfc
             WHERE impNtfc.LegacyId = n.PrimaryNotificationId";
 
-        public NotificationImportHelper(IConfiguration configuration, IOptions<MigrationConfig> migrationConfig, NtbsContext ntbsContext)
-        {
-            connectionString = configuration.GetConnectionString("migration");
-            var tablePrefix = migrationConfig.Value.TablePrefix;
-            importedNotificationsTableName = $"{tablePrefix}ImportedNotifications";
-            
-            // The BulkInsertImportedNotificationsQueryTemplate query needs the name of the app database
-            // - see its doc for more info
-            _appDb = ntbsContext.Database.GetDbConnection().Database;
-        }
 
-        public async Task CreateTableIfNotExists()
-        {
-            using (var connection = new SqlConnection(connectionString))
-            {
-                connection.Open();
-                string query = String.Format(createImportedNotificationsTableQuery, importedNotificationsTableName);
-                await connection.QueryAsync(query);
-            }
-        }
-
-        public string InsertImportedNotificationQuery =>
-            string.Format(InsertImportedNotificationTemplate, importedNotificationsTableName);
-
-        public string BulkInsertImportedNotificationsQuery =>
-            string.Format(BulkInsertImportedNotificationsQueryTemplate(), importedNotificationsTableName);
-
-        public string SelectImportedNotificationByIdQuery =>
-            string.Format(SelectImportedNotificationByIdTemplate, importedNotificationsTableName);
+        private string CreateTableQuery => $@"
+            IF (NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = '{_importedNotificationsTableName}'))
+            CREATE TABLE {_importedNotificationsTableName} (
+                LegacyId varchar(255) NOT NULL PRIMARY KEY,
+                ImportedAt datetime NOT NULL
+            )";
     }
 }

--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -3,7 +3,9 @@ using Microsoft.Extensions.Configuration;
 using System.Data.SqlClient;
 using Dapper;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
+using ntbs_service.DataAccess;
 using ntbs_service.Properties;
 
 namespace ntbs_service.DataMigration
@@ -12,6 +14,7 @@ namespace ntbs_service.DataMigration
     {
         Task CreateTableIfNotExists();
         string InsertImportedNotificationQuery { get; }
+        string BulkInsertImportedNotificationsQuery { get; }
         string SelectImportedNotificationByIdQuery { get; }
     }
 
@@ -29,9 +32,34 @@ namespace ntbs_service.DataMigration
                 ImportedAt datetime NOT NULL
             )";
 
+        private readonly string _appDb;
+
         private const string InsertImportedNotificationTemplate = @"
             INSERT INTO {0} (LegacyId, ImportedAt)
             VALUES (@LegacyId, @ImportedAt);
+        ";
+
+        /// <summary>
+        /// This query does something not done elsewhere in the app, by referencing tables from both the app db and
+        /// the migration db. As such, it relies on the fact that the two databases are hosted in such a way that
+        /// cross-querying is possible. Therefore, it won't work in dev.
+        /// It also means that we need to feed it the app db name which, of course, differs by environment. This
+        /// complexity is typically handled by the EF context, so let's try to lean on that approach as far as
+        /// possible:      
+        /// </summary>
+        private string BulkInsertImportedNotificationsQueryTemplate() => $@" 
+            WITH ntbsNotifications AS (
+	            SELECT ETSID AS LegacyId
+	            FROM {_appDb}..Notification 
+	            WHERE ETSID IS NOT NULL
+	            UNION
+	            SELECT DISTINCT LTBRID AS LegacyId
+	            FROM {_appDb}..Notification 
+	            WHERE LTBRID IS NOT NULL
+            )
+            INSERT INTO {0}
+	            SELECT LegacyId, GETDATE() FROM ntbsNotifications
+	            WHERE NOT EXISTS (SELECT 1 FROM {0} where {0}.LegacyId = ntbsNotifications.LegacyId)
         ";
 
         private const string SelectImportedNotificationByIdTemplate = @"
@@ -39,11 +67,15 @@ namespace ntbs_service.DataMigration
             FROM {0} impNtfc
             WHERE impNtfc.LegacyId = n.PrimaryNotificationId";
 
-        public NotificationImportHelper(IConfiguration configuration, IOptions<MigrationConfig> migrationConfig)
+        public NotificationImportHelper(IConfiguration configuration, IOptions<MigrationConfig> migrationConfig, NtbsContext ntbsContext)
         {
             connectionString = configuration.GetConnectionString("migration");
             var tablePrefix = migrationConfig.Value.TablePrefix;
             importedNotificationsTableName = $"{tablePrefix}ImportedNotifications";
+            
+            // The BulkInsertImportedNotificationsQueryTemplate query needs the name of the app database
+            // - see its doc for more info
+            _appDb = ntbsContext.Database.GetDbConnection().Database;
         }
 
         public async Task CreateTableIfNotExists()
@@ -56,7 +88,13 @@ namespace ntbs_service.DataMigration
             }
         }
 
-        public string InsertImportedNotificationQuery => string.Format(InsertImportedNotificationTemplate, importedNotificationsTableName);
-        public string SelectImportedNotificationByIdQuery => string.Format(SelectImportedNotificationByIdTemplate, importedNotificationsTableName);
+        public string InsertImportedNotificationQuery =>
+            string.Format(InsertImportedNotificationTemplate, importedNotificationsTableName);
+
+        public string BulkInsertImportedNotificationsQuery =>
+            string.Format(BulkInsertImportedNotificationsQueryTemplate(), importedNotificationsTableName);
+
+        public string SelectImportedNotificationByIdQuery =>
+            string.Format(SelectImportedNotificationByIdTemplate, importedNotificationsTableName);
     }
 }

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -34,6 +34,7 @@ namespace ntbs_service.DataMigration
         private readonly IPostcodeService _postcodeService;
         private readonly IImportLogger _logger;
         private readonly IMigrationRepository _migrationRepository;
+        private readonly IMigratedNotificationsMarker _migratedNotificationsMarker;
         private readonly ISpecimenService _specimenService;
         private readonly IReferenceDataRepository _referenceDataRepository;
 
@@ -44,6 +45,7 @@ namespace ntbs_service.DataMigration
                              IImportLogger logger,
                              IHub sentryHub,
                              IMigrationRepository migrationRepository,
+                             IMigratedNotificationsMarker migratedNotificationsMarker,
                              ISpecimenService specimenService,
                              IReferenceDataRepository referenceDataRepository)
         {
@@ -58,6 +60,7 @@ namespace ntbs_service.DataMigration
             _postcodeService = postcodeService;
             _logger = logger;
             _migrationRepository = migrationRepository;
+            _migratedNotificationsMarker = migratedNotificationsMarker;
             _specimenService = specimenService;
             _referenceDataRepository = referenceDataRepository;
         }
@@ -173,7 +176,7 @@ namespace ntbs_service.DataMigration
             try
             {
                 var savedNotifications = await _notificationImportRepository.AddLinkedNotificationsAsync(notifications);
-                await _migrationRepository.MarkNotificationsAsImportedAsync(savedNotifications);
+                await _migratedNotificationsMarker.MarkNotificationsAsImportedAsync(savedNotifications);
                 importResult.NtbsIds = savedNotifications.ToDictionary(x => x.LegacyId, x => x.NotificationId);
                 await ImportReferenceLabResultsAsync(savedNotifications, importResult);
 

--- a/ntbs-service/Jobs/HangfireJobScheduler.cs
+++ b/ntbs-service/Jobs/HangfireJobScheduler.cs
@@ -12,6 +12,7 @@ namespace ntbs_service.Jobs
         private const string UnmatchedLabResultAlertsJobId = "unmatched-lab-result-alerts";
         private const string DataQualityAlertsJobId = "data-quality-alerts";
         private const string NotificationClusterUpdateJobId = "notification-cluster-update";
+        private const string MarkImportedNotificationsAsImportedJobId = "mark-notifications-as-imported";
         
         public static void ScheduleRecurringJobs(ScheduledJobsConfig scheduledJobsConfig)
         {
@@ -91,6 +92,19 @@ namespace ntbs_service.Jobs
             else
             {
                 RecurringJob.RemoveIfExists(NotificationClusterUpdateJobId);
+            }
+
+            if (scheduledJobsConfig.MarkImportedNotificationsAsImportedEnabled)
+            {
+                RecurringJob.AddOrUpdate<MarkImportedNotificationsAsImportedJob>(
+                    MarkImportedNotificationsAsImportedJobId,
+                    job => job.Run(JobCancellationToken.Null),
+                    scheduledJobsConfig.MarkImportedNotificationsAsImportedCron,
+                    TimeZoneInfo.Local);
+            }
+            else
+            {
+                RecurringJob.RemoveIfExists(MarkImportedNotificationsAsImportedJobId);
             }
         }
     }

--- a/ntbs-service/Jobs/MarkImportedNotificationsAsImportedJob.cs
+++ b/ntbs-service/Jobs/MarkImportedNotificationsAsImportedJob.cs
@@ -18,7 +18,7 @@ namespace ntbs_service.Jobs
         {
             Log.Information($"Starting mark imported notifications as imported job");
             
-            await _notificationsMarker.BulkMarkNotificationsAsImported();
+            await _notificationsMarker.BulkMarkNotificationsAsImportedAsync();
 
             Log.Information($"Finishing mark imported notifications as imported job");
         }

--- a/ntbs-service/Jobs/MarkImportedNotificationsAsImportedJob.cs
+++ b/ntbs-service/Jobs/MarkImportedNotificationsAsImportedJob.cs
@@ -1,0 +1,26 @@
+﻿using System.Threading.Tasks;
+using Hangfire;
+using ntbs_service.DataMigration;
+using Serilog;
+
+namespace ntbs_service.Jobs
+{
+    public class MarkImportedNotificationsAsImportedJob
+    {
+        private readonly IMigratedNotificationsMarker _notificationsMarker;
+
+        public MarkImportedNotificationsAsImportedJob(IMigratedNotificationsMarker notificationsMarker)
+        {
+            this._notificationsMarker = notificationsMarker;
+        }
+
+        public async Task Run(IJobCancellationToken token)
+        {
+            Log.Information($"Starting mark imported notifications as imported job");
+            
+            await _notificationsMarker.BulkMarkNotificationsAsImported();
+
+            Log.Information($"Finishing mark imported notifications as imported job");
+        }
+    }
+}

--- a/ntbs-service/Pages/Health.cshtml
+++ b/ntbs-service/Pages/Health.cshtml
@@ -1,6 +1,11 @@
 ﻿@page
 @model ntbs_service.Pages.Health
 
+@functions {
+        private const string Tick = "\u2714\ufe0f";
+        private const string Cross = "\u274c\ufe0f";
+}
+
 @{
     Layout = null;
 }
@@ -20,50 +25,105 @@
 
     <div>
         <h2>Optional modules</h2>
-        <div>Audit: @(Model.AuditEnabled ? "enabled" : "disabled")</div>
-        <div>Cluster matching: @(Model.ClusterMatchingEnabled ? "enabled" : "disabled")</div>
-        <div>Reference lab restults: @(Model.ReferenceLabResultsEnabled ? "enabled" : "disabled")</div>
-        <div>Reporing services: @(Model.ReportingServicesEnabled ? "enabled" : "disabled")</div>
+        <div>Audit: @(Model.AuditEnabled ? Tick : Cross)</div>
+        <div>Cluster matching: @(Model.ClusterMatchingEnabled ? Tick : Cross)</div>
+        <div>Reference lab restults: @(Model.ReferenceLabResultsEnabled ? Tick : Cross)</div>
+        <div>Reporing services: @(Model.ReportingServicesEnabled ? Tick : Cross)</div>
     </div>
 
     <div>
         <h2>Scheduled Jobs Configuration</h2>
 
-        <div>User sync job: @(Model.ScheduledJobsConfig.UserSyncEnabled ? "enabled" : "disabled") </div>
-        @if (Model.ScheduledJobsConfig.UserSyncEnabled)
-        {
-            <div>User sync timing: @Model.ScheduledJobsConfig.UserSyncCron</div>
-        }
+        <div>
+            User sync job:
+            @if (Model.ScheduledJobsConfig.UserSyncEnabled)
+            {
+                @Tick
+                <span>Cron: @Model.ScheduledJobsConfig.UserSyncCron</span>
+            }
+            else
+            {
+                @Cross
+            }
+        </div>
 
-        <div>Close inactive notifications job: @(Model.ScheduledJobsConfig.CloseInactiveNotificationsEnabled ? "enabled" : "disabled") </div>
-        @if (Model.ScheduledJobsConfig.CloseInactiveNotificationsEnabled)
-        {
-            <div>Close inactive notifications timing: @Model.ScheduledJobsConfig.CloseInactiveNotificationsCron</div>
-        }
+        <div>
+            Close inactive notifications job:
+            @if (Model.ScheduledJobsConfig.CloseInactiveNotificationsEnabled)
+            {
+                @Tick
+                <span>Cron: @Model.ScheduledJobsConfig.CloseInactiveNotificationsCron</span>
+            }
+            else
+            {
+                @Cross
+            }
+        </div>
 
-        <div>Drug resistance profile update job: @(Model.ScheduledJobsConfig.DrugResistanceProfileUpdateEnabled ? "enabled" : "disabled") </div>
-        @if (Model.ScheduledJobsConfig.DrugResistanceProfileUpdateEnabled)
-        {
-            <div>Drug resistance profile update timing: @Model.ScheduledJobsConfig.DrugResistanceProfileUpdateCron</div>
-        }
+        <div>
+            Drug resistance profile update job:
+            @if (Model.ScheduledJobsConfig.DrugResistanceProfileUpdateEnabled)
+            {
+                @Tick
+                <span>Cron: @Model.ScheduledJobsConfig.DrugResistanceProfileUpdateCron</span>
+            }
+            else
+            {
+                @Cross
+            }
+        </div>
 
-        <div>Unmatched lab result alerts job: @(Model.ScheduledJobsConfig.UnmatchedLabResultAlertsEnabled ? "enabled" : "disabled") </div>
-        @if (Model.ScheduledJobsConfig.UnmatchedLabResultAlertsEnabled)
-        {
-            <div>Unmatched lab result alerts timing: @Model.ScheduledJobsConfig.UnmatchedLabResultAlertsCron</div>
-        }
+        <div>
+            Unmatched lab result alerts job:
+            @if (Model.ScheduledJobsConfig.UnmatchedLabResultAlertsEnabled)
+            {
+                @Tick
+                <span>Cron: @Model.ScheduledJobsConfig.UnmatchedLabResultAlertsCron</span>
+            }
+            else
+            {
+                @Cross
+            }
+        </div>
 
-        <div>Data quality alerts job: @(Model.ScheduledJobsConfig.DataQualityAlertsEnabled ? "enabled" : "disabled") </div>
-        @if (Model.ScheduledJobsConfig.DataQualityAlertsEnabled)
-        {
-            <div>Data quality alerts timing: @Model.ScheduledJobsConfig.DataQualityAlertsCron</div>
-        }
+        <div>
+            Data quality alerts job:
+            @if (Model.ScheduledJobsConfig.DataQualityAlertsEnabled)
+            {
+                @Tick
+                <span>Cron: @Model.ScheduledJobsConfig.DataQualityAlertsCron</span>
+            }
+            else
+            {
+                @Cross
+            }
+        </div>
 
-        <div>Notification cluster update job: @(Model.ScheduledJobsConfig.NotificationClusterUpdateEnabled ? "enabled" : "disabled") </div>
-        @if (Model.ScheduledJobsConfig.NotificationClusterUpdateEnabled)
-        {
-            <div>Notification cluster update timing: @Model.ScheduledJobsConfig.NotificationClusterUpdateCron</div>
-        }
+        <div>
+            Notification cluster update job:
+            @if (Model.ScheduledJobsConfig.NotificationClusterUpdateEnabled)
+            {
+                @Tick
+                <span>Cron: @Model.ScheduledJobsConfig.NotificationClusterUpdateCron</span>
+            }
+            else
+            {
+                @Cross
+            }
+        </div>
+
+        <div>
+            Mark migrated notifications as imported:
+            @if (Model.ScheduledJobsConfig.MarkImportedNotificationsAsImportedEnabled)
+            {
+                @Tick
+                <span>Cron: @Model.ScheduledJobsConfig.MarkImportedNotificationsAsImportedCron</span>
+            }
+            else
+            {
+                @Cross
+            }
+        </div>
     </div>
 
 </div>

--- a/ntbs-service/Properties/ScheduledJobsConfig.cs
+++ b/ntbs-service/Properties/ScheduledJobsConfig.cs
@@ -19,5 +19,8 @@
         
         public bool NotificationClusterUpdateEnabled { get; set; }
         public string NotificationClusterUpdateCron { get; set; }
+        
+        public bool MarkImportedNotificationsAsImportedEnabled { get; set; }
+        public string MarkImportedNotificationsAsImportedCron { get; set; }
     }
 }

--- a/ntbs-service/Services/LegacySearchService.cs
+++ b/ntbs-service/Services/LegacySearchService.cs
@@ -24,17 +24,15 @@ namespace ntbs_service.Services
 
     public class LegacySearchService : ILegacySearchService
     {
-        private const string SelectQueryStartTemplate = @"SELECT * " + FromString;
-        private const string CountQueryTemplate = @"SELECT COUNT(*) " + FromString;
-        const string FromString = @"
+        private string SelectQueryStart => @"SELECT * " + FromString;
+        private string CountQuery => @"SELECT COUNT(*) " + FromString;
+
+        private string FromString => $@"
             FROM MergedNotifications n 
             LEFT JOIN Addresses addrs ON addrs.OldNotificationId = n.PrimaryNotificationId
             LEFT JOIN Demographics dmg ON dmg.OldNotificationId = n.PrimaryNotificationId
-            WHERE NOT EXISTS ({0})
+            WHERE NOT EXISTS ({_notificationImportHelper.SelectImportedNotificationWhereIdEquals("n.PrimaryNotificationId")})
             ";
-        private string SelectQueryStart => string.Format(SelectQueryStartTemplate, _notificationImportHelper.SelectImportedNotificationByIdQuery);
-
-        private string CountQuery => string.Format(CountQueryTemplate, _notificationImportHelper.SelectImportedNotificationByIdQuery);
 
         const string SelectQueryEnd = @"
             ORDER BY CASE
@@ -139,7 +137,7 @@ namespace ntbs_service.Services
                 NotificationStatusString = "Legacy",
                 NotificationDate = (result.NotificationDate as DateTime?).ConvertToString(),
                 Source = result.Source,
-                Sex = Sexes.Where(s => s.SexId == result.NtbsSexId)?.Single().Label,
+                Sex = Sexes.Single(s => s.SexId == result.NtbsSexId).Label,
                 SortByDate = result.NotificationDate,
                 Name = result.FamilyName.ToUpper() + ", " + result.GivenName,
                 CountryOfBirth = result.BirthCountryName,

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -136,6 +136,7 @@ namespace ntbs_service
             services.AddScoped<IReferenceDataRepository, ReferenceDataRepository>();
             services.AddScoped<IAlertRepository, AlertRepository>();
             services.AddScoped<INotificationImportRepository, NotificationImportRepository>();
+            services.AddScoped<IMigratedNotificationsMarker, MigratedNotificationsMarker>();
             services.AddScoped<INotificationImportHelper, NotificationImportHelper>();
             services.AddScoped<IMigrationRepository, MigrationRepository>();
             services.AddScoped<IItemRepository<ManualTestResult>, TestResultRepository>();

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -16,7 +16,8 @@
     "DrugResistanceProfileUpdateEnabled": false,
     "UnmatchedLabResultAlertsEnabled": false,
     "DataQualityAlertsEnabled": false,
-    "NotificationClusterUpdateEnabled": false
+    "NotificationClusterUpdateEnabled": false,
+    "MarkImportedNotificationsAsImportedEnabled": false
   },
   "ExternalLinks": {
     "ReportingUri": ""

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -33,6 +33,8 @@
     "DataQualityAlertsEnabled": true,
     "DataQualityAlertsCron": "0 4 * * *",
     "NotificationClusterUpdateEnabled": true,
-    "NotificationClusterUpdateCron": "0 5 * * 0"
+    "NotificationClusterUpdateCron": "0 5 * * 0",
+    "MarkImportedNotificationsAsImportedEnabled": true,
+    "MarkImportedNotificationsAsImportedCron": "5 4 * * *"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
The main aim of this ticket is to provide a way to update the importedNotifications table(s) after the actual import process. It tries to solve the problem of a notification importing correctly, but failing to make a record of that fact in the migration db. There's not really a way to *prevent* that as such without having a cross-db transaction! So, instead, we're providing a clean-up job, that can:
a) be run at the end of the bulk migration at cutover; and
b) be scheduled to run periodically.

Because it's not actually possible to run this job locally (see comments in code for what causes this limitation), I've only tested the actually SQL query by hand so far. So there are a few more things to finish off - see checklist below - but I think it's a good point to have the code reviewed!

While in this area, I threw in a couple more improvements:
- not fetching data for already-imported notifications in the bulk-migration process (this was causing a lot of unnecessary data piping especially on e.g. a re-trigger of an import job)
- A clean up of the notification import helper

## Checklist:
- [x] Add entries in the env configuration files.
- [x] Test on int (to have basic idea of it working)
- ❌ Test on live (for larger volume and the live permissions setup) - unable to do this whilst we use the migration db on the devbox (and not the one on the cluster). Instead will test for (somewhat larger) volume on test and make sure to record the performance as part of QA.
