### PR TITLE
NTBS-2082 and NTBS-2085 field accessibility fixes

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
@@ -56,10 +56,12 @@
     </validate-date>
     <br />
 
-    <h2> @title </h2>
-
     <filtered-dropdown filter-handler-path="GetFilteredListsByTbService" :filtering-refs="['caseManagers', 'hospitals']" inline-template>
-        <div>
+        <nhs-fieldset>
+            <nhs-fieldset-legend nhs-legend-size="Large">
+                <h2 class="nhsuk-fieldset__heading"> @title </h2>
+            </nhs-fieldset-legend>
+
             @if (Model.Notification.NotificationStatus == NotificationStatus.Draft)
             {
                 <validate-input model="HospitalDetails" property="TBServiceCode" shouldvalidatefull="@fullValidation"
@@ -151,8 +153,7 @@
             </validate-input>
             <br />
 
-        </div>
+        </nhs-fieldset>
     </filtered-dropdown>
 
-    
 </div>

--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
@@ -146,7 +146,7 @@
                                     @healthcareSetting.GetDisplayName()
                                 </label>
                             </div>
-                        } 
+                        }
                         else
                         {
                             <div class="nhsuk-radios__item">
@@ -169,7 +169,7 @@
                                         </label>
                                         <input ref="inputField" v-on:blur="validate" is-error-input=@hasHealthcareDescriptionError nhs-input-type="Standard"
                                                fixed-width="Ten" asp-for="ClinicalDetails.HealthcareDescription" type="text">
-                                    </nhs-form-group>                   
+                                    </nhs-form-group>
                                 </validate-input>
                             </div>
                         }
@@ -419,34 +419,34 @@
                 </div>
             </nhs-fieldset>
         </nhs-form-group>
-    
-        <h2>@Html.DisplayNameFor(m => m.Notification.ClinicalDetails.IsPostMortem)</h2>
-            <nhs-fieldset>
-                <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
-                    <div class="nhsuk-radios__item">
-                        <input asp-for="ClinicalDetails.IsPostMortem" id="postmortem-yes" class="nhsuk-radios__input" type="radio" value="true" data-aria-controls="conditional-postmortem-conditional">
-                        <label class="nhsuk-label nhsuk-radios__label" for="postmortem-yes">
-                            Yes
-                        </label>
-                    </div>
-                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-postmortem-conditional">
-                        <label class="nhsuk-label" for="postmortem-save-button"> Please record the death outcome on the treatment events page </label>
-                        <button
-                            nhs-button-type="Standard"
-                            classes="ntbsuk-button--primary"
-                            name="SaveAndRouteToTreatmentEvents"
-                            value="SaveAndRouteToTreatmentEvents"
-                            id="postmortem-save-button">
-                            Save and go to treatment events
-                        </button>
-                    </div>
-                    <div class="nhsuk-radios__item">
-                        <input asp-for="ClinicalDetails.IsPostMortem" id="postmortem-no" class="nhsuk-radios__input" type="radio" value="false">
-                        <label class="nhsuk-label nhsuk-radios__label" for="postmortem-no">
-                            No
-                        </label>
-                    </div>
-                </div>
-            </nhs-fieldset>
+
+    <nhs-fieldset>
+        <nhs-fieldset-legend nhs-legend-size="Standard">@Html.DisplayNameFor(m => m.ClinicalDetails.IsPostMortem)</nhs-fieldset-legend>
+        <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
+            <div class="nhsuk-radios__item">
+                <input asp-for="ClinicalDetails.IsPostMortem" id="postmortem-yes" class="nhsuk-radios__input" type="radio" value="true" data-aria-controls="conditional-postmortem-conditional">
+                <label class="nhsuk-label nhsuk-radios__label" for="postmortem-yes">
+                    Yes
+                </label>
+            </div>
+            <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-postmortem-conditional">
+                <p class="nhsuk-label"> Please record the death outcome on the treatment events page </p>
+                <button
+                    nhs-button-type="Standard"
+                    classes="ntbsuk-button--primary"
+                    name="SaveAndRouteToTreatmentEvents"
+                    value="SaveAndRouteToTreatmentEvents"
+                    id="postmortem-save-button">
+                    Save and go to treatment events
+                </button>
+            </div>
+            <div class="nhsuk-radios__item">
+                <input asp-for="ClinicalDetails.IsPostMortem" id="postmortem-no" class="nhsuk-radios__input" type="radio" value="false">
+                <label class="nhsuk-label nhsuk-radios__label" for="postmortem-no">
+                    No
+                </label>
+            </div>
+        </div>
+    </nhs-fieldset>
     </div>
 </date-comparison>

