### PR TITLE
NTBS-2111: Show alerts to new TB Service users for transferred notification

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -309,7 +309,6 @@ namespace ntbs_integration_tests.Helpers
                 {
                     AlertId = ALERT_ID,
                     AlertStatus = AlertStatus.Open,
-                    TbServiceCode = PERMITTED_SERVICE_CODE,
                     CreationDate = DateTime.Now,
                     NotificationId = NOTIFIED_ID,
                     AlertType = AlertType.Test
@@ -354,7 +353,6 @@ namespace ntbs_integration_tests.Helpers
                     AlertType = AlertType.TransferRejected,
                     AlertId = TRANSFER_REJECTED_ID,
                     NotificationId = NOTIFIED_ID,
-                    TbServiceCode = TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID,
                     AlertStatus = AlertStatus.Open
                 }
             };

--- a/ntbs-service-unit-tests/Services/AlertServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AlertServiceTest.cs
@@ -103,8 +103,6 @@ namespace ntbs_service_unit_tests.Services
             Assert.Equal(AlertStatus.Open, alert.AlertStatus);
             Assert.Equal(1, alert.NotificationId);
             Assert.Equal("1", alert.SpecimenId);
-            Assert.Equal("testUsername@email.com", alert.CaseManagerUsername);
-            Assert.Equal("AB0000001", alert.TbServiceCode);
         }
     }
 }

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -16,7 +16,7 @@ namespace ntbs_service.DataAccess
 
         Task<DataQualityPotentialDuplicateAlert> GetDuplicateAlertByNotificationIdAndDuplicateId(int notificationId,
             int duplicateId);
-        IQueryable<Alert> GetOpenAlertsForNotificationIQueryable(int notificationId);
+        Task<IList<Alert>> GetOpenAlertsForNotificationAsync(int notificationId);
         Task<IList<UnmatchedLabResultAlert>> GetAllOpenUnmatchedLabResultAlertsAsync();
         Task<DataQualityDraftAlert> GetOpenDraftAlertForNotificationAsync(int notificationId);
         Task AddAlertAsync(Alert alert);
@@ -84,10 +84,11 @@ namespace ntbs_service.DataAccess
                 .SingleOrDefaultAsync();
         }
         
-        public IQueryable<Alert> GetOpenAlertsForNotificationIQueryable(int notificationId)
+        public async Task<IList<Alert>> GetOpenAlertsForNotificationAsync(int notificationId)
         {
-            return GetBaseOpenAlertIQueryable()
-                .Where(a => a.NotificationId == notificationId);
+            return await GetBaseOpenAlertIQueryable()
+                .Where(a => a.NotificationId == notificationId)
+                .ToListAsync();
         }
 
         public IQueryable<Alert> GetBaseOpenAlertIQueryable()

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -671,8 +671,6 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.AlertStatus)
                     .HasConversion(alertStatusEnumConverter)
                     .HasMaxLength(EnumMaxLength);
-                entity.Property(e => e.CaseManagerUsername).HasMaxLength(64);
-                entity.Property(e => e.TbServiceCode).IsRequired().HasMaxLength(16);
                 entity.Property(e => e.ClosingUserId).HasMaxLength(64);
                 entity.HasIndex(p => new { p.NotificationId, p.AlertType });
                 entity.Property(e => e.AlertType)
@@ -694,7 +692,7 @@ namespace ntbs_service.DataAccess
                     .HasValue<DataQualityDotVotAlert>(AlertType.DataQualityDotVotAlert)
                     .HasValue<DataQualityPotentialDuplicateAlert>(AlertType.DataQualityPotientialDuplicate);
 
-                entity.HasIndex(e => new { e.AlertStatus, e.AlertType, e.TbServiceCode });
+                entity.HasIndex(e => new { e.AlertStatus, e.AlertType });
             });
 
             modelBuilder.Entity<TestAlert>().HasBaseType<Alert>();
@@ -703,6 +701,8 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.TransferReason)
                     .HasConversion(transferReasonEnumConverter)
                     .HasMaxLength(EnumMaxLength);
