### PR TITLE
NTBS-2091 NHS Frontend upgrade

### DIFF
--- a/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
+++ b/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
@@ -72,7 +72,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var specimenDetailsSections = document.QuerySelectorAll(".specimen-details");
+                var specimenDetailsSections = document.QuerySelectorAll(".nhsuk-care-card--specimen");
                 Assert.Equal(expectedLabReferenceNumbers.Count, specimenDetailsSections.Length);
 
                 foreach (var expectedLabReferenceNumber in expectedLabReferenceNumbers)
@@ -102,7 +102,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var specimenDetailsSections = document.QuerySelectorAll(".specimen-details");
+                var specimenDetailsSections = document.QuerySelectorAll(".nhsuk-care-card--specimen");
                 Assert.Equal(0, specimenDetailsSections.Length);
             }
         }
@@ -130,7 +130,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var specimenDetailsSections = document.QuerySelectorAll(".specimen-details");
+                var specimenDetailsSections = document.QuerySelectorAll(".nhsuk-care-card--specimen");
                 Assert.Equal(expectedLabReferenceNumbers.Count, specimenDetailsSections.Length);
 
                 foreach (var expectedLabReferenceNumber in expectedLabReferenceNumbers)
@@ -167,7 +167,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-                var specimenDetailsSections = document.QuerySelectorAll(".specimen-details");
+                var specimenDetailsSections = document.QuerySelectorAll(".nhsuk-care-card--specimen");
                 Assert.Equal(expectedLabReferenceNumbers.Count, specimenDetailsSections.Length);
 
                 foreach (var expectedLabReferenceNumber in expectedLabReferenceNumbers)
@@ -194,7 +194,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 const string url = "/LabResults";
                 var response = await client.GetAsync(url);
                 var document = await GetDocumentAsync(response);
-                
+
                 var formData = new Dictionary<string, string>
                 {
                     [$"PotentialMatchSelections[{specimenNumber}].NotificationId"] =
@@ -214,7 +214,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 // rendered values.
             }
         }
-        
+
         [Fact]
         public async Task NationalTeam_CanMatchSpecimenForManualNotificationId()
         {
@@ -233,7 +233,7 @@ namespace ntbs_integration_tests.LabResultsPage
 
                 var formData = new Dictionary<string, string>
                 {
-                    [$"PotentialMatchSelections[{specimenNumber}].NotificationId"] = 
+                    [$"PotentialMatchSelections[{specimenNumber}].NotificationId"] =
                         IndexModel.ManualNotificationIdValue.ToString(),
                     [$"PotentialMatchSelections[{specimenNumber}].ManualNotificationId"] =
                         manualMatchNotificationId.ToString(),
@@ -244,14 +244,14 @@ namespace ntbs_integration_tests.LabResultsPage
 
                 // Assert
                 await AssertAndFollowRedirect(postResponse, url);
-                
+
                 // As session/tempData aren't functional by default with webApplicationFactory, and configuring this
                 // wasn't deemed a good use of time, cannot confirm that the flash message is shown here.
                 // Additionally as we're using a mocked specimen service, the unmatched specimen is not removed from the
                 // rendered values.
             }
         }