--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsTreatmentOptions.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsTreatmentOptions.cshtml
@@ -15,7 +15,7 @@
             <nhs-fieldset-legend nhs-legend-size="Standard">DOT offered?</nhs-fieldset-legend>
             <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                 <div class="nhsuk-radios__item">
-                    <input asp-for="ClinicalDetails.IsDotOffered" id="dot-offered-yes" class="nhsuk-radios__input" type="radio" value="@Status.Yes" 
+                    <input asp-for="ClinicalDetails.IsDotOffered" id="dot-offered-yes" class="nhsuk-radios__input" type="radio" value="@Status.Yes"
                         data-aria-controls="conditional-dot-offered-conditional">
                     <label class="nhsuk-label nhsuk-radios__label" for="dot-offered-yes">
                         @(Status.Yes)
@@ -31,7 +31,7 @@
                                     <nhs-radios-item>
                                         <input nhs-input-type="Radios" asp-for="ClinicalDetails.DotStatus" id="dot-status-@status" type="radio" value="@status" />
                                         <label nhs-label-type="Radios" for="dot-status-@status">@status.GetDisplayName()</label>
-                                    </nhs-radios-item> 
+                                    </nhs-radios-item>
                                 }
                             </nhs-radios>
                         </nhs-fieldset>
@@ -108,19 +108,19 @@
     <nhs-form-group nhs-form-group-type="@mdrGroupState" id="ClinicalDetails-IsMDRTreatment">
         <nhs-fieldset aria-describedby="regimen-error">
             <nhs-fieldset-legend nhs-legend-size="Standard">Planned treatment regimen</nhs-fieldset-legend>
-            <span ref="errorField" nhs-span-type="ErrorMessage" asp-validation-for="ClinicalDetails.IsMDRTreatment"	
+            <span ref="errorField" nhs-span-type="ErrorMessage" asp-validation-for="ClinicalDetails.IsMDRTreatment"
                                                                   has-error="@hasMdrError" id="regimen-error"></span>
-            
+
             <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                 <div class="nhsuk-radios__item">
-                    <input nhs-input-type="Radios" asp-for="ClinicalDetails.TreatmentRegimen" id="regimen-standardTherapy" class="nhsuk-radios__input" type="radio" 
+                    <input nhs-input-type="Radios" asp-for="ClinicalDetails.TreatmentRegimen" id="regimen-standardTherapy" class="nhsuk-radios__input" type="radio"
                         value="@TreatmentRegimen.StandardTherapy">
                     <label class="nhsuk-label nhsuk-radios__label" for="regimen-standardTherapy">Standard Therapy</label>
                 </div>
-            
-                    
+
+
                 <div class="nhsuk-radios__item">
-                    <input nhs-input-type="Radios" asp-for="ClinicalDetails.TreatmentRegimen" id="regimen-mdr" class="nhsuk-radios__input" type="radio" 
+                    <input nhs-input-type="Radios" asp-for="ClinicalDetails.TreatmentRegimen" id="regimen-mdr" class="nhsuk-radios__input" type="radio"
                         value="@TreatmentRegimen.MdrTreatment" data-aria-controls="conditional-mdr-conditional">
                     <label class="nhsuk-label nhsuk-radios__label" for="regimen-mdr">RR/MDR/XDR treatment</label>
                 </div>
@@ -163,23 +163,23 @@
                         </nhs-form-group>
                     </validate-date>
                 </div>
-                
+
                 <div class="nhsuk-radios__item">