+                entity.Property(e => e.TbServiceCode).HasColumnName("TbServiceCode").HasMaxLength(16);
+                entity.Property(e => e.CaseManagerUsername).HasColumnName("CaseManagerUsername").HasMaxLength(64);;
             });
             modelBuilder.Entity<UnmatchedLabResultAlert>(entity =>
             {

--- a/ntbs-service/Jobs/DataQualityAlertsJob.cs
+++ b/ntbs-service/Jobs/DataQualityAlertsJob.cs
@@ -87,11 +87,6 @@ namespace ntbs_service.Jobs
                         T alert = (T)Activator.CreateInstance(typeof(T));
                         alert.NotificationId = n.NotificationId;
                         alert.CreationDate = now;
-                        alert.TbServiceCode = n.HospitalDetails?.TBServiceCode;
-                        if (alert.AlertType != AlertType.TransferRequest)
-                        {
-                            alert.CaseManagerUsername = n.HospitalDetails?.CaseManagerUsername;
-                        }
 
                         return (Alert) alert;
                     })

--- a/ntbs-service/Jobs/DataQualityAlertsJob.cs
+++ b/ntbs-service/Jobs/DataQualityAlertsJob.cs
@@ -6,7 +6,6 @@ using Hangfire;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
-using ntbs_service.Models.Enums;
 using ntbs_service.Services;
 using Serilog;
 

--- a/ntbs-service/Migrations/20210223122109_MoveTbServiceAndCaseManagerToTransferAlert.Designer.cs
+++ b/ntbs-service/Migrations/20210223122109_MoveTbServiceAndCaseManagerToTransferAlert.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Enums;
@@ -10,9 +11,10 @@ using ntbs_service.Models.Enums;
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210223122109_MoveTbServiceAndCaseManagerToTransferAlert")]
+    partial class MoveTbServiceAndCaseManagerToTransferAlert
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210223122109_MoveTbServiceAndCaseManagerToTransferAlert.cs
+++ b/ntbs-service/Migrations/20210223122109_MoveTbServiceAndCaseManagerToTransferAlert.cs
@@ -1,0 +1,74 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class MoveTbServiceAndCaseManagerToTransferAlert : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Alert_TbService_TbServiceCode",
+                table: "Alert");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Alert_AlertStatus_AlertType_TbServiceCode",
+                table: "Alert");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "TbServiceCode",
+                table: "Alert",
+                maxLength: 16,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldMaxLength: 16);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Alert_AlertStatus_AlertType",
+                table: "Alert",
+                columns: new[] { "AlertStatus", "AlertType" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Alert_TbService_TbServiceCode",
+                table: "Alert",
+                column: "TbServiceCode",
+                principalSchema: "ReferenceData",
+                principalTable: "TbService",
+                principalColumn: "Code",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Alert_TbService_TbServiceCode",
+                table: "Alert");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Alert_AlertStatus_AlertType",
+                table: "Alert");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "TbServiceCode",
+                table: "Alert",
+                maxLength: 16,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldMaxLength: 16,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Alert_AlertStatus_AlertType_TbServiceCode",
+                table: "Alert",
+                columns: new[] { "AlertStatus", "AlertType", "TbServiceCode" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Alert_TbService_TbServiceCode",
+                table: "Alert",
+                column: "TbServiceCode",
+                principalSchema: "ReferenceData",
+                principalTable: "TbService",
+                principalColumn: "Code",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/Alerts/Alert.cs
+++ b/ntbs-service/Models/Entities/Alerts/Alert.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.DataAnnotations;
 using ntbs_service.Helpers;
 using ntbs_service.Models.Enums;
-using ntbs_service.Models.ReferenceEntities;
 
 namespace ntbs_service.Models.Entities.Alerts
 {
@@ -13,13 +12,6 @@ namespace ntbs_service.Models.Entities.Alerts
         public int? NotificationId { get; set; }
         public virtual Notification Notification { get; set; }
         public DateTime CreationDate { get; set; }
-        
-        [Display(Name = "TB Service")]
-        public string TbServiceCode { get; set; }
-        public virtual TBService TbService { get; set; }
-        [Display(Name = "Case Manager")]
-        public string CaseManagerUsername { get; set; }
-        public virtual User CaseManager { get; set; }
         public AlertStatus AlertStatus { get; set; }
         public DateTime? ClosureDate { get; set; }
         public string ClosingUserId { get; set; }
@@ -28,12 +20,8 @@ namespace ntbs_service.Models.Entities.Alerts
         public virtual string ActionLink { get; }
         public virtual string Action { get; }
         public virtual bool NotDismissable  { get; }
-        [Display(Name = "Case manager")] 
-        public string CaseManagerFullName => CaseManager?.DisplayName ?? "";
         [Display(Name = "Alert date")]
         public string FormattedCreationDate => CreationDate.ConvertToString();
-        [Display(Name = "TB Service")]
-        public string TbServiceName => TbService?.Name;
     }
 
 }

