### PR TITLE
NTBS-2119 Use responsive tables

### DIFF
--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -32,7 +32,7 @@
                     </select>
                 </div>
 
-                <nhs-table class="notifications-table">
+                <nhs-table class="notifications-table" responsive>
                     <nhs-table-head>
                         <nhs-table-item>
                             @Html.DisplayNameFor(model => model.Alerts[0].NotificationId)
@@ -56,7 +56,7 @@
                         @foreach (var item in Model.Alerts)
                         {
                             <nhs-table-body-row id="alert-@item.AlertId" v-if="TbServiceCode === '@item.TbServiceCode' || TbServiceCode === 'Show all'">
-                                <nhs-table-item>
+                                <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.NotificationId)">
                                     @if (item.NotificationId != null)
                                     {
                                         var overviewPageLink = RouteHelper.GetNotificationPath(item.NotificationId.GetValueOrDefault(), NotificationSubPaths.Overview);
@@ -65,17 +65,12 @@
                                         </a>
                                     }
                                 </nhs-table-item>
-                                <nhs-table-item>
+                                <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.FormattedCreationDate)">
                                     @Html.DisplayFor(_ => item.FormattedCreationDate)
                                 </nhs-table-item>
-                                <nhs-table-item>
-                                    <a href="@item.ActionLink">
-                                        @Html.DisplayFor(_ => item.AlertType)
-                                    </a>
-                                    <br />
-                                    @Html.DisplayFor(_ => item.Action)
+                                <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.AlertType)">
                                 </nhs-table-item>
-                                <nhs-table-item>
+                                <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.CaseManagerName)<br />@Html.DisplayNameFor(model => model.Alerts[0].TbServiceName)">
                                     @if (!string.IsNullOrWhiteSpace(item.CaseManagerName))
                                     {
                                         @item.CaseManagerName
@@ -83,7 +78,7 @@
                                     }
                                     @item.TbServiceName
                                 </nhs-table-item>
-                                <nhs-table-item>
+                                <nhs-table-item heading-text="Dismiss">
                                     @if (!item.NotDismissable)
                                     {
                                         <form method="post" action="@RouteHelper.GetAlertPath(@item.AlertId, AlertSubPaths.Dismiss)">
@@ -107,7 +102,7 @@
     <nhs-width-container container-width="Standard">
         <h2 class="heading"> Draft notifications </h2>
 
-        <nhs-table class="notifications-table">
+        <nhs-table class="notifications-table" responsive>
             <nhs-table-head>
                 <nhs-table-item>
                     @Html.DisplayNameFor(model => model.DraftNotifications[0].NotificationId)
@@ -129,21 +124,21 @@
                 @foreach (var item in Model.DraftNotifications)
                 {
                     <nhs-table-body-row>
-                        <nhs-table-item>
+                        <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.NotificationId)">
                             <a href="@RouteHelper.GetNotificationPath(item.NotificationId, NotificationSubPaths.Overview)" class="govuk-link govuk-link--no-visited-state">
                                 @Html.DisplayFor(_ => item.NotificationId)
                             </a>
                         </nhs-table-item>
-                        <nhs-table-item>
+                        <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.PatientDetails.FullName)">
                             @Html.DisplayFor(_ => item.PatientDetails.FullName)
                         </nhs-table-item>
-                        <nhs-table-item>
+                        <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.FormattedCreationDate)">
                             @Html.DisplayFor(_ => item.FormattedCreationDate)
                         </nhs-table-item>
-                        <nhs-table-item>
+                        <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.HospitalDetails.TBServiceName)">
                             @Html.DisplayFor(_ => item.HospitalDetails.TBServiceName)
                         </nhs-table-item>
-                        <nhs-table-item>
+                        <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.HospitalDetails.CaseManagerName)">
                             @Html.DisplayFor(_ => item.HospitalDetails.CaseManagerName)
                         </nhs-table-item>
                     </nhs-table-body-row>
@@ -155,7 +150,7 @@
 
 <nhs-width-container container-width="Standard">
     <h2 class="heading"> Recent notifications </h2>
-    <nhs-table class="notifications-table">
+    <nhs-table class="notifications-table" responsive>
         <nhs-table-head>
             <nhs-table-item>
                 @Html.DisplayNameFor(model => model.RecentNotifications[0].NotificationId)
