### PR TITLE
Ntbs 1633 fix duplicates being pulled in

### DIFF
--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -108,7 +108,7 @@ namespace ntbs_service.DataAccess
         public async Task<bool> NotificationWithLegacyIdExistsAsync(string id)
         {
             return await _context.Notification
-                .AnyAsync(e => e.LTBRID == id || e.ETSID == id);
+                .AnyAsync(n => n.LTBRID == id || n.ETSID == id);
         }
 
         public async Task<int> GetNotificationIdByLegacyIdAsync(string legacyId)

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -466,8 +466,8 @@ namespace ntbs_service.DataAccess
                 entity.HasIndex(e => e.NotificationStatus);
 
                 entity.HasIndex(e => new { e.NotificationStatus, e.SubmissionDate });
-                entity.HasIndex(e => e.LTBRID);
-                entity.HasIndex(e => e.ETSID);
+                entity.HasIndex(e => e.LTBRID).IsUnique();
+                entity.HasIndex(e => e.ETSID).IsUnique();
                 entity.HasIndex(e => e.LTBRPatientId);
                 entity.HasIndex(e => e.ClusterId);
             });

--- a/ntbs-service/DataMigration/ImportLogger.cs
+++ b/ntbs-service/DataMigration/ImportLogger.cs
@@ -32,7 +32,7 @@ namespace ntbs_service.DataMigration
 
         public void LogFailure(PerformContext context, string requestId, string message, Exception exception = null)
         {
-            Log.Information(exception, $"NOTIFICATION IMPORT - {requestId} - {message}");
+            Log.Error(exception, $"NOTIFICATION IMPORT - {requestId} - {message}");
 
             context.SetTextColor(ConsoleTextColor.Red);
             context.WriteLine($"NOTIFICATION IMPORT - {requestId} - {message}");

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -21,6 +21,14 @@ namespace ntbs_service.DataMigration
     {
         [ExpirationTimeTwoWeeks]
         Task<IList<ImportResult>> ImportByLegacyIdsAsync(PerformContext context, string requestId, List<string> legacyIds);
+        /// <summary>
+        /// Import notifications (and their linked ones) with notification dates in range [rangeStartDate, rangeEndDate)
+        /// </summary>
+        /// <param name="context"></param>
+        /// <param name="requestId"></param>
+        /// <param name="rangeStartDate"></param>
+        /// <param name="rangeEndDate"></param>
+        /// <returns></returns>
         [ExpirationTimeTwoWeeks]
         Task<IList<ImportResult>> ImportByDateAsync(PerformContext context, string requestId, DateTime rangeStartDate, DateTime rangeEndDate);
     }
@@ -106,6 +114,8 @@ namespace ntbs_service.DataMigration
                 {
                     _logger.LogFailure(context, requestId, "Invalid state. Some notifications already exist in NTBS database. Manual intervention needed");
                 }
+                // The last option is that ALL notifications in the group were filtered out - that's OK! It means we
+                // have already imported this group - this will show up in the import errors.
             }
 
             var importResults = new List<ImportResult>();

--- a/ntbs-service/Migrations/20200708110716_AddUniquenessIndeciesOnLegacyIds.Designer.cs
+++ b/ntbs-service/Migrations/20200708110716_AddUniquenessIndeciesOnLegacyIds.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Enums;
@@ -10,9 +11,10 @@ using ntbs_service.Models.Enums;
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20200708110716_AddUniquenessIndeciesOnLegacyIds")]
+    partial class AddUniquenessIndeciesOnLegacyIds
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20200708110716_AddUniquenessIndeciesOnLegacyIds.cs
+++ b/ntbs-service/Migrations/20200708110716_AddUniquenessIndeciesOnLegacyIds.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class AddUniquenessIndeciesOnLegacyIds : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_Notification_ETSID",
+                table: "Notification",
+                column: "ETSID",
+                unique: true,
+                filter: "[ETSID] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Notification_LTBRID",
+                table: "Notification",
+                column: "LTBRID",
+                unique: true,
+                filter: "[LTBRID] IS NOT NULL");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Notification_ETSID",
+                table: "Notification");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Notification_LTBRID",
+                table: "Notification");
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -41,6 +41,9 @@ namespace ntbs_service.Models.Entities
         public int NotificationId { get; set; }
         [MaxLength(50)]
         public string ETSID { get; set; }
+        // For LTBR records, this contains the first segment of their legacy id, which corresponds to the "patient" entity in LTBR.
+        // E.g. records with LTBRIDs 123-1 and 123-2 belong to the same patient, with LTBRPatientId 123.
+        // These are all legacy values and are not actively used by the NTBS system.
         [MaxLength(50)]
         public string LTBRPatientId { get; set; }
         [MaxLength(50)]