--- a/ntbs-service/Models/Entities/Alerts/AlertWithTbServiceForDisplay.cs
+++ b/ntbs-service/Models/Entities/Alerts/AlertWithTbServiceForDisplay.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.ComponentModel.DataAnnotations;
+using ntbs_service.Helpers;
+using ntbs_service.Models.Enums;
+
+namespace ntbs_service.Models.Entities.Alerts
+{
+    public class AlertWithTbServiceForDisplay
+    {
+        public int AlertId { get; set; }
+        public int? NotificationId { get; set; }
+        public DateTime CreationDate { get; set; }
+        public bool NotDismissable  { get; set; }
+        public string FormattedCreationDate => CreationDate.ConvertToString();
+        public AlertType AlertType { get; set; }
+        public string ActionLink { get; set; }
+        public string Action { get; set; }
+        public string TbServiceCode { get; set; }
+        [Display(Name =  "TB Service")]
+        public string TbServiceName { get; set; }
+        [Display(Name =  "Case Manager")]
+        public string CaseManagerName { get; set; }
+    }
+
+}

--- a/ntbs-service/Models/Entities/Alerts/TransferAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/TransferAlert.cs
@@ -3,6 +3,7 @@ using ntbs_service.Models.Validations;
 using System.ComponentModel.DataAnnotations;
 using EFAuditer;
 using ntbs_service.Helpers;
+using ntbs_service.Models.ReferenceEntities;
 
 namespace ntbs_service.Models.Entities.Alerts
 
@@ -37,5 +38,11 @@ namespace ntbs_service.Models.Entities.Alerts
 
         public string RootEntityType => RootEntities.Notification;
         public string RootId => NotificationId.ToString();
+        [Display(Name = "TB Service")]
+        public string TbServiceCode { get; set; }
+        public virtual TBService TbService { get; set; }
+        [Display(Name = "Case Manager")]
+        public string CaseManagerUsername { get; set; }
+        public virtual User CaseManager { get; set; }
     }
 }

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
@@ -20,7 +20,7 @@
         
         <div class="transfer-request-information flex-container"> 
             <div class="transfer-request-information-label"> Sending TB service: </div>
-            <div> @Model.TransferAlert.TbServiceName </div>
+            <div> @Model.TransferAlert.TbService.Name </div>
         </div>
 
         <div class="transfer-request-information flex-container"> 

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml
@@ -20,12 +20,12 @@
         
         <div class="transfer-request-information flex-container"> 
             <div class="transfer-request-information-label"> Sending TB service: </div>
-            <div> @Model.TransferAlert.TbService.Name </div>
+            <div> @Model.TransferAlert.TbService?.Name </div>
         </div>
 
         <div class="transfer-request-information flex-container"> 
             <div class="transfer-request-information-label"> Sending case manager: </div>