-        
+
         [Fact]
         public async Task NationalTeam_CanNotManuallyMatchToNonExistentNotificationId_ValidationError()
         {
@@ -270,7 +270,7 @@ namespace ntbs_integration_tests.LabResultsPage
 
                 var formData = new Dictionary<string, string>
                 {
-                    [$"PotentialMatchSelections[{specimenNumber}].NotificationId"] = 
+                    [$"PotentialMatchSelections[{specimenNumber}].NotificationId"] =
                         IndexModel.ManualNotificationIdValue.ToString(),
                     [$"PotentialMatchSelections[{specimenNumber}].ManualNotificationId"] =
                         manualMatchNotificationId.ToString(),
@@ -282,10 +282,10 @@ namespace ntbs_integration_tests.LabResultsPage
 
                 // Assert
                 result.AssertValidationErrorResponse();
-                
+
                 resultDocument.AssertErrorSummaryMessage(
-                    $"PotentialMatchSelections[{specimenNumber}]-ManualNotificationId", 
-                    $"PotentialMatchSelections[{specimenNumber}]-ManualNotificationId", 
+                    $"PotentialMatchSelections[{specimenNumber}]-ManualNotificationId",
+                    $"PotentialMatchSelections[{specimenNumber}]-ManualNotificationId",
                     "The notification ID does not exist, verify you have entered the correct ID before moving forward");
 
             }

--- a/ntbs-service/Pages/LabResults/Index.cshtml
+++ b/ntbs-service/Pages/LabResults/Index.cshtml
@@ -56,10 +56,16 @@ else
     <h2 class="govuk-visually-hidden">Unmatched specimens and potential matches</h2>
     @foreach (var specimen in Model.UnmatchedSpecimens)
     {
-        <div class="nhsuk-panel-with-label specimen-details">
-            <h3 class="nhsuk-panel-with-label__label" id="@($"specimen-{specimen.ReferenceLaboratoryNumber}")">
-                Reference laboratory number @specimen.ReferenceLaboratoryNumber
-            </h3>
+        <div class="nhsuk-care-card nhsuk-care-card--specimen">
+            <div class="nhsuk-care-card__heading-container">
+                <h3 class="nhsuk-care-card__heading" id="@($"specimen-{specimen.ReferenceLaboratoryNumber}")">
+                    <span role="text">
+                        Reference laboratory number @specimen.ReferenceLaboratoryNumber
+                    </span>
+                </h3>
+                <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
+            </div>
+            <div class="nhsuk-care-card__content">
             <form method="post" autocomplete="off">
                 <div>
                     <nhs-grid-row>
@@ -241,6 +247,7 @@ else
                     </button>
                 </div>
             </form>
+            </div>
         </div>
     }
 }

--- a/ntbs-service/package-lock.json
+++ b/ntbs-service/package-lock.json
@@ -20,7 +20,7 @@
         "file-loader": "6.2.0",
         "formdata-polyfill": "3.0.20",
         "govuk-frontend": "3.11.0",
-        "nhsuk-frontend": "3.1.0",
+        "nhsuk-frontend": "4.1.0",
         "qs": "6.9.6",
         "sass": "1.32.8",
         "url-loader": "4.1.1",
@@ -29,7 +29,7 @@
       },
       "devDependencies": {
         "@sentry/webpack-plugin": "1.14.1",
-        "@types/node": "14.14.30",
+        "@types/node": "14.14.31",
         "@types/webpack-env": "1.16.0",
         "css-loader": "5.0.2",
         "mini-css-extract-plugin": "1.3.8",
@@ -1153,9 +1153,9 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
     "node_modules/@types/node": {
-      "version": "14.14.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.30.tgz",
-      "integrity": "sha512-gUWhy8s45fQp4PqqKecsnOkdW0kt1IaKjgOIR3HPokkzTmQj9ji2wWFID5THu1MKrtO+d4s2lVrlEhXUsPXSvg==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
     },
     "node_modules/@types/webpack-env": {
@@ -2805,12 +2805,11 @@
       "dev": true
     },
     "node_modules/nhsuk-frontend": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-3.1.0.tgz",
-      "integrity": "sha512-b3mt1E4N+MVkVUjrNtF1z/FyGn8icz2d5slQ/baPAbKbvOvfgE0ecqv6BrggiyGMzFXeSYuA8pTMhRU90jmv/Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-Qg/2O72XeHkyzMnEV58bvrYb9Wg0QcoTIZgBAa8B0ch6yO0rW+u6tNv3eD2fSkQ8NLBGWVRmdBAXGtcn1xMQZw==",
       "dependencies": {
-        "accessible-autocomplete": "^2.0.2",
-        "sass-mq": "^5.0.1"
+        "accessible-autocomplete": "^2.0.3"
       }
     },
     "node_modules/node-fetch": {
@@ -3297,11 +3296,6 @@
       "engines": {
         "node": ">= 10.13.0"
       }
-    },
-    "node_modules/sass-mq": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
-      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
     },
     "node_modules/schema-utils": {
       "version": "3.0.0",
@@ -5116,9 +5110,9 @@
       "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
     },
     "@types/node": {
-      "version": "14.14.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.30.tgz",
-      "integrity": "sha512-gUWhy8s45fQp4PqqKecsnOkdW0kt1IaKjgOIR3HPokkzTmQj9ji2wWFID5THu1MKrtO+d4s2lVrlEhXUsPXSvg==",
+      "version": "14.14.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+      "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
       "dev": true
     },
     "@types/webpack-env": {
@@ -6439,12 +6433,11 @@
       "dev": true
     },
     "nhsuk-frontend": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-3.1.0.tgz",