@@ -177,21 +172,21 @@
             @foreach (var item in Model.RecentNotifications)
             {
                 <nhs-table-body-row>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.NotificationId)">
                         <a href="@RouteHelper.GetNotificationPath(item.NotificationId, NotificationSubPaths.Overview)" class="govuk-link--no-visited-state">
                             @Html.DisplayFor(modelItem => item.NotificationId)
                         </a>
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.PatientDetails.FullName)">
                         @Html.DisplayFor(modelItem => item.PatientDetails.FullName)
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.FormattedNotificationDate)">
                         @Html.DisplayFor(modelItem => item.FormattedNotificationDate)
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.HospitalDetails.TBServiceName)">
                         @Html.DisplayFor(modelItem => item.HospitalDetails.TBServiceName)
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.HospitalDetails.CaseManagerName)">
                         @Html.DisplayFor(modelItem => item.HospitalDetails.CaseManagerName)
                     </nhs-table-item>
                 </nhs-table-body-row>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -27,14 +27,14 @@
                     <strong> Outcome at 12 months </strong> @(Model.OutcomeAt12Months?.TreatmentOutcomeType.GetDisplayName() ?? "No outcome recorded")
                 </div>
             }
-            
+
             @if (Model.Should24MonthOutcomeBeDisplayed)
             {
                 <div>
                     <strong> Outcome at 24 months </strong> @(Model.OutcomeAt24Months?.TreatmentOutcomeType.GetDisplayName() ?? "No outcome recorded")
                 </div>
             }
-            
+
             @if (Model.Should36MonthOutcomeBeDisplayed)
             {
                 <div>
@@ -46,7 +46,7 @@
         @for (var episodeNumber = 1; episodeNumber <= Model.GroupedTreatmentEvents.Count; episodeNumber++)
         {
             var treatmentEvents = Model.GroupedTreatmentEvents[episodeNumber];
-            
+
             <div>
                 <h4 class="episode-grouping-overview-heading">Treatment period @episodeNumber</h4>
                 @if (treatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
@@ -58,7 +58,7 @@
                     <span>@treatmentEvents.First().FormattedEventDate to Present</span>
                 }
             </div>
-            <nhs-table classes="nhsuk-table--reduced-font">
+            <nhs-table classes="nhsuk-table--reduced-font" responsive>
                 <nhs-table-head>
                     <nhs-table-item classes="one-sixth-column">Date</nhs-table-item>
                     <nhs-table-item classes="two-sixth-column">Event</nhs-table-item>
@@ -69,8 +69,10 @@
                     @foreach (var treatmentEvent in treatmentEvents)
                     {
                         <nhs-table-body-row>
-                            <nhs-table-item>@treatmentEvent.FormattedEventDate</nhs-table-item>
-                            <nhs-table-item>
+                            <nhs-table-item heading-text="Date">
+                                @treatmentEvent.FormattedEventDate
+                            </nhs-table-item>
+                            <nhs-table-item heading-text="Event">
                                 @treatmentEvent.FormattedEventTypeAndOutcome
                                 @if (treatmentEvent.TreatmentOutcome?.TreatmentOutcomeSubType != null)
                                 {
@@ -78,12 +80,16 @@
                                     <span>@treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType.GetDisplayName()</span>
                                 }
                             </nhs-table-item>
-                            <nhs-table-item>@treatmentEvent.TbService?.Name</nhs-table-item>
-                            <nhs-table-item>@treatmentEvent.CaseManager?.DisplayName</nhs-table-item>
+                            <nhs-table-item heading-text="TB service">
+                                @treatmentEvent.TbService?.Name
+                            </nhs-table-item>
+                            <nhs-table-item heading-text="Case Manager">
+                                @treatmentEvent.CaseManager?.DisplayName
+                            </nhs-table-item>
                         </nhs-table-body-row>
                     }
                 </nhs-table-body>
             </nhs-table>
         }
-    </div>   
+    </div>
 }