-            <div> @Model.Notification?.HospitalDetails.CaseManagerName </div>
+            <div> @Model.Notification.HospitalDetails?.CaseManagerName </div>
         </div>
         
         <div class="transfer-request-information flex-container">

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -159,11 +159,9 @@ namespace ntbs_service.Pages.Alerts
             var user = await _referenceDataRepository.GetUserByUsernameAsync(User.Username());
             var transferRejectedAlert = new TransferRejectedAlert
             {
-                CaseManagerUsername = Notification.HospitalDetails.CaseManagerUsername,
                 NotificationId = NotificationId,
                 RejectionReason = DeclineTransferReason ?? "No reason was given when declining this transfer.",
-                DecliningUserAndTbServiceString = $"{user.DisplayName}, {TransferAlert.TbServiceName}",
-                TbServiceCode = Notification.HospitalDetails.TBServiceCode
+                DecliningUserAndTbServiceString = $"{user.DisplayName}, {TransferAlert.TbService.Name}"
             };
 
             // Dismiss any existing transfer rejected alert so that the new one can be created

--- a/ntbs-service/Pages/Alerts/_TransferPendingPartial.cshtml
+++ b/ntbs-service/Pages/Alerts/_TransferPendingPartial.cshtml
@@ -35,7 +35,7 @@
                     TB Service
                 </span>
                 <div>
-                    @Model.TransferAlert.TbServiceName
+                    @Model.TransferAlert.TbService?.Name
                 </div>
             </nhs-grid-column>
 
@@ -44,7 +44,7 @@
                     Case manager
                 </span>
                 <div>
-                    @Model.TransferAlert.CaseManagerFullName
+                    @Model.TransferAlert.CaseManager.DisplayName
                 </div>
             </nhs-grid-column>
         </nhs-grid-row>

--- a/ntbs-service/Pages/Alerts/_TransferPendingPartial.cshtml
+++ b/ntbs-service/Pages/Alerts/_TransferPendingPartial.cshtml
@@ -44,7 +44,7 @@
                     Case manager
                 </span>
                 <div>
-                    @Model.TransferAlert.CaseManager.DisplayName
+                    @Model.TransferAlert.CaseManager?.DisplayName
                 </div>
             </nhs-grid-column>
         </nhs-grid-row>

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -44,8 +44,13 @@
                             @Html.DisplayNameFor(model => model.Alerts[0].AlertType)
                         </nhs-table-item>
                         <nhs-table-item>
+<<<<<<< HEAD
                             @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.CaseManager)
                             <br />
+=======
+                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.CaseManagerName)
+                            <br/>
+>>>>>>> c500ac29... NTBS-2111: Fix when transfer requests should be shown
                             @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.TBServiceName)
                         </nhs-table-item>
                         <nhs-table-item>
@@ -76,9 +81,9 @@
                                     @Html.DisplayFor(_ => item.Action)
                                 </nhs-table-item>
                                 <nhs-table-item>
-                                    @if (!string.IsNullOrWhiteSpace(item.Notification?.HospitalDetails?.CaseManager?.DisplayName))
+                                    @if (!string.IsNullOrWhiteSpace(item.Notification?.HospitalDetails?.CaseManagerName))
                                     {
-                                        @item.Notification.HospitalDetails.CaseManager.DisplayName
+                                        @item.Notification.HospitalDetails.CaseManagerName
                                         <br />
                                     }
                                     @item.Notification?.HospitalDetails?.TBServiceName

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -44,7 +44,7 @@
                             @Html.DisplayNameFor(model => model.Alerts[0].AlertType)
                         </nhs-table-item>
                         <nhs-table-item>
-                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.CaseManager.DisplayName)
+                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.CaseManager)
                             <br />
                             @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.TBServiceName)
                         </nhs-table-item>
@@ -76,12 +76,12 @@
                                     @Html.DisplayFor(_ => item.Action)
                                 </nhs-table-item>
                                 <nhs-table-item>
-                                    @if (!string.IsNullOrWhiteSpace(item.Notification.HospitalDetails.CaseManager.DisplayName))
+                                    @if (!string.IsNullOrWhiteSpace(item.Notification?.HospitalDetails?.CaseManager?.DisplayName))
                                     {
                                         @item.Notification.HospitalDetails.CaseManager.DisplayName
                                         <br />
                                     }
-                                    @item.Notification.HospitalDetails.TBServiceName
+                                    @item.Notification?.HospitalDetails?.TBServiceName
                                 </nhs-table-item>
                                 <nhs-table-item>
                                     @if (!item.NotDismissable)

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -44,9 +44,9 @@
                             @Html.DisplayNameFor(model => model.Alerts[0].AlertType)
                         </nhs-table-item>
                         <nhs-table-item>
