### PR TITLE
Ntbs 2049 import cluster data

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/ClusterImportTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ClusterImportTest.cs
@@ -1,0 +1,157 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using ntbs_service.DataAccess;
+using ntbs_service.DataMigration;
+using ntbs_service.Models;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Enums;
+using ntbs_service.Services;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataMigration
+{
+    public class ClusterImportTest
+    {
+        private readonly IClusterImportService _clusterImportService;
+
+        private readonly Mock<INotificationClusterRepository> _notificationClusterRepository;
+        private readonly Mock<INotificationRepository> _notificationRepository;
+
+        public ClusterImportTest()
+        {
+            _notificationClusterRepository = new Mock<INotificationClusterRepository>();
+            _notificationRepository = new Mock<INotificationRepository>();
+            _clusterImportService = new ClusterImportService(
+                _notificationClusterRepository.Object,
+                _notificationRepository.Object);
+        }
+
+        [Fact]
+        public async Task NotificationImport_SetsCluster_WhenItExists()
+        {
+            // Arrange
+            const string clusterId = "ABC123";
+            const int etsId = 11;
+            var notification = new Notification {NotificationId = 400, ETSID = etsId.ToString()};
+            SetupClusterIdForEtsId(etsId, clusterId);
+
+            // Act
+            var notifications = new List<Notification> {notification};
+            await _clusterImportService.UpdateClusterInformation(notifications);
+
+            // Assert
+            Assert.Equal(clusterId, notification.ClusterId);
+            _notificationRepository.Verify(nr => nr.SaveChangesAsync(NotificationAuditType.SystemEdited, AuditService.AuditUserSystem), Times.Once);
+        }
+
+        [Fact]
+        public async Task NotificationImport_UpdatesNotificationIdInReportingDatabase_WhenClusterExists()
+        {
+            // Arrange
+            const string clusterId = "ABC123";
+            const int etsId = 11;
+            var notification = new Notification { NotificationId = 400, ETSID = etsId.ToString() };
+            SetupClusterIdForEtsId(etsId, clusterId);
+
+            // Act
+            var notifications = new List<Notification> { notification };
+            await _clusterImportService.UpdateClusterInformation(notifications);
+
+            // Assert
+            _notificationClusterRepository.Verify(ncr => ncr.SetNotificationClusterValue(etsId, notification.NotificationId), Times.Once);
+        }
+
+        [Fact]
+        public async Task NotificationImport_DoesNotSetCluster_WhenItIsNull()
+        {
+            // Arrange
+            const int etsId = 11;
+            var notification = new Notification { NotificationId = 400, ETSID = etsId.ToString() };
+            SetupClusterIdForEtsId(etsId, null);
+
+            // Act
+            var notifications = new List<Notification> { notification };
+            await _clusterImportService.UpdateClusterInformation(notifications);
+
+            // Assert
+            Assert.Null(notification.ClusterId);
+        }
+
+        [Fact]
+        public async Task NotificationImport_DoesNotSetCluster_WhenNoEntryIsFound()
+        {
+            // Arrange
+            const int etsId = 11;
+            var notification = new Notification { NotificationId = 400, ETSID = etsId.ToString() };
+            SetupNoEntryForEtsId(etsId);
+
+            // Act
+            var notifications = new List<Notification> { notification };
+            await _clusterImportService.UpdateClusterInformation(notifications);
+
+            // Assert
+            Assert.Null(notification.ClusterId);
+        }
+
+        [Theory]
+        [InlineData("123A")]
+        [InlineData(null)]
+        public async Task NotificationImport_DoesNotSetCluster_WhenEtsIdIsNotInteger(string etsId)
+        {
+            // Arrange
+            var notification = new Notification { NotificationId = 400, ETSID = etsId };
+
+            // Act
+            var notifications = new List<Notification> { notification };
+            await _clusterImportService.UpdateClusterInformation(notifications);
+
+            // Assert
+            Assert.Null(notification.ClusterId);
+        }
+
+        [Fact]
+        public async Task ClusterImport_CanProcessMultipleNotificationsAtOnce()
+        {
+            // Arrange
+            const int etsId1 = 11;
+            const int etsId2 = 22;
+            const int etsId3 = 33;
+            const string clusterId = "A888";
+            var notification1 = new Notification { NotificationId = 400, ETSID = etsId1.ToString() };
+            var notification2 = new Notification { NotificationId = 401, ETSID = etsId2.ToString() };
+            var notification3 = new Notification { NotificationId = 402, ETSID = etsId3.ToString() };
+            SetupClusterIdForEtsId(etsId1, clusterId);
+            SetupClusterIdForEtsId(etsId2, clusterId);
+            SetupNoEntryForEtsId(etsId3);
+
+            // Act
+            var notifications = new List<Notification> { notification1, notification2, notification3 };
+            await _clusterImportService.UpdateClusterInformation(notifications);
+
+            // Assert
+            Assert.Equal(clusterId, notification1.ClusterId);
+            Assert.Equal(clusterId, notification2.ClusterId);
+            Assert.Null(notification3.ClusterId);
+            _notificationClusterRepository.Verify(ncr => ncr.SetNotificationClusterValue(etsId1, notification1.NotificationId), Times.Once);
+            _notificationClusterRepository.Verify(ncr => ncr.SetNotificationClusterValue(etsId2, notification2.NotificationId), Times.Once);
+            _notificationRepository.Verify(nr => nr.SaveChangesAsync(NotificationAuditType.SystemEdited, AuditService.AuditUserSystem), Times.Exactly(2));
+        }
+
+        private void SetupClusterIdForEtsId(int etsId, string clusterId)
+        {
+            _notificationClusterRepository.Setup(ncr => ncr.GetNotificationClusterValue(etsId))
+                .Returns(Task.FromResult(new NotificationClusterValue
+                {
+                    NotificationId = etsId,
+                    ClusterId = clusterId
+                }));
+        }
+
+        private void SetupNoEntryForEtsId(int etsId)
+        {
+            _notificationClusterRepository.Setup(ncr => ncr.GetNotificationClusterValue(etsId))
+                .Returns(Task.FromResult<NotificationClusterValue>(null));
+        }
+    }
+}