-      "integrity": "sha512-b3mt1E4N+MVkVUjrNtF1z/FyGn8icz2d5slQ/baPAbKbvOvfgE0ecqv6BrggiyGMzFXeSYuA8pTMhRU90jmv/Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-Qg/2O72XeHkyzMnEV58bvrYb9Wg0QcoTIZgBAa8B0ch6yO0rW+u6tNv3eD2fSkQ8NLBGWVRmdBAXGtcn1xMQZw==",
       "requires": {
-        "accessible-autocomplete": "^2.0.2",
-        "sass-mq": "^5.0.1"
+        "accessible-autocomplete": "^2.0.3"
       }
     },
     "node-fetch": {
@@ -6824,11 +6817,6 @@
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"
       }
-    },
-    "sass-mq": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/sass-mq/-/sass-mq-5.0.1.tgz",
-      "integrity": "sha512-ugSVZO5fzasSFrGfKCtY02spnkOOfo9U9sXuzCuSXoCl1CgcoqdJRdNmigZkhvRVph1GKM6o0pgI00Jjc445CA=="
     },
     "schema-utils": {
       "version": "3.0.0",

--- a/ntbs-service/package.json
+++ b/ntbs-service/package.json
@@ -8,6 +8,10 @@
     "build": "webpack --config webpack.dev.js",
     "build:prod": "webpack --config webpack.prod.js"
   },
+  "browserslist": [
+    "defaults",
+    "IE 11"
+  ],
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/ntbs-service/package.json
+++ b/ntbs-service/package.json
@@ -24,7 +24,7 @@
     "file-loader": "6.2.0",
     "formdata-polyfill": "3.0.20",
     "govuk-frontend": "3.11.0",
-    "nhsuk-frontend": "3.1.0",
+    "nhsuk-frontend": "4.1.0",
     "qs": "6.9.6",
     "sass": "1.32.8",
     "url-loader": "4.1.1",
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@sentry/webpack-plugin": "1.14.1",
-    "@types/node": "14.14.30",
+    "@types/node": "14.14.31",
     "@types/webpack-env": "1.16.0",
     "css-loader": "5.0.2",
     "mini-css-extract-plugin": "1.3.8",