-                            @Html.DisplayNameFor(model => model.Alerts[0].CaseManagerFullName)
+                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.CaseManager.DisplayName)
                             <br />
-                            @Html.DisplayNameFor(model => model.Alerts[0].TbServiceName)
+                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.TBServiceName)
                         </nhs-table-item>
                         <nhs-table-item>
                             Dismiss
@@ -55,7 +55,7 @@
                     <nhs-table-body>
                         @foreach (var item in Model.Alerts)
                         {
-                            <nhs-table-body-row id="alert-@item.AlertId" v-if="TbServiceCode === '@item.TbServiceCode' || TbServiceCode === 'Show all'">
+                            <nhs-table-body-row id="alert-@item.AlertId">
                                 <nhs-table-item>
                                     @if (item.NotificationId != null)
                                     {
@@ -76,12 +76,12 @@
                                     @Html.DisplayFor(_ => item.Action)
                                 </nhs-table-item>
                                 <nhs-table-item>
-                                    @if (!string.IsNullOrWhiteSpace(item.CaseManagerFullName))
+                                    @if (!string.IsNullOrWhiteSpace(item.Notification.HospitalDetails.CaseManager.DisplayName))
                                     {
-                                        @item.CaseManagerFullName
+                                        @item.Notification.HospitalDetails.CaseManager.DisplayName
                                         <br />
                                     }
-                                    @item.TbServiceName
+                                    @item.Notification.HospitalDetails.TBServiceName
                                 </nhs-table-item>
                                 <nhs-table-item>
                                     @if (!item.NotDismissable)

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -44,14 +44,9 @@
                             @Html.DisplayNameFor(model => model.Alerts[0].AlertType)
                         </nhs-table-item>
                         <nhs-table-item>
-<<<<<<< HEAD
-                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.CaseManager)
+                            @Html.DisplayNameFor(model => model.Alerts[0].CaseManagerName)
                             <br />
-=======
-                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.CaseManagerName)
-                            <br/>
->>>>>>> c500ac29... NTBS-2111: Fix when transfer requests should be shown
-                            @Html.DisplayNameFor(model => model.Alerts[0].Notification.HospitalDetails.TBServiceName)
+                            @Html.DisplayNameFor(model => model.Alerts[0].TbServiceName)
                         </nhs-table-item>
                         <nhs-table-item>
                             Dismiss
@@ -60,7 +55,7 @@
                     <nhs-table-body>
                         @foreach (var item in Model.Alerts)
                         {
-                            <nhs-table-body-row id="alert-@item.AlertId">
+                            <nhs-table-body-row id="alert-@item.AlertId" v-if="TbServiceCode === '@item.TbServiceCode' || TbServiceCode === 'Show all'">
                                 <nhs-table-item>
                                     @if (item.NotificationId != null)
                                     {
@@ -81,12 +76,12 @@
                                     @Html.DisplayFor(_ => item.Action)
                                 </nhs-table-item>
                                 <nhs-table-item>
-                                    @if (!string.IsNullOrWhiteSpace(item.Notification?.HospitalDetails?.CaseManagerName))
+                                    @if (!string.IsNullOrWhiteSpace(item.CaseManagerName))
                                     {
-                                        @item.Notification.HospitalDetails.CaseManagerName
+                                        @item.CaseManagerName
                                         <br />
                                     }
-                                    @item.Notification?.HospitalDetails?.TBServiceName
+                                    @item.TbServiceName
                                 </nhs-table-item>
                                 <nhs-table-item>
                                     @if (!item.NotDismissable)

--- a/ntbs-service/Pages/Index.cshtml.cs
+++ b/ntbs-service/Pages/Index.cshtml.cs
@@ -34,7 +34,7 @@ namespace ntbs_service.Pages
             _homepageKpiService = homepageKpiService;
         }
 
-        public IList<Alert> Alerts { get; set; }
+        public IList<AlertWithTbServiceForDisplay> Alerts { get; set; }
         public IList<Notification> DraftNotifications { get;set; }
         public IList<Notification> RecentNotifications { get;set; }
         public SelectList TbServices { get; set; }
@@ -81,7 +81,8 @@ namespace ntbs_service.Pages
                 return;
             var services = (await _userService.GetTbServicesAsync(User)).ToList();
             TbServices = new SelectList(services, nameof(TBService.Code), nameof(TBService.Name));
-            Alerts = await _authorizationService.FilterAlertsForUserAsync(User, _alertRepository.GetBaseOpenAlertIQueryable().ToList());
+            var alertsForTbServices = await _alertRepository.GetOpenAlertsByTbServiceCodesAsync(services.Select(tb => tb.Code));
+            Alerts = await _authorizationService.FilterAlertsForUserAsync(User, alertsForTbServices);
         }
     }
 }