-                    <input asp-for="ClinicalDetails.TreatmentRegimen" id="regimen-other" class="nhsuk-radios__input" type="radio" value="@TreatmentRegimen.Other" 
+                    <input asp-for="ClinicalDetails.TreatmentRegimen" id="regimen-other" class="nhsuk-radios__input" type="radio" value="@TreatmentRegimen.Other"
                         data-aria-controls="conditional-regimen-other-conditional">
                     <label class="nhsuk-label nhsuk-radios__label" for="regimen-other">
                         Other
                     </label>
                 </div>
-                 
-                
+
+
                 <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-regimen-other-conditional">
                     <validate-input model="ClinicalDetails" property="TreatmentRegimenOtherDescription" inline-template>
                         @{
                             var hasTreatmentRegimenOtherDescriptionError = !Model.IsValid("ClinicalDetails.TreatmentRegimenOtherDescription");
                             var TreatmentRegimenOtherDescriptionGroupState = hasTreatmentRegimenOtherDescriptionError ? Error : Standard;
                         }
-                        <nhs-form-group nhs-form-group-type=@TreatmentRegimenOtherDescriptionGroupState aria-describedby="relationship-description-error">
+                        <nhs-form-group nhs-form-group-type=@TreatmentRegimenOtherDescriptionGroupState aria-describedby="other-regimen-text-error">
                             <span nhs-span-type="ErrorMessage" ref="errorField" has-error="@hasTreatmentRegimenOtherDescriptionError"
                                 asp-validation-for="ClinicalDetails.TreatmentRegimenOtherDescription" id="other-regimen-text-error">
                             </span>

--- a/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
@@ -15,7 +15,7 @@
             </nhs-fieldset-legend>
             <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios" v-on:focusout="validate">
                 <div class="nhsuk-radios__item">
-                    <input asp-for="TravelDetails.HasTravel" nhs-input-type="Radios" type="radio" value="@Status.Yes" 
+                    <input asp-for="TravelDetails.HasTravel" nhs-input-type="Radios" type="radio" value="@Status.Yes"
                            id="travelDetails-hasTravelYes" ref="hasDataYes" data-aria-controls="conditional-has-travel" />
                     <label for="travelDetails-hasTravelYes" nhs-label-type="Radios">
                         @Status.Yes
@@ -54,6 +54,9 @@
                                   id="travel-country1Id-error" ref="country1IdErrorRef" has-error="@hasCountry1IdError"></span>
                             <div ref="country1Id" aria-describedby="travel-country1Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" inline-template>
+                                    <label asp-for="TravelDetails.Country1Id" nhs-label-type="Standard">
+                                        Most recent country travelled to
+                                    </label>
                                     <select asp-for="TravelDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
                                         <option value=""></option>
                                     </select>
@@ -150,7 +153,7 @@
                         @Status.No
                     </label>
                 </div>
-                
+
                 <div class="nhsuk-radios__item">
                     <input asp-for="TravelDetails.HasTravel" nhs-input-type="Radios" type="radio" value="@Status.Unknown"
                             id="travelDetails-hasTravelUnknown" ref="hasDataUnknown" />

--- a/ntbs-service/Pages/Search/Index.cshtml
+++ b/ntbs-service/Pages/Search/Index.cshtml
@@ -10,18 +10,18 @@
 <form-leave-checker></form-leave-checker>
 
 <nhs-width-container container-width="Standard">
-    <h1 class="search-header"> Search </h1>
     <div class="search-page">
         <form method="get" autocomplete="off">
             @{
                 var searchParametersError = !Model.ValidationService.IsValid("SearchParameters");
                 var searchParametersGroupState = searchParametersError ? Error : Standard;
             }
-            <nhs-form-group nhs-form-group-type=@searchParametersGroupState>
-                <nhs-fieldset aria-describedby="one-parameter-required-error">
-                    <span nhs-span-type="ErrorMessage" id="one-parameter-required-error"
-                        asp-validation-for="SearchParameters" has-error="@searchParametersError"></span>
-                    <br />
+            <nhs-fieldset aria-describedby="one-parameter-required-error">
+                <nhs-fieldset-legend nhs-legend-size="XLarge" is-page-heading="true"> Search </nhs-fieldset-legend>
+
+                <nhs-form-group nhs-form-group-type="@searchParametersGroupState" classes="nhsuk-u-margin-bottom-4">
+                    <span nhs-span-type="ErrorMessage" id="one-parameter-required-error" classes="nhsuk-u-margin-bottom-4"
+                            asp-validation-for="SearchParameters" has-error="@searchParametersError"></span>
 
                     @{
                         var idFilterError = !Model.ValidationService.IsValid("SearchParameters.IdFilter");
@@ -60,34 +60,41 @@
                         }
                         <nhs-form-group nhs-form-group-type=@dobGroupState classes="nhs-form-group--search-date">
                             <span ref="errorField" nhs-span-type="ErrorMessage" id="dob-error" classes="search-error"
