### PR TITLE
Add manual GitHub action dispatch

### DIFF
--- a/.github/workflows/ntbs-test-and-deploy.yml
+++ b/.github/workflows/ntbs-test-and-deploy.yml
@@ -3,6 +3,7 @@ name: test and publish to int
 on:
   push:
     branches: [ master ]
+  workflow_dispatch: 
 
 jobs:
   test-and-publish-job:
@@ -49,6 +50,7 @@ jobs:
 
       # Deploy to int
       - name: Save kubeconfig
+        if: github.ref == 'refs/heads/master'
         env:
           KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
         run: echo "$KUBE_CONFIG" > $GITHUB_WORKSPACE/.kubeconfig


### PR DESCRIPTION
## Description
Add ability to manually dispatch GitHub actions, but don't push this to `int` unless this came from a commit to master.