--- a/ntbs-service/Pages/Index.cshtml.cs
+++ b/ntbs-service/Pages/Index.cshtml.cs
@@ -81,7 +81,7 @@ namespace ntbs_service.Pages
                 return;
             var services = (await _userService.GetTbServicesAsync(User)).ToList();
             TbServices = new SelectList(services, nameof(TBService.Code), nameof(TBService.Name));
-            Alerts = await _authorizationService.FilterAlertsForUserAsync(User, _alertRepository.GetBaseOpenAlertIQueryable());
+            Alerts = await _authorizationService.FilterAlertsForUserAsync(User, _alertRepository.GetBaseOpenAlertIQueryable().ToList());
         }
     }
 }

--- a/ntbs-service/Pages/Index.cshtml.cs
+++ b/ntbs-service/Pages/Index.cshtml.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
@@ -81,10 +80,8 @@ namespace ntbs_service.Pages
             if (_userService.GetUserType(User) == UserType.NationalTeam)
                 return;
             var services = (await _userService.GetTbServicesAsync(User)).ToList();
-            var tbServiceCodes = services.Select(s => s.Code);
             TbServices = new SelectList(services, nameof(TBService.Code), nameof(TBService.Name));
-            var nonFilteredAlerts = await _alertRepository.GetOpenAlertsByTbServiceCodesAsync(tbServiceCodes);
-            Alerts = await _authorizationService.FilterAlertsForUserAsync(User, nonFilteredAlerts);
+            Alerts = await _authorizationService.FilterAlertsForUserAsync(User, _alertRepository.GetBaseOpenAlertIQueryable());
         }
     }
 }

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -34,7 +34,7 @@ namespace ntbs_service.Pages.Notifications
 
         public Notification Notification { get; set; }
         public NotificationBannerModel NotificationBannerModel { get; set; }
-        public IList<Alert> Alerts { get; set; }
+        public IList<AlertWithTbServiceForDisplay> Alerts { get; set; }
         public DataQualityDraftAlert DraftAlert { get; set; }
         public PermissionLevel PermissionLevel { get; set; }
         public string PermissionReason { get; set; }

--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using ntbs_service.DataAccess;
@@ -147,7 +148,7 @@ namespace ntbs_service.Services
 
         public async Task<IList<Alert>> GetAlertsForNotificationAsync(int notificationId, ClaimsPrincipal user)
         {
-            var alerts = _alertRepository.GetOpenAlertsForNotificationIQueryable(notificationId);
+            var alerts = await _alertRepository.GetOpenAlertsForNotificationAsync(notificationId);
             var filteredAlerts = await _authorizationService.FilterAlertsForUserAsync(user, alerts);
 
             return filteredAlerts;

--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -147,7 +147,7 @@ namespace ntbs_service.Services
 
         public async Task<IList<Alert>> GetAlertsForNotificationAsync(int notificationId, ClaimsPrincipal user)
         {
-            var alerts = await _alertRepository.GetOpenAlertsForNotificationAsync(notificationId);
+            var alerts = _alertRepository.GetOpenAlertsForNotificationIQueryable(notificationId);
             var filteredAlerts = await _authorizationService.FilterAlertsForUserAsync(user, alerts);
 
             return filteredAlerts;
@@ -172,8 +172,6 @@ namespace ntbs_service.Services
                     AlertStatus = AlertStatus.Open,
                     NotificationId = notification.NotificationId,
                     SpecimenId = specimenMatchPairing.ReferenceLaboratoryNumber,
-                    CaseManagerUsername = notification.HospitalDetails.CaseManagerUsername,
-                    TbServiceCode = notification.HospitalDetails.TBServiceCode,
                     CreationDate = DateTime.Now
                 });
             }