--- a/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
+++ b/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
@@ -10,9 +10,10 @@
 
 @if (Model.Count != 0)
 {
-    <nhs-table id="manual-results" 
-           caption="Manual Test Results" 
-           classes="@(isReducedTable ? "nhsuk-table--reduced-font" : null)">
+    <nhs-table id="manual-results"
+           aria-label="Manual Test Results"
+           classes="@(isReducedTable ? "nhsuk-table--reduced-font" : null)"
+           responsive>
         <nhs-table-head>
             <nhs-table-item>
                 @Html.DisplayNameFor(_ => header.TestDate)
@@ -35,23 +36,23 @@
             @foreach (var result in orderedResults)
             {
                 <nhs-table-body-row id="manual-test-result-@result.ManualTestResultId">
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.TestDate)">
                         @result.TestDate?.ConvertToString()
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.ManualTestTypeId)">
                         @result.ManualTestType.Description
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.SampleTypeId)">
                         @result?.SampleType?.Description
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.Result)">
                         @result.Result.GetDisplayName()
                     </nhs-table-item>
                     @if (showEditLinks)
                     {
                         var subPath = NotificationSubPaths.EditManualTestResult(result.ManualTestResultId);
                         var path = RouteHelper.GetNotificationPath(result.NotificationId, subPath);
-                        <nhs-table-item>
+                        <nhs-table-item heading-text="Edit">
                             <a href="@path" class="govuk-link--no-visited-state"> Edit </a>
                         </nhs-table-item>
                     }

--- a/ntbs-service/Pages/Shared/_TreatmentEventTable.cshtml
+++ b/ntbs-service/Pages/Shared/_TreatmentEventTable.cshtml
@@ -9,7 +9,7 @@
 
 @if (Model.Count != 0)
 {
-    <nhs-table id="treatment-events" aria-label="Treatment Events" classes="nhsuk-table--reduced-font" responsive>
+    <nhs-table id="treatment-events" aria-label="Treatment Events" classes="nhsuk-table--reduced-font wrap-cell-contents" responsive>
         <nhs-table-head>
             <nhs-table-item>
                 @Html.DisplayNameFor(_ => header.EventDate)

--- a/ntbs-service/Pages/Shared/_TreatmentEventTable.cshtml
+++ b/ntbs-service/Pages/Shared/_TreatmentEventTable.cshtml
@@ -9,7 +9,7 @@
 
 @if (Model.Count != 0)
 {
-    <nhs-table id="treatment-events" caption="Treatment Events" classes="nhsuk-table--reduced-font">
+    <nhs-table id="treatment-events" aria-label="Treatment Events" classes="nhsuk-table--reduced-font" responsive>
         <nhs-table-head>
             <nhs-table-item>
                 @Html.DisplayNameFor(_ => header.EventDate)
@@ -35,24 +35,24 @@
             @foreach (var result in orderedResults)
             {
                 <nhs-table-body-row id="treatment-event-@result.TreatmentEventId">
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.EventDate)">
                         @result.EventDate?.ConvertToString()
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.TreatmentEventType)">
                         @result.TreatmentEventType.GetDisplayName()
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.TreatmentOutcome.TreatmentOutcomeType)">
                         @result.TreatmentOutcome?.TreatmentOutcomeType.GetDisplayName()
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.TreatmentOutcome.TreatmentOutcomeSubType)">
                         @result.TreatmentOutcome?.TreatmentOutcomeSubType?.GetDisplayName()
                     </nhs-table-item>
