### PR TITLE
NTBS-2055 Update display name formatting

### DIFF
--- a/ntbs-service-unit-tests/Helpers/NameFormattingHelperTest.cs
+++ b/ntbs-service-unit-tests/Helpers/NameFormattingHelperTest.cs
@@ -1,0 +1,27 @@
+﻿using ntbs_service.Helpers;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Helpers
+{
+    public class NameFormattingHelperTest
+    {
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData("Alice", "Alice")]
+        [InlineData("John Smith", "John Smith")]
+        [InlineData("A O'Double-Barrelled", "A O'Double-Barrelled")]
+        [InlineData("Иван Петрович Сидоров", "Иван Петрович Сидоров")]
+        [InlineData("  John Smith ", "John Smith")]
+        [InlineData("DOE, Jane (TAUNTON AND SOMERSET NHS FOUNDATION TRUST)", "DOE, Jane")]
+        [InlineData("DOE Jane (R54) SJUHNT", "DOE Jane")]
+        public void FormatDisplayName_FormatsCorrectly(string initialDisplayName, string expectedFormattedName)
+        {
+            // Act
+            var actualFormattedName = NameFormattingHelper.FormatDisplayName(initialDisplayName);
+
+            // Assert
+            Assert.Equal(expectedFormattedName, actualFormattedName);
+        }
+    }
+}

--- a/ntbs-service/Helpers/NameFormattingHelper.cs
+++ b/ntbs-service/Helpers/NameFormattingHelper.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.RegularExpressions;
+
+namespace ntbs_service.Helpers
+{
+    public static class NameFormattingHelper
+    {
+        public static string FormatDisplayName(string displayName)
+        {
+            // Extract the name "John Smith" from the display name "   John Smith (NHS Trust Name)"
+
+            if (displayName == null)
+            {
+                return null;
+            }
+
+            var splitName = displayName.Split('(');
+            return splitName.Length == 0 ? "" : splitName[0].Trim();
+        }
+    }
+}

--- a/ntbs-service/Services/AzureAdDirectoryService.cs
+++ b/ntbs-service/Services/AzureAdDirectoryService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.Graph;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Properties;
@@ -260,13 +261,17 @@ namespace ntbs_service.Services
             if(IsUserExternal(graphUser)){
                 userName = !String.IsNullOrEmpty(graphUser.Mail) ? graphUser.Mail : graphUser.UserPrincipalName;
             }
-            
+
+            var displayName = !String.IsNullOrEmpty(graphUser.DisplayName)
+                ? NameFormattingHelper.FormatDisplayName(graphUser.DisplayName)
+                : $"{graphUser.GivenName} {graphUser.Surname}";
+
             var user = new Models.Entities.User
             {
                 Username = userName,
                 GivenName = graphUser.GivenName,
                 FamilyName = graphUser.Surname,
-                DisplayName = graphUser.DisplayName,
+                DisplayName = displayName,
                 IsActive = graphUser.AccountEnabled.HasValue && graphUser.AccountEnabled.Value,
                 AdGroups = string.Join(",", groupNames),
                 IsCaseManager = tbServicesMatchingGroups.Any()

--- a/ntbs-service/Services/UserService.cs
+++ b/ntbs-service/Services/UserService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
@@ -117,12 +118,12 @@ namespace ntbs_service.Services
 
         public async Task<string> GetUserDisplayName(ClaimsPrincipal user)
         {
-            string displayName = user.Identity.Name;
+            string displayName = NameFormattingHelper.FormatDisplayName(user.Identity.Name);
 
             if(displayName.Contains("@")){
                 var nameClaim = user.Claims.FirstOrDefault(c => c.Type == "name");
                 if(nameClaim != null) {
-                    displayName = nameClaim.Value;
+                    displayName = NameFormattingHelper.FormatDisplayName(nameClaim.Value);
                 }
             }
 


### PR DESCRIPTION
## Description
Changes for NTBS-2055

* Add a display name formatting helper to remove long trust names from display names retrieved from Azure AD
* Add some unit tests for this helper
* Use this when formatting the user name in the website header
* Use this when populating the User table in the regular sync job
* Add a fallback to use given and family names as a display name if there is no display name present (which is the case for some legacy users)

## Checklist:
- [x] Automated tests are passing locally.