@@ -183,27 +181,8 @@ namespace ntbs_service.Services
         
         private async Task PopulateAndAddAlertAsync(Alert alert)
         {
-            await PopulateAlertAsync(alert);
+            alert.CreationDate = DateTime.Today;
             await _alertRepository.AddAlertAsync(alert);
-        }
-
-        private async Task PopulateAlertAsync(Alert alert)
-        {
-            if (alert.NotificationId != null)
-            {
-                var notification = await _notificationRepository.GetNotificationAsync(alert.NotificationId.Value);
-                
-                alert.CreationDate = DateTime.Today;
-                if (alert.CaseManagerUsername == null && alert.AlertType != AlertType.TransferRequest)
-                {
-                    alert.CaseManagerUsername = notification?.HospitalDetails?.CaseManagerUsername;
-                }
-
-                if (alert.TbServiceCode == null)
-                {
-                    alert.TbServiceCode = notification?.HospitalDetails?.TBServiceCode;
-                }
-            }
         }
     }
 }

--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using ntbs_service.DataAccess;

--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -20,7 +20,7 @@ namespace ntbs_service.Services
         Task DismissAlertAsync(int alertId, string userId);
         Task AutoDismissAlertAsync<T>(Notification notification) where T : Alert;
         Task DismissMatchingAlertAsync<T>(int notificationId, string auditUsername = AuditService.AuditUserSystem) where T : Alert;
-        Task<IList<Alert>> GetAlertsForNotificationAsync(int notificationId, ClaimsPrincipal user);
+        Task<IList<AlertWithTbServiceForDisplay>> GetAlertsForNotificationAsync(int notificationId, ClaimsPrincipal user);
         Task CreateAlertsForUnmatchedLabResults(IEnumerable<SpecimenMatchPairing> specimenMatchPairings);
     }
 
@@ -145,7 +145,7 @@ namespace ntbs_service.Services
             }
         }
 
-        public async Task<IList<Alert>> GetAlertsForNotificationAsync(int notificationId, ClaimsPrincipal user)
+        public async Task<IList<AlertWithTbServiceForDisplay>> GetAlertsForNotificationAsync(int notificationId, ClaimsPrincipal user)
         {
             var alerts = await _alertRepository.GetOpenAlertsForNotificationAsync(notificationId);
             var filteredAlerts = await _authorizationService.FilterAlertsForUserAsync(user, alerts);

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -213,7 +213,8 @@ namespace ntbs_service.Services
 
         private bool AlertIsForNotificationInOrTransferToGivenServices(Alert alert, ICollection<string> givenTbServiceCodes, IList<int> notificationIdsInServices)
         {
-            return (alert.NotificationId != null && 
+            return (alert.NotificationId != null &&
+                    alert.AlertType != AlertType.TransferRequest &&
                     notificationIdsInServices.Contains((int)alert.NotificationId)) ||
                    (alert.AlertType == AlertType.TransferRequest &&
                     givenTbServiceCodes.Contains((alert as TransferAlert)?.TbServiceCode));


### PR DESCRIPTION
## Description
- The filtering of alerts is now fixed, we check that the alert is either: not a transfer and for a notification in our service OR is a transfer to our service. The logic for this and for whether a user has permission to manage a notification has been moved to one place.
- The Alert model no longer contains TB Service or Case Manager, these are only used in the case of a Transfer Alert (where we store the new TB Service/Case Manager we are transferring to). This means that the information in the alert table on the dashboard now comes from the related notification.

## Checklist:
- [x] Automated tests are passing locally.
### Schema changes
- [x] EF migrations created and committed. Snapshot committed