-                    <nhs-table-item>
+                    <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.Note)">
                         @result.Note
                     </nhs-table-item>
                     @if (showEditLinks)
                     {
-                        <nhs-table-item>
+                        <nhs-table-item heading-text="Edit">
                             @if(result.IsEditable)
                             {
                                 var subPath = NotificationSubPaths.EditTreatmentEvent(result.TreatmentEventId);

--- a/ntbs-service/wwwroot/css/table.scss
+++ b/ntbs-service/wwwroot/css/table.scss
@@ -10,7 +10,27 @@
 // NHS UK tables have changed their internal padding.
 // See https://nhsuk.github.io/nhsuk-frontend/components/tables/tables-panel.html
 // Overall it's an improvement, but the lack of LHS space looks odd in the first column - this hack alleviates that.
-.nhsuk-table__header:first-child,
-.nhsuk-table__cell:first-child {
-  padding-left: 8px;
+
+.nhsuk-table-responsive .nhsuk-table__head .nhsuk-table__row .nhsuk-table__header:first-child,
+.nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row .nhsuk-table__cell:first-child {
+    padding-left: 8px;
+}
+
+.nhsuk-table-responsive .nhsuk-table__head .nhsuk-table__row .nhsuk-table__header:last-child,
+.nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row .nhsuk-table__cell:last-child {
+    padding-right: 8px;
+}
+
+// Add some padding to the responsive table cells as well, because for narrow screens each cell gets its own
+// row (visually, not semantically). The hover highlighting doesn't look great without this padding, with the
+// highlighting finishing on the edge of the last letter.
+.nhsuk-table-responsive .nhsuk-table__body .nhsuk-table__row td.nhsuk-table__cell {
+  @include mq($until: desktop) {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
+
+  @include mq($from: desktop) {
+    padding-right: nhsuk-spacing(3);
+  }
 }

--- a/ntbs-service/wwwroot/css/table.scss
+++ b/ntbs-service/wwwroot/css/table.scss
@@ -21,6 +21,10 @@
     padding-right: 8px;
 }
 
+.wrap-cell-contents .nhsuk-table__header {
+    white-space: normal;
+}
+
 // Add some padding to the responsive table cells as well, because for narrow screens each cell gets its own
 // row (visually, not semantically). The hover highlighting doesn't look great without this padding, with the
 // highlighting finishing on the edge of the last letter.


### PR DESCRIPTION
Use the new [NHS responsive tables](https://service-manual.nhs.uk/design-system/components/table#3-or-more-column-table) added in v4 for tables with more than 3 columns, as recommended by the design system.

## Description
* Fix table captions from NHS v4 update: captions are no longer hidden in NHS v4. We were basically using them as aria-labels, so switch them to be aria-labels. 
* Use responsive tables for tables with more than 3 columns.
* Tweak the table padding CSS to make the table row hover highlighting look nice for narrow-viewport tables.
* Add an updated version of the NHS frontend fork, with responsive table templating added.

## Checklist:
- [x] Automated tests are passing locally.
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))

## Screenshots
<details>
  <summary>Dashboard page</summary>

### Dashboard page: wide
![wide_dashboard](https://user-images.githubusercontent.com/3650110/109475519-b9abcc80-7a6d-11eb-8e1b-db6d68cd341b.png)
### Dashboard page: narrow
![narrow_dashboard_1](https://user-images.githubusercontent.com/3650110/109475518-b9133600-7a6d-11eb-9616-5a207bc6628f.png)
![narrow_dashboard_2](https://user-images.githubusercontent.com/3650110/109475513-b9133600-7a6d-11eb-8a7d-83715309e617.png)
</details>

<details>
  <summary>Test results in overview</summary>

### Test results in overview: wide
![test_results_wide](https://user-images.githubusercontent.com/3650110/109475510-b87a9f80-7a6d-11eb-8224-4b7806e743eb.png)  
### Test results in overview: narrow
![test_results_narrow](https://user-images.githubusercontent.com/3650110/109475509-b7e20900-7a6d-11eb-84b8-f2e165f78a10.png)
</details>

<details>
  <summary>Test results in edit page</summary>

### Test results in edit page: wide
![test_results_more_details_wide](https://user-images.githubusercontent.com/3650110/109475505-b6b0dc00-7a6d-11eb-9e1a-a570c0267636.png)
### Test results in edit page: narrow
![test_results_more_details_narrow](https://user-images.githubusercontent.com/3650110/109475504-b6184580-7a6d-11eb-8fd0-a33301f56ada.png)
</details>

<details>
  <summary>Treatment events in overview</summary>

### Treatment events in overview: wide
![treatment_event_overview_wide](https://user-images.githubusercontent.com/3650110/109475512-b87a9f80-7a6d-11eb-8e1c-f55f53f98a5c.png)
### Treatment events in overview: narrow
![treatment_event_overview_narrow](https://user-images.githubusercontent.com/3650110/109475511-b87a9f80-7a6d-11eb-9aa5-a53ff018b9c0.png)
</details>

<details>
  <summary>Treatment events edit page</summary>

### Treatment events in edit page: wide
![treatment_event_more_details_wide](https://user-images.githubusercontent.com/3650110/109475508-b7e20900-7a6d-11eb-8c97-a13d49c1fccf.png)
### Treatment events in edit page: wide
![treatment_event_more_details_narrow](https://user-images.githubusercontent.com/3650110/109475506-b7497280-7a6d-11eb-9024-1540aeb109bc.png)
</details>