### PR TITLE
NTBS-2054 Use display name for case manager sorting

### DIFF
--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -173,8 +173,7 @@ namespace ntbs_service.DataAccess
                 .ThenInclude(c => c.TbService)
                 .ThenInclude(s => s.PHEC)
                 .Where(u => u.IsCaseManager)
-                .OrderBy(u => u.FamilyName)
-                .ThenBy(u => u.GivenName)
+                .OrderBy(u => u.DisplayName)
                 .ToListAsync();
         }
 
@@ -204,7 +203,7 @@ namespace ntbs_service.DataAccess
                 .SelectMany(t => t.CaseManagerTbServices.Select(join => join.CaseManager))
                 .Where(user => user.IsCaseManager)
                 .Distinct()
-                .OrderBy(c => c.FamilyName)
+                .OrderBy(c => c.DisplayName)
                 .ToListAsync();
         }
 

--- a/ntbs-service/Pages/ServiceDirectory/Region.cshtml.cs
+++ b/ntbs-service/Pages/ServiceDirectory/Region.cshtml.cs
@@ -20,7 +20,7 @@ namespace ntbs_service.Pages.ServiceDirectory
         {
             _referenceDataRepository = referenceDataRepository;
         }
-        
+
         [BindProperty(SupportsGet = true)]
         public string PhecCode { get; set; }
 
@@ -29,23 +29,23 @@ namespace ntbs_service.Pages.ServiceDirectory
 
         public async Task<IActionResult> OnGetAsync()
         {
-            TbServicesWithCaseManagers = 
+            TbServicesWithCaseManagers =
                 (await _referenceDataRepository.GetTbServicesWithCaseManagersFromPhecCodeAsync(PhecCode))
                 .ToDictionary(
-                    service => service, 
+                    service => service,
                     service => service.CaseManagerTbServices
                         .Select(c => c.CaseManager)
-                        .OrderBy(c => c.FamilyName)
+                        .OrderBy(c => c.DisplayName)
                         .ToList()
                     );
 
             Phec = await _referenceDataRepository.GetPhecByCode(PhecCode);
-            
+
             PrepareBreadcrumbs();
-            
+
             return Page();
         }
-        
+
         private void PrepareBreadcrumbs()
         {
             var breadcrumbs = new List<Breadcrumb>


### PR DESCRIPTION
## Description
Use `User.DisplayName` to order lists of case managers instead of `User.FamilyName` which might be `null` when using Azure AD. 

## Checklist:
- [x] Automated tests are passing locally.
- [x] Checked ordering of test users in LCHC, and it orders the new Softwire user names correctly.