-                                asp-validation-for="SearchParameters.PartialDob" has-error="@dobError"></span>
-                            <label nhs-label-type="Standard" classes="search-label--standard" for="dob"> Date of birth </label>
-                            <nhs-date-input id="dob" classes="date-input--search">
-                                <nhs-date-input-item>
-                                    <nhs-form-group nhs-form-group-type="Standard" classes="search-date-input">
-                                        <label nhs-label-type="Date" asp-for="SearchParameters.PartialDob.Day" classes="search-date-input-label">Day</label>
-                                        <input nhs-input-type="Date" fixed-width="Two" ref="dayInput"
-                                                is-error-input=@dobError asp-for="SearchParameters.PartialDob.Day" />
-                                    </nhs-form-group>
-                                </nhs-date-input-item>
-                                <nhs-date-input-item>
-                                    <nhs-form-group nhs-form-group-type="Standard"  classes="search-date-input">
-                                        <label nhs-label-type="Date" asp-for="SearchParameters.PartialDob.Month" classes="search-date-input-label">Month</label>
-                                        <input nhs-input-type="Date" fixed-width="Two" ref="monthInput"
-                                                is-error-input=@dobError asp-for="SearchParameters.PartialDob.Month" />
-                                    </nhs-form-group>
-                                </nhs-date-input-item>
-                                <nhs-date-input-item>
-                                    <nhs-form-group nhs-form-group-type="Standard"  classes="search-date-input">
-                                        <label nhs-label-type="Date" asp-for="SearchParameters.PartialDob.Year" classes="search-date-input-label">Year</label>
-                                        <input nhs-input-type="Date" fixed-width="Four" ref="yearInput"
-                                                is-error-input=@dobError asp-for="SearchParameters.PartialDob.Year" />
-                                    </nhs-form-group>
-                                </nhs-date-input-item>
-                            </nhs-date-input>
-                            <nhs-hint nhs-hint-type="Standard" id="partial-dates-allowed-hint" classes="search-hint">
-                                Dates can be partial
-                            </nhs-hint>
+                                  asp-validation-for="SearchParameters.PartialDob" has-error="@dobError"></span>
+                            <nhs-fieldset classes="nhs-form-group--search-date">
+                                <nhs-fieldset-legend nhs-legend-size="Standard" classes="search-legend--standard">
+                                    <span class="nhsuk-label search-label--standard">
+                                        Date of birth
+                                    </span>
+                                </nhs-fieldset-legend>
+
+                                <nhs-date-input id="dob" classes="date-input--search">
+                                    <nhs-date-input-item>
+                                        <nhs-form-group nhs-form-group-type="Standard" classes="search-date-input">
+                                            <label nhs-label-type="Date" asp-for="SearchParameters.PartialDob.Day" classes="search-date-input-label">Day</label>
+                                            <input nhs-input-type="Date" fixed-width="Two" ref="dayInput"
+                                                    is-error-input=@dobError asp-for="SearchParameters.PartialDob.Day" />
+                                        </nhs-form-group>
+                                    </nhs-date-input-item>
+                                    <nhs-date-input-item>
+                                        <nhs-form-group nhs-form-group-type="Standard"  classes="search-date-input">
+                                            <label nhs-label-type="Date" asp-for="SearchParameters.PartialDob.Month" classes="search-date-input-label">Month</label>
+                                            <input nhs-input-type="Date" fixed-width="Two" ref="monthInput"
+                                                    is-error-input=@dobError asp-for="SearchParameters.PartialDob.Month" />
+                                        </nhs-form-group>
+                                    </nhs-date-input-item>
+                                    <nhs-date-input-item>
+                                        <nhs-form-group nhs-form-group-type="Standard"  classes="search-date-input">
+                                            <label nhs-label-type="Date" asp-for="SearchParameters.PartialDob.Year" classes="search-date-input-label">Year</label>
+                                            <input nhs-input-type="Date" fixed-width="Four" ref="yearInput"
+                                                    is-error-input=@dobError asp-for="SearchParameters.PartialDob.Year" />
+                                        </nhs-form-group>
+                                    </nhs-date-input-item>
+                                </nhs-date-input>
+                                <nhs-hint nhs-hint-type="Standard" id="partial-dob-dates-allowed-hint" classes="search-hint">
+                                    Dates can be partial
+                                </nhs-hint>
+                        </nhs-fieldset>
                         </nhs-form-group>
                     </date-input>
 
