### PR TITLE
NTBS-2054 Use display name instead of given and family names

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -180,8 +180,7 @@ namespace ntbs_integration_tests.Helpers
                 new User
                 {
                     Username = CASEMANAGER_ABINGDON_EMAIL,
-                    GivenName = "TestCase",
-                    FamilyName = "TestManager",
+                    DisplayName = "TestCase TestManager",
                     AdGroups = "Global.NIS.NTBS.Service_Abingdon",
                     IsActive = true,
                     IsCaseManager = true
@@ -189,8 +188,7 @@ namespace ntbs_integration_tests.Helpers
                 new User
                 {
                     Username = CASEMANAGER_ABINGDON_EMAIL2,
-                    GivenName = "TestCase2",
-                    FamilyName = "TestManager",
+                    DisplayName = "TestCase2 TestManager",
                     AdGroups = "Global.NIS.NTBS.Service_Abingdon",
                     IsActive = true,
                     IsCaseManager = true
@@ -198,8 +196,7 @@ namespace ntbs_integration_tests.Helpers
                 new User
                 {
                     Username = "Developer@ntbs.phe.com",
-                    GivenName = "BaseTestCase",
-                    FamilyName = "BaseTestManager",
+                    DisplayName = "BaseTestCase BaseTestManager",
                     AdGroups = "Global.NIS.NTBS.NTS",
                     IsActive = true,
                     IsCaseManager = true

--- a/ntbs-service-unit-tests/Services/CaseManagerSearchServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/CaseManagerSearchServiceTest.cs
@@ -1,0 +1,221 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using ntbs_service.DataAccess;
+using ntbs_service.Models;
+using ntbs_service.Models.Entities;
+using ntbs_service.Services;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Services
+{
+    public class CaseManagerSearchServiceTest
+    {
+        private static readonly PaginationParameters DefaultPaginationParameters =
+            new PaginationParameters {Offset = 0, PageSize = 20};
+
+        private static readonly List<User> DefaultDisplayNameCaseManagers = new List<User>
+        {
+            CreateDefaultCaseManager(displayName: "Test UserOne"),
+            CreateDefaultCaseManager(displayName: "Test UserTwo"),
+            CreateDefaultCaseManager(displayName: "Test UserThree"),
+        };
+
+        private static readonly List<User> DefaultGivenNameCaseManagers = new List<User>
+        {
+            CreateDefaultCaseManager(givenName: "Test UserOne"),
+            CreateDefaultCaseManager(givenName: "Test UserTwo"),
+            CreateDefaultCaseManager(givenName: "Test UserThree"),
+        };
+
+        private static readonly List<User> DefaultFamilyNameCaseManagers = new List<User>
+        {
+            CreateDefaultCaseManager(familyName: "Test UserOne"),
+            CreateDefaultCaseManager(familyName: "Test UserTwo"),
+            CreateDefaultCaseManager(familyName: "Test UserThree"),
+        };
+
+        private readonly Mock<IReferenceDataRepository> _mockReferenceDataRepository;
+        private readonly ICaseManagerSearchService _service;
+
+        public CaseManagerSearchServiceTest()
+        {
+            _mockReferenceDataRepository = new Mock<IReferenceDataRepository>();
+
+            _service = new CaseManagerSearchService(_mockReferenceDataRepository.Object);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_ReturnsEmptyList()
+        {
+            // Arrange
+            const string searchString = "";
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered()).ReturnsAsync(new List<User>());
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(0, results.count);
+            Assert.Empty(results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_ReturnsEmptyListWhenThereAreNoDisplayNameMatches()
+        {
+            // Arrange
+            const string searchString = "abcdefg";
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered())
+                .ReturnsAsync(DefaultDisplayNameCaseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(0, results.count);
+            Assert.Empty(results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_ReturnsEmptyListWhenThereAreNoGivenNameMatches()
+        {
+            // Arrange
+            const string searchString = "abcdefg";
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered())
+                .ReturnsAsync(DefaultGivenNameCaseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(0, results.count);
+            Assert.Empty(results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_ReturnsEmptyListWhenThereAreNoFamilyNameMatches()
+        {
+            // Arrange
+            const string searchString = "abcdefg";
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered())
+                .ReturnsAsync(DefaultFamilyNameCaseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(0, results.count);
+            Assert.Empty(results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_ReturnsDisplayNameMatchingUsers()
+        {
+            // Arrange
+            const string searchString = "UserT";
+            var expectedResults = new List<User> {DefaultDisplayNameCaseManagers[1], DefaultDisplayNameCaseManagers[2]};
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered())
+                .ReturnsAsync(DefaultDisplayNameCaseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(2, results.count);
+            Assert.Equal(expectedResults, results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_ReturnsGivenNameMatchingUsers()
+        {
+            // Arrange
+            const string searchString = "UserT";
+            var expectedResults = new List<User> {DefaultGivenNameCaseManagers[1], DefaultGivenNameCaseManagers[2]};
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered())
+                .ReturnsAsync(DefaultGivenNameCaseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(2, results.count);
+            Assert.Equal(expectedResults, results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_ReturnsFamilyNameMatchingUsers()
+        {
+            // Arrange
+            const string searchString = "UserT";
+            var expectedResults = new List<User> {DefaultFamilyNameCaseManagers[1], DefaultFamilyNameCaseManagers[2]};
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered())
+                .ReturnsAsync(DefaultFamilyNameCaseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(2, results.count);
+            Assert.Equal(expectedResults, results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_IsCaseInsensitive()
+        {
+            // Arrange
+            const string searchString = "oNe";
+            var expectedResults = new List<User> {DefaultDisplayNameCaseManagers[0]};
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered())
+                .ReturnsAsync(DefaultDisplayNameCaseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, DefaultPaginationParameters);
+
+            // Assert
+            Assert.Equal(1, results.count);
+            Assert.Equal(expectedResults, results.caseManagers);
+        }
+
+        [Fact]
+        public async Task OrderAndPaginateQueryableAsync_PaginatesCorrectly()
+        {
+            // Arrange
+            const string searchString = "Test";
+            var caseManagers = Enumerable.Range(1, 10).Select(i => CreateDefaultCaseManager($"Test {i}")).ToList();
+            var paginationParameters = new PaginationParameters {Offset = 2, PageSize = 3};
+
+            var expectedResults = new List<User> {caseManagers[2], caseManagers[3], caseManagers[4]};
+
+            _mockReferenceDataRepository.Setup(r => r.GetAllCaseManagersOrdered()).ReturnsAsync(caseManagers);
+
+            // Act
+            var results = await _service.OrderAndPaginateQueryableAsync(searchString, paginationParameters);
+
+            // Assert
+            Assert.Equal(10, results.count);
+            Assert.Equal(expectedResults, results.caseManagers);
+        }
+
+        private static User CreateDefaultCaseManager(string displayName = null, string givenName = null,
+            string familyName = null,
+            List<CaseManagerTbService> caseManagerTbServices = null)
+        {
+            return new User
+            {
+                DisplayName = displayName,
+                GivenName = givenName,
+                FamilyName = familyName,
+                CaseManagerTbServices = caseManagerTbServices ?? new List<CaseManagerTbService>(),
+                IsCaseManager = true
+            };
+        }
+    }
+}

--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -235,7 +235,7 @@ namespace ntbs_service.DataAccess
                 CaseManagers = filteredCaseManagers.Select(n => new OptionValue
                 {
                     Value = n.Username,
-                    Text = n.FullName
+                    Text = n.DisplayName
                 })
             };
             return filteredHospitalDetailsPageSelectLists;

--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -28,7 +28,7 @@ namespace ntbs_service.DataAccess
         Task<IList<PHEC>> GetAllPhecs();
         Task<PHEC> GetPhecByCode(string phecCode);
         Task<IList<User>> GetAllCaseManagers();
-        IQueryable<User> GetAllCaseManagersQueryable();
+        Task<List<User>> GetAllCaseManagersOrdered();
         Task<User> GetCaseManagerByUsernameAsync(string username);
         Task<User> GetUserByUsernameAsync(string username);
         Task<IList<Hospital>> GetHospitalsByTbServiceCodesAsync(IEnumerable<string> tbServices);
@@ -109,7 +109,7 @@ namespace ntbs_service.DataAccess
                 .Select(h => h.TBService)
                 .SingleOrDefaultAsync();
         }
-        
+
         public async Task<IList<TBService>> GetTbServicesFromPhecCodeAsync(string phecCode)
         {
             return await GetTbServicesQueryable()
@@ -132,7 +132,7 @@ namespace ntbs_service.DataAccess
                 .Include(tb => tb.PHEC)
                 .Where(tb => roles.Contains(tb.PHEC.AdGroup));
         }
-        
+
         public IQueryable<TBService> GetDefaultTbServicesForNhsUserQueryable(IEnumerable<string> roles)
         {
             return GetTbServicesQueryable()
@@ -166,7 +166,7 @@ namespace ntbs_service.DataAccess
                 .ToListAsync();
         }
 
-        public IQueryable<User> GetAllCaseManagersQueryable()
+        public Task<List<User>> GetAllCaseManagersOrdered()
         {
             return _context.User
                 .Include(u => u.CaseManagerTbServices)
@@ -174,7 +174,8 @@ namespace ntbs_service.DataAccess
                 .ThenInclude(s => s.PHEC)
                 .Where(u => u.IsCaseManager)
                 .OrderBy(u => u.FamilyName)
-                .ThenBy(u => u.GivenName);
+                .ThenBy(u => u.GivenName)
+                .ToListAsync();
         }
 
         public async Task<User> GetCaseManagerByUsernameAsync(string username)
@@ -186,7 +187,7 @@ namespace ntbs_service.DataAccess
                 .Where(u => u.IsCaseManager)
                 .SingleOrDefaultAsync(c => c.Username == username);
         }
-        
+
         public async Task<User> GetUserByUsernameAsync(string username)
         {
             return await _context.User
@@ -322,7 +323,7 @@ namespace ntbs_service.DataAccess
             TreatmentOutcomeType type,
             TreatmentOutcomeSubType? subType)
         {
-            return await _context.TreatmentOutcome.SingleOrDefaultAsync(t => 
+            return await _context.TreatmentOutcome.SingleOrDefaultAsync(t =>
                 t.TreatmentOutcomeType == type
                 && t.TreatmentOutcomeSubType == subType);
         }

--- a/ntbs-service/DataAccess/UserRepository.cs
+++ b/ntbs-service/DataAccess/UserRepository.cs
@@ -79,7 +79,7 @@ namespace ntbs_service.DataAccess
         {
             return _context.User.ToDictionaryAsync(
                 user => user.Username,
-                user => user.FullName
+                user => user.DisplayName
             );
         }
 

--- a/ntbs-service/Models/Entities/Alerts/Alert.cs
+++ b/ntbs-service/Models/Entities/Alerts/Alert.cs
@@ -29,7 +29,7 @@ namespace ntbs_service.Models.Entities.Alerts
         public virtual string Action { get; }
         public virtual bool NotDismissable  { get; }
         [Display(Name = "Case manager")] 
-        public string CaseManagerFullName => CaseManager?.FullName ?? "";
+        public string CaseManagerFullName => CaseManager?.DisplayName ?? "";
         [Display(Name = "Alert date")]
         public string FormattedCreationDate => CreationDate.ConvertToString();
         [Display(Name = "TB Service")]

--- a/ntbs-service/Models/Entities/HospitalDetails.cs
+++ b/ntbs-service/Models/Entities/HospitalDetails.cs
@@ -61,7 +61,7 @@ namespace ntbs_service.Models.Entities
 
         [NotMapped]
         [Display(Name = "Case Manager")]
-        public string CaseManagerName => CaseManager?.FullName;
+        public string CaseManagerName => CaseManager?.DisplayName;
 
         string IOwnedEntityForAuditing.RootEntityType => RootEntities.Notification;
     }

--- a/ntbs-service/Models/Entities/User.cs
+++ b/ntbs-service/Models/Entities/User.cs
@@ -55,8 +55,6 @@ namespace ntbs_service.Models.Entities
 
         public virtual ICollection<CaseManagerTbService> CaseManagerTbServices { get; set; }
 
-        public string FullName => GivenName + " " + FamilyName;
-
         public bool ArePrimaryContactDetailsMissing => String.IsNullOrEmpty(JobTitle)
                                                        && String.IsNullOrEmpty(PhoneNumberPrimary)
                                                        && String.IsNullOrEmpty(EmailPrimary);

--- a/ntbs-service/Pages/Admin/CloneNotification.cshtml.cs
+++ b/ntbs-service/Pages/Admin/CloneNotification.cshtml.cs
@@ -49,7 +49,7 @@ namespace ntbs_service.Pages.Admin
             var caseManagers = referenceDataRepository.GetAllCaseManagers().Result;
             CaseManagers = new SelectList(caseManagers,
                 nameof(Models.Entities.User.Username),
-                nameof(Models.Entities.User.FullName));
+                nameof(Models.Entities.User.DisplayName));
             
             Sexes = _referenceDataRepository.GetAllSexesAsync().Result.ToList();
         }

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
@@ -124,7 +124,7 @@ namespace ntbs_service.Pages.Alerts
             var caseManagers = await _referenceDataRepository.GetAllCaseManagers();
             CaseManagers = new SelectList(caseManagers,
                 nameof(Models.Entities.User.Username),
-                nameof(Models.Entities.User.FullName));
+                nameof(Models.Entities.User.DisplayName));
             var phecs = await _referenceDataRepository.GetAllPhecs();
             Phecs = new SelectList(phecs, nameof(PHEC.Code), nameof(PHEC.Name));
         }
@@ -166,7 +166,7 @@ namespace ntbs_service.Pages.Alerts
                     CaseManagers = filteredCaseManagers.Select(n => new OptionValue
                     {
                         Value = n.Username.ToString(),
-                        Text = n.FullName
+                        Text = n.DisplayName
                     })
                 });
         }

--- a/ntbs-service/Pages/ContactDetails/Edit.cshtml
+++ b/ntbs-service/Pages/ContactDetails/Edit.cshtml
@@ -15,7 +15,7 @@
         <partial name="Notifications/Edit/_SinglePageErrorSummaryPartial"/>
     </div>
 
-    <h2 class="nhsuk-heading-l"> @Model.ContactDetails.FullName </h2>
+    <h2 class="nhsuk-heading-l"> @Model.ContactDetails.DisplayName </h2>
     <div class="case-manager-details-edit-container">
         <h3 class="nhsuk-heading-m"> Contact details </h3>
     </div>

--- a/ntbs-service/Pages/ContactDetails/Index.cshtml
+++ b/ntbs-service/Pages/ContactDetails/Index.cshtml
@@ -3,7 +3,7 @@
 
 @{
     Layout = "./_Layout";
-    ViewData["Title"] = $"{Model.ContactDetails.FullName} contact details";
+    ViewData["Title"] = $"{Model.ContactDetails.DisplayName} contact details";
     var backLink = ViewData["Referer"];
 }
 

--- a/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
+++ b/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
@@ -71,7 +71,7 @@ namespace ntbs_service.Pages.ContactDetails
                     Url = $"/ServiceDirectory/Region/{region.Code}"
                 });
             }
-            breadcrumbs.Add((new Breadcrumb {Label = ContactDetails.FullName, Url = $"/ContactDetails/{ContactDetails.Username}"}));
+            breadcrumbs.Add((new Breadcrumb {Label = ContactDetails.DisplayName, Url = $"/ContactDetails/{ContactDetails.Username}"}));
 
             ViewData["Breadcrumbs"] = breadcrumbs;
         }

--- a/ntbs-service/Pages/ContactDetails/_CaseManagerDetailsPartial.cshtml
+++ b/ntbs-service/Pages/ContactDetails/_CaseManagerDetailsPartial.cshtml
@@ -2,7 +2,7 @@
 @model ntbs_service.Models.Entities.User
 
 <nhs-width-container container-width="Standard">
-    <h2 class="nhsuk-heading-l"> @Model.FullName </h2>
+    <h2 class="nhsuk-heading-l"> @Model.DisplayName </h2>
     <div class="case-manager-details-edit-container">
         <h3 class="nhsuk-heading-m"> Contact details </h3>
         @if (ViewData["IsEditable"] as bool? == true)

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -99,7 +99,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             Hospitals = new SelectList(hospitals, nameof(Hospital.HospitalId), nameof(Hospital.Name));
 
             var caseManagers = await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(tbServiceCodes);
-            CaseManagers = new SelectList(caseManagers, nameof(Models.Entities.User.Username), nameof(Models.Entities.User.FullName));
+            CaseManagers = new SelectList(caseManagers, nameof(Models.Entities.User.Username), nameof(Models.Entities.User.DisplayName));
         }
 
         protected override IActionResult RedirectForDraft(bool isBeingSubmitted)

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -79,7 +79,7 @@
                                 }
                             </nhs-table-item>
                             <nhs-table-item>@treatmentEvent.TbService?.Name</nhs-table-item>
