### PR TITLE
NTBS-2107 Use explicit SQL in duplicate notification check

### DIFF
--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
+using ntbs_service.Models.QueryEntities;
 
 namespace ntbs_service.DataAccess
 {
@@ -46,7 +47,7 @@ namespace ntbs_service.DataAccess
         Task<int> GetNotificationsEligibleForDqTreatmentOutcome36AlertsCountAsync();
 
         // Potential Duplicates
-        Task<IList<DataQualityRepository.NotificationAndDuplicateIds>>
+        Task<IList<NotificationAndDuplicateIds>>
             GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
     }
 
@@ -292,45 +293,31 @@ namespace ntbs_service.DataAccess
         private async Task<IList<NotificationAndDuplicateIds>>
             GetNotificationIdsEligibleForDqPotentialDuplicateAlertsBasedOnMatchingNhsNumberAsync()
         {
-            return await _context.Notification
-                .SelectMany(_ => _context.Notification,
-                    (notification, duplicate) => new {notification, duplicate})
-                .Where(t =>
-                    // Check that one of the following cases are true:
-                    // Check that the notification's nhs numbers match, the notification is notified and the notifications
-                    // have been notified for at least the minimum amount of time specified
-                    (
-                        (
-                            t.notification.PatientDetails.NhsNumber == t.duplicate.PatientDetails.NhsNumber &&
-                            t.notification.PatientDetails.NhsNumber != null 
-                        ) // check that the notifications have happened long enough in the past
-                        &&
-                        (
-                            t.notification.NotificationId != t.duplicate.NotificationId &&
-                            t.notification.NotificationDate <
-                            DateTime.Now.AddDays(-DataQualityPotentialDuplicateAlert.MinNumberDaysNotifiedForAlert) &&
-                            t.duplicate.NotificationDate <
-                            DateTime.Now.AddDays(-DataQualityPotentialDuplicateAlert.MinNumberDaysNotifiedForAlert)
-                        ) 
-                        // Check that notifications are not already linked.
-                        &&
-                        (
-                            t.notification.NotificationStatus == NotificationStatus.Notified &&
-                            t.duplicate.NotificationStatus == NotificationStatus.Notified &&
-                            (t.notification.GroupId != t.duplicate.GroupId || t.notification.GroupId == null)
-                        )
-                    )
-                )
-                .Select(t => new NotificationAndDuplicateIds
-                {
-                    NotificationId = t.notification.NotificationId, DuplicateId = t.duplicate.NotificationId
-                }).ToListAsync();
-        }
-
-        public class NotificationAndDuplicateIds
-        {
-            public int NotificationId { get; set; }
-            public int DuplicateId { get; set; }
+            // The query that EF generates for this (when we write it in C#) is not fast enough. The problem is the
+            // difference in the way that SQL and C# compare nulls. In this case we want the SQL behaviour (where two
+            // NULLs are not considered equal). However, EF assumes that we want the C# behaviour (where two NULLs are
+            // considered equal). If we explicitly add the null checks, then EF generates an overcomplicated query
+            // which runs too slowly.
+            // We can change the EF behaviour by setting UseRelationalNulls to false, however this can only be done
+            // globally and in most situations we probably want the default behaviour.
+            // See https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.infrastructure.relationaldbcontextoptionsbuilder-2.userelationalnulls?view=efcore-5.0
+            return await _context.NotificationAndDuplicateIds.FromSql(@"SELECT N1.[NotificationId] AS [NotificationId], N2.[NotificationId] AS [DuplicateId] 
+FROM [Notification] AS N1
+LEFT JOIN [Patients] AS P1 ON N1.[NotificationId] = P1.[NotificationId]
+CROSS JOIN [Notification] AS N2
+LEFT JOIN [Patients] AS P2 ON N2.[NotificationId] = P2.[NotificationId]
+WHERE 
+((P1.[GivenName] = P2.[GivenName] and P1.[FamilyName] = P2.[FamilyName])
+OR
+(P1.[GivenName] = P2.[FamilyName] and P1.[FamilyName] = P2.[GivenName]))
+AND P1.[Dob] = P2.[Dob]
+AND P1.[NotificationId] <> P2.[NotificationId]
+AND N1.[NotificationDate] < DATEADD(day, -45.0E0, GETDATE())
+AND N2.[NotificationDate] < DATEADD(day, -45.0E0, GETDATE())
+AND (N1.[NotificationStatus] IN ('Notified', 'Closed')) 
+AND (N2.[NotificationStatus] IN ('Notified', 'Closed')) 
+AND (N1.[GroupId] <> N2.[GroupId] OR N1.[GroupId] is NULL or N2.[GroupId] is NULL)")
+                .ToListAsync();
         }
 
         private IQueryable<Notification> GetNotificationQueryableForNotifiedDataQualityAlerts<T>() where T : Alert

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -7,6 +7,7 @@ using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
+using ntbs_service.Models.QueryEntities;
 using ntbs_service.Models.ReferenceEntities;
 
 // Note: we've adopted a convention where reference data lives in a separate schema to the main tables.
@@ -64,6 +65,8 @@ namespace ntbs_service.DataAccess
         public virtual DbSet<MBovisOccupationExposure> MBovisOccupationExposures { get; set; }
         public virtual DbSet<MBovisAnimalExposure> MBovisAnimalExposure { get; set; }
         public virtual DbSet<PreviousTbService> PreviousTbService { get; set; }
+
+        public DbQuery<NotificationAndDuplicateIds> NotificationAndDuplicateIds { get; set; }
 
         public virtual void SetValues<TEntityClass>(TEntityClass entity, TEntityClass values)
         {

--- a/ntbs-service/Jobs/DataQualityAlertsJob.cs
+++ b/ntbs-service/Jobs/DataQualityAlertsJob.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -115,19 +115,18 @@ namespace ntbs_service.Jobs
             await CreateTreatmentOutcome12MonthAlertsInBulkAsync();
             await CreateTreatmentOutcome24MonthAlertsInBulkAsync();
             await CreateTreatmentOutcome36MonthAlertsInBulkAsync();
-            
-            // NTBS-2107 - temporarily disable duplicate checking for performance reasons
-            //var possibleDuplicateNotificationIds =
-            //    await _dataQualityRepository.GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
-            //foreach (var notification in possibleDuplicateNotificationIds)
-            //{
-            //    var alert = new DataQualityPotentialDuplicateAlert
-            //    {
-            //        NotificationId = notification.NotificationId, 
-            //        DuplicateId = notification.DuplicateId
-            //    };
-            //    await _alertService.AddUniquePotentialDuplicateAlertAsync(alert);
-            //}
+
+            var possibleDuplicateNotificationIds =
+                await _dataQualityRepository.GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
+            foreach (var notification in possibleDuplicateNotificationIds)
+            {
+                var alert = new DataQualityPotentialDuplicateAlert
+                {
+                    NotificationId = notification.NotificationId,
+                    DuplicateId = notification.DuplicateId
+                };
+                await _alertService.AddUniquePotentialDuplicateAlertAsync(alert);
+            }
 
             Log.Information($"Finished data quality alerts job");
         }

--- a/ntbs-service/Models/QueryEntities/NotificationAndDuplicateIds.cs
+++ b/ntbs-service/Models/QueryEntities/NotificationAndDuplicateIds.cs
@@ -1,0 +1,8 @@
+﻿namespace ntbs_service.Models.QueryEntities
+{
+    public class NotificationAndDuplicateIds
+    {
+        public int NotificationId { get; set; }
+        public int DuplicateId { get; set; }
+    }
+}


### PR DESCRIPTION
Update the notification duplicate check to use raw sql for performance reasons.

There were not any existing tests for this job, and because our 'integration' tests use an in-memory database we wouldn't be able to test the relevant logic here, so I haven't added any :-(