--- a/ntbs-service/Pages/Admin/Migration.cshtml
+++ b/ntbs-service/Pages/Admin/Migration.cshtml
@@ -11,6 +11,17 @@
     <h1>Import Legacy Notifications</h1>
 
     <form method="post" enctype="multipart/form-data">
+        @if (Model.Triggered)
+        {
+            <nhs-inset-text>
+                Job triggered successfully - see the
+                <a href="/Hangfire">Hangfire dashboard</a>
+                to track the created jobs
+            </nhs-inset-text>
+        }
+        
+        <label nhs-label-type="Standard" asp-for="NotificationIds">Notification Ids</label>
+        <nhs-hint nhs-hint-type="Standard">Enter ids here, or upload a of ids with a single id per line</nhs-hint>
         <input nhs-input-type="Standard" asp-for="NotificationIds">
         <br/>
 
@@ -22,75 +33,79 @@
         </div>
         <br/>
 
-        <date-input inline-template>
-            @{
-                var notificationDateStartError = !Model.ValidationService.IsValid(nameof(Model.NotificationDateRangeStart));
-                var notificationDateStartGroupState = notificationDateStartError ? Error : Standard;
-            }
-            <nhs-form-group nhs-form-group-type=@notificationDateStartGroupState classes="nhs-form-group--import-by-date">
-                <span nhs-span-type="ErrorMessage" id="notification-start-date-error" classes="import-error"
-                    asp-validation-for="NotificationDateRangeStart" has-error="@notificationDateStartError"></span>
-                <label nhs-label-type="Standard" for="notification-start-date"> Start Notification Date Range </label>
-                <nhs-date-input id="notification-start-date">
-                    <nhs-date-input-item>
-                        <nhs-form-group nhs-form-group-type="Standard">
-                            <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Day">Day</label>
-                            <input ref="dayInput" nhs-input-type="Date" fixed-width="Two"
-                                is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Day" />
-                        </nhs-form-group>
-                    </nhs-date-input-item>
-                    <nhs-date-input-item>
-                        <nhs-form-group nhs-form-group-type="Standard">
-                            <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Month">Month</label>
-                            <input ref="monthInput" nhs-input-type="Date" fixed-width="Two"
-                                is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Month" />
-                        </nhs-form-group>
-                    </nhs-date-input-item>
-                    <nhs-date-input-item>
-                        <nhs-form-group nhs-form-group-type="Standard">
-                            <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Year">Year</label>
-                            <input ref="yearInput" nhs-input-type="Date" fixed-width="Four"
-                                is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Year" />
-                        </nhs-form-group>
-                    </nhs-date-input-item>
-                </nhs-date-input>
-            </nhs-form-group>
-        </date-input>
+        <nhs-fieldset>
+            <nhs-fieldset-legend nhs-legend-size="Standard">Date range</nhs-fieldset-legend>
+            <nhs-hint nhs-hint-type="Standard">Including the start date and up to but not including the end date</nhs-hint>
+            <date-input inline-template>
+                @{
+                    var notificationDateStartError = !Model.ValidationService.IsValid(nameof(Model.NotificationDateRangeStart));
+                    var notificationDateStartGroupState = notificationDateStartError ? Error : Standard;
+                }
+                <nhs-form-group nhs-form-group-type=@notificationDateStartGroupState classes="nhs-form-group--import-by-date">
+                    <span nhs-span-type="ErrorMessage" id="notification-start-date-error" classes="import-error"
+                          asp-validation-for="NotificationDateRangeStart" has-error="@notificationDateStartError"></span>
+                    <label nhs-label-type="Standard" for="notification-start-date"> Start date </label>
+                    <nhs-date-input id="notification-start-date">
+                        <nhs-date-input-item>
+                            <nhs-form-group nhs-form-group-type="Standard">
+                                <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Day">Day</label>
+                                <input ref="dayInput" nhs-input-type="Date" fixed-width="Two"
+                                       is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Day"/>
+                            </nhs-form-group>
+                        </nhs-date-input-item>
+                        <nhs-date-input-item>
+                            <nhs-form-group nhs-form-group-type="Standard">
+                                <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Month">Month</label>
+                                <input ref="monthInput" nhs-input-type="Date" fixed-width="Two"
+                                       is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Month"/>
+                            </nhs-form-group>
+                        </nhs-date-input-item>
+                        <nhs-date-input-item>
+                            <nhs-form-group nhs-form-group-type="Standard">
+                                <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Year">Year</label>
+                                <input ref="yearInput" nhs-input-type="Date" fixed-width="Four"
+                                       is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Year"/>
+                            </nhs-form-group>
+                        </nhs-date-input-item>
+                    </nhs-date-input>
+                </nhs-form-group>
+            </date-input>
 