-                            <nhs-table-item>@treatmentEvent.CaseManager?.FullName</nhs-table-item>
+                            <nhs-table-item>@treatmentEvent.CaseManager?.DisplayName</nhs-table-item>
                         </nhs-table-body-row>
                     }
                 </nhs-table-body>

--- a/ntbs-service/Pages/ServiceDirectory/Region.cshtml
+++ b/ntbs-service/Pages/ServiceDirectory/Region.cshtml
@@ -48,7 +48,7 @@
                                 {
                                     <nhs-table-body-row>
                                         <nhs-table-item>
-                                            @caseManager.FullName
+                                            @caseManager.DisplayName
                                         </nhs-table-item>
                                         <nhs-table-item>
                                             @caseManager.JobTitle

--- a/ntbs-service/Pages/ServiceDirectory/SearchResults.cshtml
+++ b/ntbs-service/Pages/ServiceDirectory/SearchResults.cshtml
@@ -55,7 +55,7 @@
                     <!-- Each search hit is displayed using a notification banner -->
                     <div class="case-manager-search-result-container" id="search-result-item">
                         <a class="case-manager-search-result-name" href=@($"/ContactDetails/{caseManager.Username}")>
-                             @caseManager.FullName
+                             @caseManager.DisplayName
                         </a>
                         <nhs-summary-list classes="case-manager-search-result-item-summary" is-without-border="true">
                             @foreach (var tbService in caseManager.CaseManagerTbServices.Select(x => x.TbService))

--- a/ntbs-service/Services/CaseManagerSearchService.cs
+++ b/ntbs-service/Services/CaseManagerSearchService.cs
@@ -38,8 +38,9 @@ namespace ntbs_service.Services
             // This query is too complex to translate to sql, so we explicitly work on an in-memory list.
             // The size of the directory should make this ok.
             var filtered = caseManagers.Where(c =>
-                    searchKeywords.Any(s => c.FamilyName.ToLower().Contains(s))
-                    || searchKeywords.Any(s => c.GivenName.ToLower().Contains(s))
+                    searchKeywords.Any(s => c.FamilyName != null && c.FamilyName.ToLower().Contains(s))
+                    || searchKeywords.Any(s => c.GivenName != null && c.GivenName.ToLower().Contains(s))
+                    || searchKeywords.Any(s => c.DisplayName.ToLower().Contains(s))
                     || c.CaseManagerTbServices.Any(x =>
                         searchKeywords.Any(s => x.TbService.Name.ToLower().Contains(s))))
                 .ToList();

--- a/ntbs-service/Services/CaseManagerSearchService.cs
+++ b/ntbs-service/Services/CaseManagerSearchService.cs
@@ -15,7 +15,7 @@ namespace ntbs_service.Services
             string searchKeyword,
             PaginationParametersBase paginationParameters);
     }
