### PR TITLE
Ntbs 1996

### DIFF
--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -321,6 +321,8 @@ namespace ntbs_service.DataAccess
             return GetNotificationsWithBasicInformationIQueryable()
                 .Include(n => n.PatientDetails.Country)
                 .Include(n => n.PatientDetails.Sex)
+                .Include(n => n.SocialContextAddresses)
+                .Include(n => n.SocialContextVenues)
                 .Include(n => n.TreatmentEvents)
                     .ThenInclude(t => t.TreatmentOutcome);
         }

--- a/ntbs-service/Models/Entities/Alerts/DataQualityClusterAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityClusterAlert.cs
@@ -10,8 +10,8 @@ namespace ntbs_service.Models.Entities.Alerts
     {
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
             n => n.ClusterId != null
-                 && (n.SocialContextAddresses == null || !n.SocialContextAddresses.Any())
-                 && (n.SocialContextVenues == null || !n.SocialContextVenues.Any());
+                 && !n.SocialContextAddresses.Any()
+                 && !n.SocialContextVenues.Any();
 
         public static readonly Func<Notification, bool> NotificationQualifies =
             NotificationQualifiesExpression.Compile();

--- a/ntbs-service/Models/Entities/Alerts/DataQualityClusterAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityClusterAlert.cs
@@ -10,8 +10,8 @@ namespace ntbs_service.Models.Entities.Alerts
     {
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
             n => n.ClusterId != null
-                 && !n.SocialContextAddresses.Any()
-                 && !n.SocialContextVenues.Any();
+                 && (n.SocialContextAddresses == null || !n.SocialContextAddresses.Any())
+                 && (n.SocialContextVenues == null || !n.SocialContextVenues.Any());
 
         public static readonly Func<Notification, bool> NotificationQualifies =
             NotificationQualifiesExpression.Compile();


### PR DESCRIPTION
1996 - fix issue with Data Quality Alert not being closed when Social Context Venue.

## Description
<!--- High level changes overview -->

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [ ] EF migrations created and committed. Snapshot committed
- [ ] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Reporting database ingestion considered (uspGenerateReusableNotification)
### Accessibility testing
Features with UI components should consider items on this list
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