-        <date-input inline-template>
-            @{
-                var notificationDateEndError = !Model.ValidationService.IsValid(nameof(Model.NotificationDateRangeEnd));
-                var notificationDateEndGroupState = notificationDateEndError ? Error : Standard;
-            }
-            <nhs-form-group nhs-form-group-type=@notificationDateEndGroupState classes="nhs-form-group--import-by-date">
-                <span nhs-span-type="ErrorMessage" id="notification-end-date-error" classes="import-error"
-                    asp-validation-for="NotificationDateRangeEnd" has-error="@notificationDateEndError"></span>
-                <label nhs-label-type="Standard" for="notification-end-date"> End Notification Date Range </label>
-                <nhs-date-input id="notification-end-date">
-                    <nhs-date-input-item>
-                        <nhs-form-group nhs-form-group-type="Standard">
-                            <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Day">Day</label>
-                            <input nhs-input-type="Date" fixed-width="Two" ref="dayInput"
-                                is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Day" />
-                        </nhs-form-group>
-                    </nhs-date-input-item>
-                    <nhs-date-input-item>
-                        <nhs-form-group nhs-form-group-type="Standard">
-                            <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Month">Month</label>
-                            <input nhs-input-type="Date" fixed-width="Two" ref="monthInput"
-                                is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Month" />
-                        </nhs-form-group>
-                    </nhs-date-input-item>
-                    <nhs-date-input-item>
-                        <nhs-form-group nhs-form-group-type="Standard">
-                            <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Year">Year</label>
-                            <input nhs-input-type="Date" fixed-width="Four" ref="yearInput"
-                                is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Year" />
-                        </nhs-form-group>
-                    </nhs-date-input-item>
-                </nhs-date-input>
-            </nhs-form-group>
-        </date-input>
+            <date-input inline-template>
+                @{
+                    var notificationDateEndError = !Model.ValidationService.IsValid(nameof(Model.NotificationDateRangeEnd));
+                    var notificationDateEndGroupState = notificationDateEndError ? Error : Standard;
+                }
+                <nhs-form-group nhs-form-group-type=@notificationDateEndGroupState classes="nhs-form-group--import-by-date">
+                    <span nhs-span-type="ErrorMessage" id="notification-end-date-error" classes="import-error"
+                          asp-validation-for="NotificationDateRangeEnd" has-error="@notificationDateEndError"></span>
+                    <label nhs-label-type="Standard" for="notification-end-date"> End date </label>
+                    <nhs-date-input id="notification-end-date">
+                        <nhs-date-input-item>
+                            <nhs-form-group nhs-form-group-type="Standard">
+                                <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Day">Day</label>
+                                <input nhs-input-type="Date" fixed-width="Two" ref="dayInput"
+                                       is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Day"/>
+                            </nhs-form-group>
+                        </nhs-date-input-item>
+                        <nhs-date-input-item>
+                            <nhs-form-group nhs-form-group-type="Standard">
+                                <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Month">Month</label>
+                                <input nhs-input-type="Date" fixed-width="Two" ref="monthInput"
+                                       is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Month"/>
+                            </nhs-form-group>
+                        </nhs-date-input-item>
+                        <nhs-date-input-item>
+                            <nhs-form-group nhs-form-group-type="Standard">
+                                <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Year">Year</label>
+                                <input nhs-input-type="Date" fixed-width="Four" ref="yearInput"
+                                       is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Year"/>
+                            </nhs-form-group>
+                        </nhs-date-input-item>
+                    </nhs-date-input>
+                </nhs-form-group>
+            </date-input>
+        </nhs-fieldset>
 
         <div>
             <button nhs-button-type="Standard" type="submit" value="Import" classes="ntbsuk-button--primary submit-search-button" id="search-button">

