### PR TITLE
NTBS-1642: Trim name inputs when searching

### DIFF
--- a/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
+++ b/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
@@ -116,7 +116,7 @@ namespace ntbs_service_unit_tests.Services
         {
             var result = ((INtbsSearchBuilder)builder.FilterByFamilyName("merry")).GetResult().ToList();
 
-            Assert.Equal(2, result.Count());
+            Assert.Equal(2, result.Count);
             Assert.Equal("Merry", result.FirstOrDefault().PatientDetails.FamilyName);
         }
 
@@ -125,7 +125,7 @@ namespace ntbs_service_unit_tests.Services
         {
             var result = ((INtbsSearchBuilder)builder.FilterByFamilyName("ry")).GetResult().ToList();
 
-            Assert.Equal(2, result.Count());
+            Assert.Equal(2, result.Count);
             Assert.Equal("Merry", result.FirstOrDefault().PatientDetails.FamilyName);
         }
 
@@ -134,7 +134,7 @@ namespace ntbs_service_unit_tests.Services
         {
             var result = ((INtbsSearchBuilder)builder.FilterByFamilyName("merr")).GetResult().ToList();
 
-            Assert.Equal(2, result.Count());
+            Assert.Equal(2, result.Count);
             Assert.Equal("Merry", result.FirstOrDefault().PatientDetails.FamilyName);
         }
 
@@ -143,7 +143,16 @@ namespace ntbs_service_unit_tests.Services
         {
             var result = ((INtbsSearchBuilder)builder.FilterByFamilyName("err")).GetResult().ToList();
 
-            Assert.Equal(2, result.Count());
+            Assert.Equal(2, result.Count);
+            Assert.Equal("Merry", result.FirstOrDefault().PatientDetails.FamilyName);
+        }
+
+        [Fact]
+        public void SearchByFamilyName_WhitespacePrefixAndSuffix()
+        {
+            var result = ((INtbsSearchBuilder)builder.FilterByFamilyName("   Merry  ")).GetResult().ToList();
+
+            Assert.Equal(2, result.Count);
             Assert.Equal("Merry", result.FirstOrDefault().PatientDetails.FamilyName);
         }
 
@@ -186,6 +195,15 @@ namespace ntbs_service_unit_tests.Services
         public void SearchByGivenName_WildcardedPrefixAndSuffix()
         {
             var result = ((INtbsSearchBuilder)builder.FilterByGivenName("roun")).GetResult().ToList();
+
+            Assert.Single(result);
+            Assert.Equal("Goround", result.FirstOrDefault().PatientDetails.GivenName);
+        }
+
+        [Fact]
+        public void SearchByGivenName_WhitespacePrefixAndSuffix()
+        {
+            var result = ((INtbsSearchBuilder)builder.FilterByGivenName("  Goround   ")).GetResult().ToList();
 
             Assert.Single(result);
             Assert.Equal("Goround", result.FirstOrDefault().PatientDetails.GivenName);

--- a/ntbs-service/Services/LegacySearchBuilder.cs
+++ b/ntbs-service/Services/LegacySearchBuilder.cs
@@ -45,7 +45,7 @@ namespace ntbs_service.Services
             if (!string.IsNullOrEmpty(familyName))
             {
                 AppendCondition("dmg.FamilyName LIKE @familyName");
-                var wildcardedFamilyName = '%' + familyName + '%';
+                var wildcardedFamilyName = '%' + familyName.Trim() + '%';
                 parameters.familyName = wildcardedFamilyName;
             }
             return this;
@@ -56,7 +56,7 @@ namespace ntbs_service.Services
             if (!string.IsNullOrEmpty(givenName))
             {
                 AppendCondition("dmg.GivenName LIKE @givenName");
-                var wildcardedGivenName = '%' + givenName + '%';
+                var wildcardedGivenName = '%' + givenName.Trim() + '%';
                 parameters.givenName = wildcardedGivenName;
             }
             return this;

--- a/ntbs-service/Services/NtbsSearchBuilder.cs
+++ b/ntbs-service/Services/NtbsSearchBuilder.cs
@@ -39,7 +39,7 @@ namespace ntbs_service.Services
         {
             if (!string.IsNullOrEmpty(familyName))
             {
-                notificationIQ = notificationIQ.Where(s => EF.Functions.Like(s.PatientDetails.FamilyName, $"%{familyName}%"));
+                notificationIQ = notificationIQ.Where(s => EF.Functions.Like(s.PatientDetails.FamilyName, $"%{familyName.Trim()}%"));
             }
             return this;
         }
@@ -48,7 +48,7 @@ namespace ntbs_service.Services
         {
             if (!string.IsNullOrEmpty(givenName))
             {
-                notificationIQ = notificationIQ.Where(s => EF.Functions.Like(s.PatientDetails.GivenName, $"%{givenName}%"));
+                notificationIQ = notificationIQ.Where(s => EF.Functions.Like(s.PatientDetails.GivenName, $"%{givenName.Trim()}%"));
             }
             return this;
         }


### PR DESCRIPTION
## Description
Trim the name inputs when searching for a notification (ntbs and legacy) and added matching tests.
We already do this for other fields where we input text (postcode and ID) by removing all whitespace.

## Checklist:
- [x] Automated tests are passing locally.