--- a/ntbs-service/DataAccess/NotificationClusterRepository.cs
+++ b/ntbs-service/DataAccess/NotificationClusterRepository.cs
@@ -5,20 +5,20 @@ using Dapper;
 using Microsoft.Extensions.Configuration;
 using ntbs_service.Models;
 
-namespace ntbs_service.Services
+namespace ntbs_service.DataAccess
 {
-    public interface INotificationClusterService
+    public interface INotificationClusterRepository
     {
         Task<IEnumerable<NotificationClusterValue>> GetNotificationClusterValues();
         Task<NotificationClusterValue> GetNotificationClusterValue(int etsNotificationId);
         Task SetNotificationClusterValue(int etsNotificationId, int ntbsNotificationId);
     }
     
-    public class NotificationClusterService : INotificationClusterService
+    public class NotificationClusterRepository : INotificationClusterRepository
     {
         private readonly string _reportingDbConnectionString;
 
-        public NotificationClusterService(IConfiguration configuration)
+        public NotificationClusterRepository(IConfiguration configuration)
         {
             _reportingDbConnectionString = configuration.GetConnectionString(Constants.DbConnectionStringReporting);
         }

--- a/ntbs-service/DataMigration/ClusterImportService.cs
+++ b/ntbs-service/DataMigration/ClusterImportService.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using ntbs_service.DataAccess;
+using ntbs_service.Models;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Enums;
+using ntbs_service.Services;
+
+namespace ntbs_service.DataMigration
+{
+    public interface IClusterImportService
+    {
+        Task UpdateClusterInformation(List<Notification> notifications);
+    }
+
+    public class ClusterImportService : IClusterImportService
+    {
+        private readonly INotificationClusterRepository _notificationClusterRepository;
+        private readonly INotificationRepository _notificationRepository;
+
+        public ClusterImportService(
+            INotificationClusterRepository notificationClusterRepository,
+            INotificationRepository notificationRepository)
+        {
+            _notificationClusterRepository = notificationClusterRepository;
+            _notificationRepository = notificationRepository;
+        }
+
+        public async Task UpdateClusterInformation(List<Notification> notifications)
+        {
+            foreach (var notification in notifications)
+            {
+                var ntbsNotificationId = notification.NotificationId;
+                if (!string.IsNullOrWhiteSpace(notification.ETSID)
+                    && int.TryParse(notification.ETSID, out var etsNotificationId))
+                {
+                    var clusterData = await _notificationClusterRepository.GetNotificationClusterValue(etsNotificationId);
+                    await UpdateClusterInformation(notification, clusterData);
+                    await _notificationClusterRepository.SetNotificationClusterValue(etsNotificationId, ntbsNotificationId);
+                }
+            }
+        }
+
+        private async Task UpdateClusterInformation(Notification notification, NotificationClusterValue clusterData)
+        {
+            if (clusterData != null)
+            {
+                notification.ClusterId = clusterData.ClusterId;
+                await _notificationRepository.SaveChangesAsync(
+                    NotificationAuditType.SystemEdited,
+                    AuditService.AuditUserSystem);
+            }
+        }
+    }
+}

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -6,9 +6,7 @@ using Hangfire.Server;
 using ntbs_service.DataAccess;
 using ntbs_service.DataMigration.Exceptions;
 using ntbs_service.Jobs;
-using ntbs_service.Models;
 using ntbs_service.Models.Entities;
-using ntbs_service.Models.Enums;
 using ntbs_service.Services;
 using Sentry;
 using Serilog;
@@ -42,8 +40,8 @@ namespace ntbs_service.DataMigration
         private readonly IMigrationRepository _migrationRepository;
         private readonly IMigratedNotificationsMarker _migratedNotificationsMarker;
         private readonly ISpecimenService _specimenService;
-        private readonly INotificationClusterService _notificationClusterService;
         private readonly IImportValidator _importValidator;
+        private readonly IClusterImportService _clusterImportService;
 
         public NotificationImportService(INotificationMapper notificationMapper,
                              INotificationRepository notificationRepository,
@@ -54,7 +52,7 @@ namespace ntbs_service.DataMigration
                              IMigratedNotificationsMarker migratedNotificationsMarker,
                              ISpecimenService specimenService,
                              IImportValidator importValidator,
-                             INotificationClusterService notificationClusterService)
+                             IClusterImportService clusterImportService)
         {
             sentryHub.ConfigureScope(s =>
             {
@@ -69,7 +67,7 @@ namespace ntbs_service.DataMigration
             _migratedNotificationsMarker = migratedNotificationsMarker;
             _specimenService = specimenService;
             _importValidator = importValidator;
-            _notificationClusterService = notificationClusterService;
+            _clusterImportService = clusterImportService;
         }
 
         public async Task<IList<ImportResult>> ImportByDateAsync(PerformContext context, string requestId, DateTime rangeStartDate, DateTime rangeEndDate)
@@ -186,7 +184,7 @@ namespace ntbs_service.DataMigration
                 await _migratedNotificationsMarker.MarkNotificationsAsImportedAsync(savedNotifications);
                 importResult.NtbsIds = savedNotifications.ToDictionary(x => x.LegacyId, x => x.NotificationId);
                 await ImportReferenceLabResultsAsync(context, requestId, savedNotifications, importResult);
-                await UpdateClusterInformation(context, requestId, savedNotifications);
+                await _clusterImportService.UpdateClusterInformation(savedNotifications);
 
                 var newIdsString = string.Join(" ,", savedNotifications.Select(x => x.NotificationId));
                 _logger.LogSuccess(context, requestId, $"Imported notifications have following Ids: {newIdsString}");
@@ -251,40 +249,6 @@ namespace ntbs_service.DataMigration
                 }
             }
             return legacyIdsToImport;
-        }
-
-        private async Task UpdateClusterInformation(
-            PerformContext context,
-            string requestId,
-            List<Notification> savedNotifications)
-        {
-            foreach (var notification in savedNotifications)
-            {
-                var ntbsNotificationId = notification.NotificationId;
-                if (!string.IsNullOrWhiteSpace(notification.ETSID)
-                    && int.TryParse(notification.ETSID, out var etsNotificationId))
-                {
-                    var clusterData = await _notificationClusterService.GetNotificationClusterValue(etsNotificationId);
-                    await UpdateClusterInformation(context, requestId, notification, clusterData);
-                    await _notificationClusterService.SetNotificationClusterValue(etsNotificationId, ntbsNotificationId);
-                }
-            }
-        }
-
-        private async Task UpdateClusterInformation(
-            PerformContext context,
-            string requestId,
-            Notification notification,
-            NotificationClusterValue clusterData)
-        {
-            if (clusterData != null)
-            {
-                notification.ClusterId = clusterData.ClusterId;
-                await _notificationRepository.SaveChangesAsync(
-                    NotificationAuditType.SystemEdited,
-                    AuditService.AuditUserSystem);
-                _logger.LogSuccess(context, requestId, $"Imported notification with ID {notification.NotificationId} into cluster with ID {clusterData.ClusterId}");
-            }
         }
     }
 }