--- a/ntbs-service/Properties/MigrationConfig.cs
+++ b/ntbs-service/Properties/MigrationConfig.cs
@@ -2,7 +2,7 @@
 {
     public class MigrationConfig
     {
-        public int DateRangeJobIntervalInMonths { get; set; }
+        public int DateRangeJobIntervalInDays { get; set; }
         public string TablePrefix { get; set; }
     }
 }

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -23,7 +23,7 @@
     "Password": "<Provided by deployment secrets>"
   },
   "MigrationConfig": {
-    "DateRangeJobIntervalInMonths": 2
+    "DateRangeJobIntervalInDays": 1
   },
   "ScheduledJobsConfig": {
     "UserSyncEnabled": true,

--- a/ntbs-service/deployments/dev.yml
+++ b/ntbs-service/deployments/dev.yml
@@ -80,8 +80,6 @@ spec:
 #                  key: password
             - name: ExternalLinks__ReportingUri
               value: ""
-            - name: MigrationConfig__DateRangeJobIntervalInMonths
-              value: "2"
             - name: MigrationConfig__TablePrefix
               value: "PheDev"
             - name: AppConfig__AuditingEnabled

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -92,8 +92,6 @@ spec:
 #                  key: password
             - name: ExternalLinks__ReportingUri
               value: ""
-            - name: MigrationConfig__DateRangeJobIntervalInMonths
-              value: "2"
             - name: MigrationConfig__TablePrefix
               value: "migrationTrial3"
             - name: AppConfig__AuditingEnabled

--- a/ntbs-service/deployments/uat-phe.yml
+++ b/ntbs-service/deployments/uat-phe.yml
@@ -92,8 +92,6 @@ spec:
 #                  key: password
             - name: ExternalLinks__ReportingUri
               value: ""
-            - name: MigrationConfig__DateRangeJobIntervalInMonths
-              value: "2"
             - name: MigrationConfig__TablePrefix
               value: "UatPheMigration"
             - name: ScheduledJobsConfig__UserSyncEnabled

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -1,3 +1,78 @@
 ﻿This folder contains an assortment of  files with auxiliary code that was found useful for the process of testing and
 verifying the outputs of the migration. It is checked in as reference and for re-use where appropriate, but there are no
 automatic mechanisms for running it or tying it with the application code. 
+
+# Analysing migration results
+
+## Copy job results by hand
+Currently, the analysis relies on manual copying out of the json presented on the hangfire's jobs pages  out into
+individual json files. This obviously doesn't scale super well and although it's been sufficient for needs so far, it's
+put a limit on how automatic that process is.
+The migrationAnalysisSnippets.js file contains code for merging those json files together and extracting the relevant
+information.
+
+## Improved process - automated fetching from the db
+Since the hangfire jobs are stored in the db, it's enticing to automate the getting of the results json directly from
+there. So far my attempts at this have failed, and it seems like mostly due to the sizes of the result strings being
+too much to handle properly by different parts of the process. I hope to come back to this after running a migration
+with smaller job sizes (so far we had them at 2-month stretches). See below WIP notes for how to achieve these things.
+
+
+
+
+Migration results are output as part of the hangfire jobs, and can be viewed through the hangfire UI, job by job.
+They are json objects, which contain info on each of the processed records and any errors that have prevented a given
+record from continuing.
+
+Viewing them job-by-job is not super robust though, so there are a couple of scripts to help A) merge them and 
+B) analyse the results.a
+
+## Merging
+The job results are saved in hangfire's db, so we can fetch them all at once from there. 
+
+We want to obtain a csv file with these and the most reliable way to achieve that is recorded here. 
+
+1. Export the data to flat file via a quick SSIS package 
+- see option 4 in this article: https://www.sqlservercentral.com/articles/8-ways-to-export-sql-results-to-a-text-file
+- Select Uniocde on the output options page
+- Select tab as the column delimiter. Using comma will interfere with the commas in the data, 
+so we'll deal with that conversion next! 
+- Use this as the script:
+```SQL
+SELECT TOP (1000) 
+	  [JobId]
+      ,[Data]
+  FROM [NTBS_Live].[HangFire].[State]
+  WHERE [Name] = 'Succeeded'
+  AND JobId IN @JobIdsYouAreInterestedId
+```
+1. Save the results to a csv file.
+    1. Copy the raw text of the output file
+    1. Paste into excel, press `Ctrl` and select "Import wizard"
+    1. Go through the wizard and pay attention to
+        - select tab as the source delimiter
+        - Make the output columns be "Text" and not "General", o/w excel will wrongly parse the json data in those
+        columns
+ 
+ 
+The consumption of the csv
+```js
+let firstRow;
+let lastRow;
+function readAllJsonFromCvs(filePath) {
+    const csv = require('csv-parser');
+    fs.createReadStream(filePath)
+        .pipe(csv())
+        .on('data', (row) => {
+            lastRow = row;
+            if (firstRow == null) firstRow = row;
+            
+            let data = JSON.parse(row.Data);
+            let result = JSON.parse(data.Result);
+            console.log(result);
+        })
+        .on('end', () => {
+            console.log('CSV file successfully processed');
+        });
+}
+```


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
Fixes amounted to:
- eliminating overlap from the dates looked at by the jobs created by date-based bulk migration. Thus reducing the risk that two jobs will even attempt to import the same value in
- Reducing the responsibility of jobs from 2-month periods to single days. This should make the jobs much less long-running, reducing the risk of unfortunate timing of uniqueness checks whislt things are held in-memory.
- setting up uniqueness indexes on the legacy id columns (a belts-and-braces approach)