--- a/ntbs-service/webpack.common.js
+++ b/ntbs-service/webpack.common.js
@@ -28,10 +28,7 @@ module.exports = {
               options: {
                   presets: [
                       [
-                      "@babel/preset-env",
-                      {
-                          "targets": {"ie": 11}
-                      }
+                          "@babel/preset-env"
                       ]
                   ]
               }

--- a/ntbs-service/wwwroot/css/_colors.scss
+++ b/ntbs-service/wwwroot/css/_colors.scss
@@ -8,6 +8,8 @@ $grey: #999999;
 $lighter-grey: #CCCCCC;
 $shaded-background-color: #F0F4F5;
 
+$phe-navy: #002776;
+
 $banner-header--draft: #dcc2c6;
 $banner-border--draft: #8c3a47;
 $banner-header--notified: $phe-red;

--- a/ntbs-service/wwwroot/css/labResults.scss
+++ b/ntbs-service/wwwroot/css/labResults.scss
@@ -1,5 +1,3 @@
-@import "./_colors.scss";
-
 .lab-results-radio-container {
   width: 60px;
   display: flex;
@@ -21,7 +19,7 @@
   display: flex;
   flex-direction: column;
   padding: 0 16px;
-  
+
   & * {
     margin-top: auto;
     margin-bottom: auto;
@@ -45,7 +43,7 @@
 .nhs-form-group--manual-lab-result {
   display: flex;
   flex-wrap: wrap;
-  
+
   > .nhsuk-label {
     margin-right: 20px;
     margin-top: 10px;
@@ -54,7 +52,7 @@
       margin-top: 7px;
     }
   }
-  
+
   > .nhsuk-error-message {
     flex-basis: 100%;
   }
@@ -66,4 +64,15 @@
   overflow: auto;
   padding-top: 24px;
   margin-bottom: 24px;
+}
+
+.nhsuk-care-card--specimen {
+  @include care-card($phe-navy, $color_nhsuk-white, 4px);
+
+  .nhsuk-care-card__arrow {
+    &:before,
+    &:after {
+      border-color: $phe-navy;
+    }
+  }
 }

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -7,6 +7,7 @@
 @import "../../node_modules/nhsuk-frontend/packages/nhsuk.scss";
 // Govuk css - needed for things like conditionally revealed radios sections
 @import "../../node_modules/vue-accessible-modal/dist/index.css";
+@import "./_colors.scss";
 @import "./checkboxes.scss";
 @import "./buttons.scss";
 @import "./notification.scss";
@@ -232,10 +233,6 @@ body {
             font-size: 16px;
         }
     }
-}
-
-.nhsuk-panel-with-label__label {
-  background-color: #002776;
 }
 
 .draft-notifications-container {

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -1,11 +1,15 @@
-﻿@use "../../node_modules/govuk-frontend/govuk/all.scss" with (
-    $govuk-assets-path: "../../node_modules/govuk-frontend/govuk/assets/"
+﻿// Govuk css - needed for things like conditionally revealed radios sections
+// Set use a relative path for assets, to allow the CSS loader to find the assets and then pass them to the
+// file/URL loaders.
+// Also, change the font-family so we don't use the GDS Transport font, because this is not a GDS service.
+@use "../../node_modules/govuk-frontend/govuk/all.scss" with (
+  $govuk-assets-path: "../../node_modules/govuk-frontend/govuk/assets/",
+  $govuk-font-family: (arial, sans-serif)
 );
 
 @import "./reset.scss";
 // We're importing the raw scss instaed of a packaged css bundle since we're using some of the dynamic elements ourselves (colour variables, functions etc)
 @import "../../node_modules/nhsuk-frontend/packages/nhsuk.scss";
-// Govuk css - needed for things like conditionally revealed radios sections
 @import "../../node_modules/vue-accessible-modal/dist/index.css";
 @import "./_colors.scss";
 @import "./checkboxes.scss";


### PR DESCRIPTION
Upgrade to NHS frontend version 4. Also included are fixes for a couple of minor bugs produced by the NPM package upgrade (NTBS-1768) which were spotted during testing this

## Description
* Upgrade to NHS frontend v4: Replace the unmatched specimen panel in the lab results page with a similar care card, because panels were removed in the NHS frontend v3 -> v4 upgrade.
* Update the forked NHS frontend tag helper submodule to use the version updated for v4.
* Fix header fonts after changing CSS loader version 
* Fix webpack builds for IE11 (the way that we tell it to target IE11 has changed, though the transpilation mechanism itself wasn't really affected by the webpack v4 -> v5 upgrade). 

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
For the new specimen card
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content is all still visible, though the layout isn't great. That said, its no worse than it was before this change was made
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Run through automated checker [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh), mostly passes, and the errors are errors that existed before these changes were made.

## Screenshot of new specimen card
![specimen_card](https://user-images.githubusercontent.com/3650110/109028086-5e6a8a80-76b9-11eb-83c3-9675e89f0279.png)