@@ -106,10 +113,9 @@
                             Enter at least two characters
                         </nhs-hint>
                     </nhs-form-group>
-                </nhs-fieldset>
-            </nhs-form-group>
-            <nhs-details display-text="Advanced options" nhs-details-type="Standard">
-                <div>
+                </nhs-form-group>
+
+                <nhs-details display-text="Advanced options" nhs-details-type="Standard">
                     <date-input inline-template>
                         @{
                             var notificationDateError = !Model.ValidationService.IsValid("SearchParameters.PartialNotificationDate");
@@ -117,8 +123,13 @@
                         }
                         <nhs-form-group nhs-form-group-type=@notificationDateGroupState classes="nhs-form-group--search-date">
                             <span ref="errorField" nhs-span-type="ErrorMessage" id="notification-date-error" classes="search-error"
-                                asp-validation-for="SearchParameters.PartialNotificationDate" has-error="@notificationDateError"></span>
-                                <label nhs-label-type="Standard" classes="search-label--long" for="notification-date"> Notification Date </label>
+                                  asp-validation-for="SearchParameters.PartialNotificationDate" has-error="@notificationDateError"></span>
+                            <nhs-fieldset classes="nhs-form-group--search-date">
+                                <nhs-fieldset-legend nhs-legend-size="Standard" classes="search-legend--long">
+                                    <span class="nhsuk-label search-label--long">
+                                        Notification Date
+                                    </span>
+                                </nhs-fieldset-legend>
                                 <nhs-date-input id="notification-date" classes="date-input--search">
                                     <nhs-date-input-item>
                                         <nhs-form-group nhs-form-group-type="Standard" classes="search-date-input">
@@ -142,9 +153,10 @@
                                         </nhs-form-group>
                                     </nhs-date-input-item>
                                 </nhs-date-input>
-                            <nhs-hint nhs-hint-type="Standard" id="partial-dates-allowed-hint" classes="search-hint">
+                            <nhs-hint nhs-hint-type="Standard" id="partial-notification-dates-allowed-hint" classes="search-hint">
                                 Dates can be partial
                             </nhs-hint>
+                            </nhs-fieldset>
                         </nhs-form-group>
                     </date-input>
 
@@ -157,15 +169,20 @@
                             asp-validation-for="SearchParameters.GivenName" has-error="@givenNameError"></span>
                         <label nhs-label-type="Standard" classes="search-label--long" asp-for="SearchParameters.GivenName"> Given Name</label>
                         <input is-error-input=@givenNameError nhs-input-type="Standard"
-                                asp-for="SearchParameters.GivenName" classes="nhsuk-input--width-10 search-input" 
+                                asp-for="SearchParameters.GivenName" classes="nhsuk-input--width-10 search-input"
                                 aria-describedby="two-character-given-name-hint" />
                         <nhs-hint nhs-hint-type="Standard" id="two-character-given-name-hint" classes="search-hint">
                             Enter at least two characters
                         </nhs-hint>
                     </nhs-form-group>
 
