### PR TITLE
NTBS-2034 Limit the number of Notifications updated per run

### DIFF
--- a/ntbs-service/Helpers/DrugResistanceHelper.cs
+++ b/ntbs-service/Helpers/DrugResistanceHelper.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Enums;
+
+namespace ntbs_service.Helpers
+{
+    public static class DrugResistanceHelper
+    {
+        public static bool IsMdr(DrugResistanceProfile profile, TreatmentRegimen? treatmentRegimen, Status? exposureToKnownCaseStatus)
+        {
+            // If user-set treatment ... 
+            return treatmentRegimen == TreatmentRegimen.MdrTreatment
+                // ... or lab results indicate MDR, ...
+                || profile.DrugResistanceProfileString == "RR/MDR/XDR"
+                // ... or if there is any data entered in the MDR pages - otherwise we could be hiding record data
+                || exposureToKnownCaseStatus != null;
+        }
+
+        public static bool IsMbovis(DrugResistanceProfile profile)
+        {
+            // If the lab results point to M. bovis species ...
+            return string.Equals("M. bovis", profile.Species, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}

--- a/ntbs-service/Jobs/DrugResistanceProfileUpdateJob.cs
+++ b/ntbs-service/Jobs/DrugResistanceProfileUpdateJob.cs
@@ -7,6 +7,8 @@ namespace ntbs_service.Jobs
 {
     public class DrugResistanceProfileUpdateJob
     {
+        private const int MaxNumberOfUpdatesPerRun = 2000;
+
         private readonly IDrugResistanceProfilesService _service;
 
         public DrugResistanceProfileUpdateJob(IDrugResistanceProfilesService service)
@@ -14,10 +16,23 @@ namespace ntbs_service.Jobs
             _service = service;
         }
 
+        // We limit the number of Notifications that this job will update to 2,000 for performance reasons.
+        // For larger numbers, the EF context was becoming very large, and the job was slowing down considerably.
+        // We would only expect a large number of updates to be needed here following a large migration. In this
+        // scenario, the job should be run manually to import all the data (and if this is forgotten then we
+        // trigger a warning in Sentry).
         public async Task Run(IJobCancellationToken token)
         {
             Log.Information($"Starting Drug resistance profile update job");
-            await _service.UpdateDrugResistanceProfiles();
+            var numberOfNotificationsStillNeedingUpdate = await _service.UpdateDrugResistanceProfiles(MaxNumberOfUpdatesPerRun);
+            var totalNumberOfNotificationsRequiredAtStartOfRun = numberOfNotificationsStillNeedingUpdate + MaxNumberOfUpdatesPerRun;
+            if (numberOfNotificationsStillNeedingUpdate > 0)
+            {
+                Log.Warning($"Discovered {totalNumberOfNotificationsRequiredAtStartOfRun} Notifications which require updates to their " +
+                            $"Drug Resistance Profile. The Drug Resistance Profile update job will only handle {MaxNumberOfUpdatesPerRun} " +
+                            $"Notifications per run, so there are still {numberOfNotificationsStillNeedingUpdate} Notifications which " +
+                            "need to be updated. Trigger the job manually in order to update these Notifications.");
+            }
             Log.Information($"Finishing Drug resistance profile update job");
         }
     }

--- a/ntbs-service/Models/Entities/NotificationDisplay.cs
+++ b/ntbs-service/Models/Entities/NotificationDisplay.cs
@@ -18,17 +18,12 @@ namespace ntbs_service.Models.Entities
         public bool TransferRequestPending => Alerts?.Any(x => x.AlertType == AlertType.TransferRequest && x.AlertStatus == AlertStatus.Open) == true;
         public bool IsLastLinkedNotificationOverOneYearOld => GetIsLastLinkedNotificationOverOneYearOld();
 
-        public bool IsMdr =>
-            // If user-set treatment ... 
-            ClinicalDetails.IsMDRTreatment 
-            // ... or lab results indicate MDR, ...
-            || DrugResistanceProfile.DrugResistanceProfileString == "RR/MDR/XDR"
-            // ... or if there is any data entered in the MDR pages - otherwise we could be hiding record data
-            || MDRDetails.MDRDetailsEntered;
+        public bool IsMdr => DrugResistanceHelper.IsMdr(
+            DrugResistanceProfile,
+            ClinicalDetails.TreatmentRegimen,
+            MDRDetails.ExposureToKnownCaseStatus);
 
-        public bool IsMBovis =>
-            // If the lab results point to M. bovis species ...
-            string.Equals("M. bovis", DrugResistanceProfile.Species, StringComparison.InvariantCultureIgnoreCase);
+        public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile);
         
         public override bool? IsLegacy => LTBRID != null || ETSID != null;
 

--- a/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
+++ b/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
 
@@ -19,17 +19,8 @@ namespace ntbs_service.Models.Projections
         public TreatmentRegimen? TreatmentRegimen { get; set; }
         public Status? ExposureToKnownCaseStatus { get; set; }
 
-        // TODO:NTBS-2034 Remove duplication with NotificationDisplay
-        public bool IsMdr =>
-            // If user-set treatment ... 
-            TreatmentRegimen == Enums.TreatmentRegimen.MdrTreatment
-            // ... or lab results indicate MDR, ...
-            || DrugResistanceProfile.DrugResistanceProfileString == "RR/MDR/XDR"
-            // ... or if there is any data entered in the MDR pages - otherwise we could be hiding record data
-            || ExposureToKnownCaseStatus != null;
+        public bool IsMdr => DrugResistanceHelper.IsMdr(DrugResistanceProfile, TreatmentRegimen, ExposureToKnownCaseStatus);
 
-        public bool IsMBovis =>
-            // If the lab results point to M. bovis species ...
-            string.Equals("M. bovis", DrugResistanceProfile.Species, StringComparison.InvariantCultureIgnoreCase);
+        public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile);
     }
 }


### PR DESCRIPTION
Set a limit on the number of notifications that will be processed on one run of the drug resistance profile import.
If there are more updates required than this then log a warning in sentry.

## Checklist:
- [x] Automated tests are passing locally.
