### PR TITLE
Updated stylesheets to not display link href when webpage is in print…

### DIFF
--- a/ntbs-service/wwwroot/css/notificationBanner.scss
+++ b/ntbs-service/wwwroot/css/notificationBanner.scss
@@ -94,6 +94,10 @@
       
         .case-manager-link {
             color: white;
+            @media print {
+                color: black;
+                text-decoration: none;
+            }
         }
       
         @media print {

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -248,3 +248,20 @@ body {
 .reduced-margin-warning-text {
   margin-bottom: 12px;
 }
+
+/* Overrides the coming soon a tag so that link is not displayed. */ 
+@media print {
+  a:after {
+      content: none;
+  } 
+  
+  /* If link should be displayed use display-link to explicitly declare behaviour. */
+  a.display-link:after {
+    color: #212b32;
+    content: " (Link: " attr(href) ")";
+    /* [1] */
+    font-size: 14pt;
+    /* [2] */ 
+  }
+}
+


### PR DESCRIPTION
Updated the application not to display link when in print mode for all <a> elements.
Added class to allow behaviour to be explicitly requested.

Case Manager is now visible when printing notification.