-                    <div class="search-sex-radios">
-                        <label nhs-label-type="Standard" classes="search-label--long" for="sex-radios"> Sex </label>
+                    <nhs-fieldset classes="search-sex-radios">
+                        <nhs-fieldset-legend nhs-legend-size="Standard" classes="search-legend--long">
+                            <span class="nhsuk-label search-label--long">
+                                Sex
+                            </span>
+                        </nhs-fieldset-legend>
+
                         <nhs-radios nhs-radios-type="Standard" classes="search-sex-radios" id="sex-radios">
                             @foreach (var sex in Model.Sexes)
                             {
@@ -186,7 +203,7 @@
                                 <label nhs-label-type="Radios" asp-for="SearchParameters.SexId" for="sexId-Any">Any</label>
                             </nhs-radios-item>
                         </nhs-radios>
-                    </div>
+                    </nhs-fieldset>
 
                     <div class="nhs-form-group--search">
                         <label nhs-label-type="Standard" classes="search-label--long" asp-for="SearchParameters.TBServiceCode"> TB service </label>
@@ -203,8 +220,8 @@
                             <option value="" selected>Select country</option>
                         </select>
                     </div>
-                </div>
-            </nhs-details>
+                </nhs-details>
+            </nhs-fieldset>
 
             <div class="submit-search-button-container">
                 <button nhs-button-type="Standard" type="submit" value="Search" classes="ntbsuk-button--primary submit-search-button" id="search-button" formaction="#search-results-section">
@@ -230,10 +247,10 @@
                 </a>
             </div>
             <p> To filter results, add more search terms and search again. </p>
-            <p> 
-                Search results are ordered with the records you can edit above those you cannot. 
+            <p>
+                Search results are ordered with the records you can edit above those you cannot.
                 <br/>
-                Draft notifications are displayed before submitted records. 
+                Draft notifications are displayed before submitted records.
             </p>
             <div class="create-notification-button-container">
                 <a href="/Notifications/Create" role="button" draggable="false" class="nhsuk-button create-notification-button--right ntbsuk-button--primary" id="create-button">

--- a/ntbs-service/wwwroot/css/search.scss
+++ b/ntbs-service/wwwroot/css/search.scss
@@ -39,7 +39,7 @@
 .nhs-form-group--search-date {
     display: inline-block;
 
-    @media(min-width: $tablet_breakpoint) {
+    @include mq($from: desktop) {
         display: flex;
         flex-wrap: wrap;
     }
@@ -49,7 +49,7 @@
     display: flex;
     flex-direction: column;
 
-    @media(min-width: $tablet_breakpoint) {
+    @include mq($from: desktop) {
         flex-direction: row;
     }
 }
@@ -60,14 +60,30 @@
     width: 160px;
 }
 
-.search-header {
-    margin-bottom: 12px;
-}
-
 .search-label--long {
     height: 100%;
     margin: auto 0;
     width: 180px;
+}
+
+.search-legend--standard {
+    height: 100%;
+    margin: auto 0;
+    width: 160px;
+
+    @include mq($from: desktop) {
+        float: left;
+    }
+}
+
+.search-legend--long {
+    height: 100%;
+    margin: auto 0;
+    width: 180px;
+
+    @include mq($from: desktop) {
+        float: left;
+    }
 }
 
 .search-hint {
@@ -83,7 +99,7 @@
     display: flex;
     margin: 5px 0;
 
-    @media(min-width: $tablet_breakpoint) {
+    @include mq($from: desktop) {
         margin: 0;
     }
 }
@@ -93,7 +109,7 @@
     width: 45px;
     height: 100%;
 
-    @media(min-width: $tablet_breakpoint) {
+    @include mq($from: desktop) {
         width: auto;
     }
 }
@@ -107,7 +123,7 @@
     display: block;
     margin: 10px 0 20px 0;
 
-    @media(min-width: $tablet_breakpoint) {
+    @include mq($from: desktop) {
         display: flex;
         margin: 0;
     }


### PR DESCRIPTION
Fixing NTBS-2082 and 2085 together because the problems are fairly intertwined, both to do with making sure that semantic HTML is used properly in forms.

## Description
Form tweaks to improve accessibility: making sure every form input has
a label, and that subgroups of inputs are in fieldsets, and all
fieldsets have a legend.

This led to some styling tweaks for the search page, because the dates
and sex input groups needed to be put in a form field, but making a
fieldset legend appear inline with its inputs is not as trivial as you
would hope (in particular, flex boxes and form legends do not seem to
play nicely together).

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