-    
+
     public class CaseManagerSearchService : ICaseManagerSearchService
     {
         private readonly IReferenceDataRepository _referenceDataRepository;
@@ -24,7 +24,7 @@ namespace ntbs_service.Services
         {
             _referenceDataRepository = referenceDataRepository;
         }
-        
+
         public async Task<(IList<User> caseManagers, int count)> OrderAndPaginateQueryableAsync(
             string searchKeyword,
             PaginationParametersBase paginationParameters)
@@ -32,23 +32,22 @@ namespace ntbs_service.Services
             var searchKeywords = searchKeyword.Split(" ")
                 .Where(x => !x.IsNullOrEmpty())
                 .Select(s => s.ToLower()).ToList();
-            var caseManagers = await _referenceDataRepository.GetAllCaseManagersQueryable()
-                .ToListAsync();
+            var caseManagers = await _referenceDataRepository.GetAllCaseManagersOrdered();
 
             // This query is too complex to translate to sql, so we explicitly work on an in-memory list.
             // The size of the directory should make this ok.
             var filtered = caseManagers.Where(c =>
                     searchKeywords.Any(s => c.FamilyName != null && c.FamilyName.ToLower().Contains(s))
                     || searchKeywords.Any(s => c.GivenName != null && c.GivenName.ToLower().Contains(s))
-                    || searchKeywords.Any(s => c.DisplayName.ToLower().Contains(s))
+                    || searchKeywords.Any(s => c.DisplayName != null && c.DisplayName.ToLower().Contains(s))
                     || c.CaseManagerTbServices.Any(x =>
                         searchKeywords.Any(s => x.TbService.Name.ToLower().Contains(s))))
                 .ToList();
 
             return (GetPaginatedItems(filtered, paginationParameters), filtered.Count);
         }
-        
-        private IList<T> GetPaginatedItems<T>(IEnumerable<T> items, 
+
+        private IList<T> GetPaginatedItems<T>(IEnumerable<T> items,
             PaginationParametersBase paginationParameters)
         {
             return items


### PR DESCRIPTION
## Description
* Use the display name field from the User table in all situations that a case manager name is required on the front end.
* Update service directory to search display names, and tolerate null given or family names.
* Update alert testing to use case manager display name.

## Checklist:
- [x] Automated tests are passing locally.