--- a/ntbs-service/Jobs/NotificationClusterUpdateJob.cs
+++ b/ntbs-service/Jobs/NotificationClusterUpdateJob.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using Hangfire;
+using ntbs_service.DataAccess;
 using ntbs_service.Services;
 using Serilog;
 
@@ -7,14 +8,14 @@ namespace ntbs_service.Jobs
 {
     public class NotificationClusterUpdateJob
     {
-        private readonly INotificationClusterService _notificationClusterService;
+        private readonly INotificationClusterRepository _notificationClusterRepository;
         private readonly INotificationService _notificationService;
 
         public NotificationClusterUpdateJob(
-            INotificationClusterService notificationClusterService,
+            INotificationClusterRepository notificationClusterRepository,
             INotificationService notificationService)
         {
-            _notificationClusterService = notificationClusterService;
+            _notificationClusterRepository = notificationClusterRepository;
             _notificationService = notificationService;
         }
 
@@ -22,7 +23,7 @@ namespace ntbs_service.Jobs
         {
             Log.Information($"Starting notification cluster update job");
             
-            var clusterValues = await _notificationClusterService.GetNotificationClusterValues();
+            var clusterValues = await _notificationClusterRepository.GetNotificationClusterValues();
             await _notificationService.UpdateNotificationClustersAsync(clusterValues);
             
             Log.Information($"Finishing notification cluster update job");

--- a/ntbs-service/Services/MockNotificationClusterService.cs
+++ b/ntbs-service/Services/MockNotificationClusterService.cs
@@ -1,15 +1,16 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using ntbs_service.DataAccess;
 using ntbs_service.Models;
 
 namespace ntbs_service.Services
 {
-    public class MockNotificationClusterService : INotificationClusterService
+    public class MockNotificationClusterRepository : INotificationClusterRepository
     {
         private readonly List<NotificationClusterValue> _notificationClusterValues;
 
-        public MockNotificationClusterService(List<NotificationClusterValue> notificationClusterValues)
+        public MockNotificationClusterRepository(List<NotificationClusterValue> notificationClusterValues)
         {
             _notificationClusterValues = notificationClusterValues;
         }

--- a/ntbs-service/Services/MockNotificationClusterService.cs
+++ b/ntbs-service/Services/MockNotificationClusterService.cs
@@ -1,4 +1,5 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using ntbs_service.Models;
 
@@ -16,6 +17,16 @@ namespace ntbs_service.Services
         public Task<IEnumerable<NotificationClusterValue>> GetNotificationClusterValues()
         {
             return Task.FromResult(_notificationClusterValues as IEnumerable<NotificationClusterValue>);
+        }
+
+        public Task<NotificationClusterValue> GetNotificationClusterValue(int etsNotificationId)
+        {
+            return Task.FromResult(_notificationClusterValues.SingleOrDefault(ncv => ncv.NotificationId == etsNotificationId));
+        }
+
+        public Task SetNotificationClusterValue(int etsNotificationId, int ntbsNotificationId)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -454,12 +454,12 @@ namespace ntbs_service
                 var notificationClusterValues = new List<NotificationClusterValue>();
                 clusterMatchingConfig.Bind("MockedNotificationClusterValues", notificationClusterValues);
 
-                services.AddScoped<INotificationClusterService>(sp =>
-                    new MockNotificationClusterService(notificationClusterValues));
+                services.AddScoped<INotificationClusterRepository>(sp =>
+                    new MockNotificationClusterRepository(notificationClusterValues));
             }
             else
             {
-                services.AddScoped<INotificationClusterService, NotificationClusterService>();
+                services.AddScoped<INotificationClusterRepository, NotificationClusterRepository>();
             }
         }
 


### PR DESCRIPTION
When importing a notification:
- Check in the reporting database to see if there is a cluster assigned to the ETS ID of the notification
- If there is:
    - Add the cluster to the notification
    - Update the entry in the reporting database to refer to the new Notification ID rather than the ETS ID

## Checklist:
- [x] Automated tests are passing locally.
