### PR TITLE
Ntbs 1858 - Added support for Azure AD to NTBS

### DIFF
--- a/ntbs-service/DataAccess/NtbsContextDesignTimeFactory.cs
+++ b/ntbs-service/DataAccess/NtbsContextDesignTimeFactory.cs
@@ -12,13 +12,19 @@ namespace ntbs_service.DataAccess
         {
             string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production";
             
-            IConfigurationRoot configuration = new ConfigurationBuilder()
+            var builder = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
                 .AddJsonFile("appsettings.json")
-                .AddJsonFile($"appsettings.{environment}.json", optional: false)
-                .AddEnvironmentVariables()
-                .Build();
-            
+                .AddJsonFile($"appsettings.{environment}.json", optional: false);
+
+            if (environment == "Development") {
+                builder.AddUserSecrets<Program>(true);
+            }
+
+            builder.AddEnvironmentVariables();
+
+            IConfigurationRoot configuration = builder.Build();
+
             var optionsBuilder = new DbContextOptionsBuilder<NtbsContext>();
             var connectionString = configuration.GetConnectionString("ntbsMigratorContext");
             optionsBuilder.UseSqlServer(connectionString);

--- a/ntbs-service/Properties/AdfsOptions.cs
+++ b/ntbs-service/Properties/AdfsOptions.cs
@@ -15,7 +15,6 @@
 
         /** Only used in development mode, allows developers to set their group membership via properties */
         public string DevGroup { get; set; }
-
     
         /** Base url for the AD FS instace */
         public string AdfsUrl { get; set; }

--- a/ntbs-service/Properties/AzureAdOptions.cs
+++ b/ntbs-service/Properties/AzureAdOptions.cs
@@ -1,0 +1,18 @@
+﻿namespace ntbs_service.Properties
+{
+    public class AzureAdOptions
+    {
+        public string ClientId { get; set; }
+    
+        public string ClientSecret { get; set; }
+
+        /** The authentication endpoint for the Azure AD tenant hosting the Azure AD Application. e.g. https://login.microsoftonline.com/mydomain.com */
+        public string Authority { get; set; }
+        
+        /** The URL to send the id/access token back to. e.g. /Index */
+        public string CallbackPath { get; set; }
+         
+        /** This will override the use of Adfs with Azure Active Directory **/
+        public string UseAzureAdAuth {get; set;}
+    }
+}

--- a/ntbs-service/Properties/AzureAdOptions.cs
+++ b/ntbs-service/Properties/AzureAdOptions.cs
@@ -13,6 +13,6 @@
         public string CallbackPath { get; set; }
          
         /** This will override the use of Adfs with Azure Active Directory **/
-        public string UseAzureAdAuth {get; set;}
+        public string Enabled {get; set;}
     }
 }

--- a/ntbs-service/README.md
+++ b/ntbs-service/README.md
@@ -49,6 +49,7 @@ A master copy of local secrets is stored in Azure Key Vault. These can be set up
 
 ```PowerShell
 # Use `az login` to authenticate first if necessary
+# Use `az account set -s 6850ca99-e7c3-4686-9208-25575cef522a` to change to phe-ntbs azure subscription
 
 az keyvault secret show `
  --vault-name "dev-phe-ntbs-secrets" `

--- a/ntbs-service/Services/AzureAdDirectoryService.cs
+++ b/ntbs-service/Services/AzureAdDirectoryService.cs
@@ -1,0 +1,15 @@
+namespace ntbs_service.Services
+{
+    public interface IAzureAdDirectoryService 
+    {
+       
+    }
+
+    public class AzureAdDirectoryService : IAzureAdDirectoryService
+    {
+        public AzureAdDirectoryService()
+        {
+
+        }
+    }
+}

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -2,7 +2,14 @@
   "AdfsOptions": {
     "Wtrealm": "https://localhost:5001/",
     "DevGroup": "Global.NIS.NTBS.NTS",
-    "UseDummyAuth": true
+    "UseDummyAuth": false
+  },
+  "AzureAdOptions": {
+    "ClientId": "<Provided by deployment secrets>",
+    "ClientSecret": "<Provided by deployment secrets>",
+    "Authority": "<Provided by deployment secrets>",
+    "CallbackPath": "/Index",
+    "Enabled": false
   },
   "ClusterMatchingConfig": {
     "MockOutClusterMatching": false,

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -7,6 +7,12 @@
     "NationalTeamAdGroup": "Global.NIS.NTBS.NTS",
     "ServiceGroupAdPrefix": "Global.NIS.NTBS.Service"
   },
+  "AzureAdOptions": {
+    "ClientId":"<Provided by deployment secrets>",
+    "ClientSecret": "<Provided by deployment secrets>",
+    "Authority": "<Provided by deployment secrets>",
+    "CallbackPath": "/Index"
+  },
   "AppConfig": {
     "AuditingEnabled": true,
     "LegacySearchEnabled": true

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -11,7 +11,8 @@
     "ClientId":"<Provided by deployment secrets>",
     "ClientSecret": "<Provided by deployment secrets>",
     "Authority": "<Provided by deployment secrets>",
-    "CallbackPath": "/Index"
+    "CallbackPath": "/Index",
+    "Enabled": false
   },
   "AppConfig": {
     "AuditingEnabled": true,

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -56,6 +56,23 @@ spec:
                 key: connectionString
           - name: AdfsOptions__Wtrealm
             value: "https://ntbs-int.61b431d7ea3041e89733.uksouth.aksapp.io/"
+          - name: AzureAdOptions__ClientId
+            valueFrom:
+              secretKeyRef:
+                name: int-azuread-options
+                key: clientId
+          - name: AzureAdOptions__ClientSecret
+            valueFrom:
+              secretKeyRef:
+                name: int-azuread-options
+                key: clientSecret
+          - name: AzureAdOptions__Authority
+            valueFrom:
+              secretKeyRef:
+                name: int-azuread-options
+                key: authority
+          - name: AzureAdOptions__Enabled
+            value: true
           - name: LdapSettings__Password
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Description
Added support for Azure AD authentication for int.

## Checklist:
- [x] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [ ] EF migrations created and committed. Snapshot committed
- [ ] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Reporting database ingestion considered (uspGenerateReusableNotification)
### Accessibility testing
Features with UI components should consider items on this list
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
