### PR TITLE
Changing the Nhs Number duplicate matching to not require date of bir…

### DIFF
--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -286,10 +286,7 @@ namespace ntbs_service.DataAccess
                     (
                         (
                             t.notification.PatientDetails.NhsNumber == t.duplicate.PatientDetails.NhsNumber &&
-                            t.notification.PatientDetails.NhsNumber != null &&
-                            // The notification's date of births match
-                            t.notification.PatientDetails.Dob == t.duplicate.PatientDetails.Dob
-
+                            t.notification.PatientDetails.NhsNumber != null 
                         ) // check that the notifications have happened long enough in the past
                         &&
                         (


### PR DESCRIPTION


## Description
Data Quality Alert Duplication check does not need both nhs number and date of birth to match, just nhs number.

## Checklist:
- [ ] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
- [ ] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [ ] EF migrations created and committed. Snapshot committed
- [ ] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Reporting database ingestion considered (uspGenerateReusableNotification)
### Accessibility testing
Features with UI components should consider items on this list
- [ ] Test functionality without javascript
- [ ] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [ ] Zoom page to 400% - content still visible?
- [ ] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [ ] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
