### PR TITLE
NTBS-2110: Migrate case managers when migrating notifications

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
+++ b/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
@@ -66,7 +66,7 @@ namespace ntbs_service_unit_tests.DataMigration
         }
 
         [Fact]
-        public async Task WhenCaseManagerForLegacyNotificationWithNoPermissionsDoesNotExistInNtbs_AddsCaseManagerWithNoTbServices()
+        public async Task WhenCaseManagerForLegacyNotificationWithIncorrectPermissionsDoesNotExistInNtbs_AddsCaseManagerWithNoTbServices()
         {
             // Arrange
             var notification = GivenLegacyNotificationWithTbServiceCode("TBS00TEST");

--- a/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
+++ b/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
@@ -13,19 +13,23 @@ using Xunit;
 
 namespace ntbs_service_unit_tests.DataMigration
 {
-    public class CaseManagerImportServiceTests : IClassFixture<CaseManagerImportServiceTests.DatabaseFixture>
+    public class CaseManagerImportServiceTests : IDisposable
     {
+        private const string NOTIFICATION_ID = "11111";
+        private const string CASE_MANAGER_USERNAME = "TestUser@nhs.net";
+        private static readonly Guid HOSPITAL_GUID = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A");
+
+        private readonly NtbsContext _context;
         private readonly CaseManagerImportService _caseManagerImportService;
         private readonly Mock<IMigrationRepository> _migrationRepositoryMock = new Mock<IMigrationRepository>();
 
         private Dictionary<string, IEnumerable<MigrationDbNotification>> _idToNotificationDict;
         private Dictionary<string, MigrationLegacyUser> _usernameToLegacyUserDict;
         private Dictionary<string, IEnumerable<MigrationLegacyUserHospital>> _usernameToLegacyUserHospitalDict;
-        private readonly NtbsContext _context;
 
-        public CaseManagerImportServiceTests(DatabaseFixture fixture)
+        public CaseManagerImportServiceTests()
         {
-            _context = fixture.Context;
+            _context = SetupTestContext();
             SetupMockMigrationRepo();
             IUserRepository userRepository = new UserRepository(_context);
             IReferenceDataRepository referenceDataRepository = new ReferenceDataRepository(_context);
@@ -34,82 +38,19 @@ namespace ntbs_service_unit_tests.DataMigration
                 _migrationRepositoryMock.Object, importLogger);
         }
 
-        [Fact]
-        public async Task WhenCaseManagerForLegacyNotificationDoesNotExistInNtbs_AddsCaseManager()
+        public void Dispose()
         {
-            // Arrange
-            var notification = new Notification
-            {
-                IsLegacy = true,
-                LTBRID = "11111",
-                HospitalDetails = new HospitalDetails {TBServiceCode = "TBS00TEST"}
-            };
-            _idToNotificationDict = new Dictionary<string, IEnumerable<MigrationDbNotification>>
-            {
-                {
-                    "11111",
-                    new List<MigrationDbNotification> {new MigrationDbNotification {CaseManager = "TestUser@nhs.net"}}
-                }
-            };
-            _usernameToLegacyUserDict = new Dictionary<string, MigrationLegacyUser>
-            {
-                {
-                    "TestUser@nhs.net",
-                    new MigrationLegacyUser {Username = "TestUser@nhs.net", GivenName = "John", FamilyName = "Johnston"}
-                }
-            };
-            _usernameToLegacyUserHospitalDict = new Dictionary<string, IEnumerable<MigrationLegacyUserHospital>> 
-                {{ "TestUser@nhs.net", new List<MigrationLegacyUserHospital>() }};
-
-            // Act
-            await _caseManagerImportService.ImportOrUpdateCaseManager(notification, null, "test-request-1");
-
-            // Assert
-            var addedUser = _context.User.SingleOrDefault();
-            Assert.NotNull(addedUser);
-            Assert.Equal("John", addedUser.GivenName);
-            Assert.Equal("Johnston", addedUser.FamilyName);
-            Assert.False(addedUser.IsActive);
-            Assert.False(addedUser.IsCaseManager);
-            Assert.DoesNotContain("TBS00TEST", addedUser.CaseManagerTbServices.Select(cmtb => cmtb.TbServiceCode));
+            _context.Dispose();
         }
 
         [Fact]
-        public async Task WhenCaseManagerForLegacyNotificationDoesNotExistAndHasCorrectPermissions_AddsCaseManagerTbServices()
+        public async Task WhenCaseManagerForLegacyNotificationWithCorrectPermissionsDoesNotExistInNtbs_AddsCaseManagerWithTbServices()
         {
             // Arrange
-            var notification = new Notification
-            {
-                IsLegacy = true,
-                LTBRID = "11111",
-                HospitalDetails = new HospitalDetails {TBServiceCode = "TBS00TEST"}
-            };
-            _idToNotificationDict = new Dictionary<string, IEnumerable<MigrationDbNotification>>
-            {
-                {
-                    "11111",
-                    new List<MigrationDbNotification> {new MigrationDbNotification {CaseManager = "TestUser@nhs.net"}}
-                }
-            };
-            _usernameToLegacyUserDict = new Dictionary<string, MigrationLegacyUser>
-            {
-                {
-                    "TestUser@nhs.net",
-                    new MigrationLegacyUser {Username = "TestUser@nhs.net", GivenName = "John", FamilyName = "Johnston"}
-                }
-            };
-            _usernameToLegacyUserHospitalDict = new Dictionary<string, IEnumerable<MigrationLegacyUserHospital>>
-            {
-                {
-                    "TestUser@nhs.net",
-                    new List<MigrationLegacyUserHospital>
-                    {
-                        new MigrationLegacyUserHospital {HospitalId = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A")}
-                    }
-                }
-            };
-            await _context.Hospital.AddAsync(new Hospital{HospitalId = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A"), TBService = new TBService{Code = "TBS00TEST"}});
-            await _context.SaveChangesAsync();
+            
+            var notification = GivenLegacyNotificationWithTbServiceCode("TBS00TEST");
+            GivenLegacyUserWithName("John", "Johnston");
+            await GivenLegacyUserHasPermissionsForTbService("TBS00TEST");
 
             // Act
             await _caseManagerImportService.ImportOrUpdateCaseManager(notification, null, "test-request-1");
@@ -125,39 +66,40 @@ namespace ntbs_service_unit_tests.DataMigration
         }
 
         [Fact]
-        public async Task WhenCaseManagerForLegacyNotificationDoesExist_UpdatesName()
+        public async Task WhenCaseManagerForLegacyNotificationWithNoPermissionsDoesNotExistInNtbs_AddsCaseManagerWithNoTbServices()
         {
             // Arrange
-            var notification = new Notification
-            {
-                IsLegacy = true,
-                LTBRID = "11111",
-                HospitalDetails = new HospitalDetails {TBServiceCode = "TBS00TEST"}
-            };
-            _idToNotificationDict = new Dictionary<string, IEnumerable<MigrationDbNotification>>
-            {
-                {
-                    "11111",
-                    new List<MigrationDbNotification> {new MigrationDbNotification {CaseManager = "TestUser@nhs.net"}}
-                }
-            };
-            _usernameToLegacyUserDict = new Dictionary<string, MigrationLegacyUser>
-            {
-                {
-                    "TestUser@nhs.net",
-                    new MigrationLegacyUser {Username = "TestUser@nhs.net", GivenName = "John", FamilyName = "Johnston"}
-                }
-            };
-            _usernameToLegacyUserHospitalDict = new Dictionary<string, IEnumerable<MigrationLegacyUserHospital>> 
-                {{ "TestUser@nhs.net", new List<MigrationLegacyUserHospital>() }};
-            await _context.User.AddAsync(new User {GivenName = "Jon", FamilyName = "Jonston", Username = "TestUser@nhs.net"});
-            await _context.SaveChangesAsync();
+            var notification = GivenLegacyNotificationWithTbServiceCode("TBS00TEST");
+            GivenLegacyUserWithName("John", "Johnston");
+            await GivenLegacyUserHasPermissionsForTbService("TBS11FAKE");
 
             // Act
             await _caseManagerImportService.ImportOrUpdateCaseManager(notification, null, "test-request-1");
 
             // Assert
-            var updatedUser = _context.User.SingleOrDefault();
+            var addedUser = _context.User.SingleOrDefault();
+            Assert.NotNull(addedUser);
+            Assert.Equal("John", addedUser.GivenName);
+            Assert.Equal("Johnston", addedUser.FamilyName);
+            Assert.False(addedUser.IsActive);
+            Assert.False(addedUser.IsCaseManager);
+            Assert.DoesNotContain("TBS00TEST", addedUser.CaseManagerTbServices.Select(cmtb => cmtb.TbServiceCode));
+        }
+
+        [Fact]
+        public async Task WhenCaseManagerForLegacyNotificationExistsInNtbs_UserNotImportedButNameUpdated()
+        {
+            // Arrange
+            var notification = GivenLegacyNotificationWithTbServiceCode("TBS00TEST");
+            GivenLegacyUserWithName("John", "Johnston");
+            await GivenLegacyUserHasPermissionsForTbService("TBS99HULL");
+            await GivenUserExistsInNtbsWithName("Jon", "Jonston");
+
+            // Act
+            await _caseManagerImportService.ImportOrUpdateCaseManager(notification, null, "test-request-1");
+
+            // Assert
+            var updatedUser = _context.User.Single();
             Assert.NotNull(updatedUser);
             Assert.Equal("John", updatedUser.GivenName);
             Assert.Equal("Johnston", updatedUser.FamilyName);
@@ -173,22 +115,65 @@ namespace ntbs_service_unit_tests.DataMigration
                 .Returns((List<string> ids) => Task.FromResult(_idToNotificationDict[ids[0]]));
         }
 
-        public class DatabaseFixture : IDisposable
+        private Notification GivenLegacyNotificationWithTbServiceCode(string TbServiceCode)
         {
-            public DatabaseFixture()
+            _idToNotificationDict = new Dictionary<string, IEnumerable<MigrationDbNotification>>
             {
-                Context = new NtbsContext(new DbContextOptionsBuilder<NtbsContext>()
-                    .UseInMemoryDatabase(nameof(CaseManagerImportService))
-                    .Options
-                );
-            }
-
-            public void Dispose()
+                {
+                    NOTIFICATION_ID,
+                    new List<MigrationDbNotification> {new MigrationDbNotification {CaseManager = CASE_MANAGER_USERNAME}}
+                }
+            };
+            return new Notification
             {
-                Context.Dispose();
-            }
+                IsLegacy = true,
+                LTBRID = NOTIFICATION_ID,
+                HospitalDetails = new HospitalDetails {TBServiceCode = TbServiceCode}
+            };
+        }
 
-            public NtbsContext Context { get; private set; }
+        private void GivenLegacyUserWithName(string givenName, string familyName)
+        {
+            _usernameToLegacyUserDict = new Dictionary<string, MigrationLegacyUser>
+            {
+                {
+                    CASE_MANAGER_USERNAME,
+                    new MigrationLegacyUser {Username = CASE_MANAGER_USERNAME, GivenName = givenName, FamilyName = familyName}
+                }
+            };
+        }
+
+        private async Task GivenLegacyUserHasPermissionsForTbService(string tbServiceCode)
+        {
+            _usernameToLegacyUserHospitalDict = new Dictionary<string, IEnumerable<MigrationLegacyUserHospital>>
+            {
+                {
+                    CASE_MANAGER_USERNAME,
+                    new List<MigrationLegacyUserHospital>
+                    {
+                        new MigrationLegacyUserHospital {HospitalId = HOSPITAL_GUID}
+                    }
+                }
+            };
+            await _context.Hospital.AddAsync(new Hospital{HospitalId = HOSPITAL_GUID, TBService = new TBService{Code = tbServiceCode}});
+            await _context.SaveChangesAsync();
+        }
+
+        private async Task GivenUserExistsInNtbsWithName(string givenName, string familyName)
+        {
+            await _context.User.AddAsync(
+                new User {GivenName = givenName, FamilyName = familyName, Username = CASE_MANAGER_USERNAME, IsActive = true});
+            await _context.SaveChangesAsync();
+        }
+
+        private NtbsContext SetupTestContext()
+        {
+            // Generating a unique database name makes sure the database is not shared between tests.
+            string dbName = Guid.NewGuid().ToString();
+            return new NtbsContext(new DbContextOptionsBuilder<NtbsContext>()
+                .UseInMemoryDatabase(dbName)
+                .Options
+            );
         }
     }
 }

--- a/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
+++ b/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moq;
+using ntbs_service.DataAccess;
+using ntbs_service.DataMigration;
+using ntbs_service.DataMigration.RawModels;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.ReferenceEntities;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataMigration
+{
+    public class CaseManagerImportServiceTests
+    {
+        private readonly CaseManagerImportService _caseManagerImportService;
+        private readonly Mock<IReferenceDataRepository> _referenceDataRepositoryMock =
+            new Mock<IReferenceDataRepository>();
+        private readonly Mock<IMigrationRepository> _migrationRepositoryMock = new Mock<IMigrationRepository>();
+        private readonly Mock<IUserRepository> _userRepositoryMock = new Mock<IUserRepository>();
+        
+        private Dictionary<string, User> _usernameToUserDict;
+        
+        private Dictionary<List<string>, IEnumerable<MigrationDbNotification>> _idToNotificationDict;
+        private Dictionary<string, MigrationLegacyUser> _usernameToLegacyUserDict;
+        private Dictionary<string, IEnumerable<MigrationLegacyUserHospital>> _usernameToLegacyUserHospitalDict;
+        
+        private Dictionary<List<Guid>, IList<TBService>> _legacyUserHospitalsToTbServicesDict;
+        private Dictionary<string, IList<CaseManagerTbService>> _usernameToCaseManagerTbServicesDict;
+
+        public CaseManagerImportServiceTests()
+        {
+            SetupMockUserRepo();
+            SetupMockMigrationRepo();
+            SetupMockReferenceRepo();
+            var importLogger = new ImportLogger();
+            _caseManagerImportService = new CaseManagerImportService(_userRepositoryMock.Object, _referenceDataRepositoryMock.Object,
+                _migrationRepositoryMock.Object, importLogger);
+        }
+
+        [Fact]
+        public async Task WhenCaseManagerForLegacyNotificationDoesNotExist_AddsCaseManager()
+        {
+            var legacyIds = new List<string> {"130331"};
+            SetupNotificationsInGroups(("130331", "1"));
+            const string royalBerkshireCode = "TBS001";
+            const string bristolRoyalCode = "TBS002";
+            const string westonGeneralCode = "TBS003";
+            _hospitalToTbServiceCodeDict = new Dictionary<Guid, TBService>
+            {
+                {new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A"), new TBService {Code = royalBerkshireCode}},
+                {new Guid("F026FDCD-7BAF-4C96-994C-20E436CC8C59"), new TBService {Code = bristolRoyalCode}},
+                {new Guid("0AC033AB-9A11-4FA6-AA1A-1FCA71180C2F"), new TBService {Code = westonGeneralCode}}
+            };
+        }
+
+        private void SetupMockUserRepo()
+        {
+            _userRepositoryMock.Setup(repo => repo.GetUserByUsername(It.IsAny<string>()))
+                .Returns((string username) => Task.FromResult(_usernameToUserDict[username]));
+        }
+
+        private void SetupMockMigrationRepo()
+        {
+            _migrationRepositoryMock.Setup(repo => repo.GetNotificationsById(It.IsAny<List<string>>()))
+                .Returns((List<string> ids) => Task.FromResult(_idToNotificationDict[ids]));
+            _migrationRepositoryMock.Setup(repo => repo.GetLegacyUserByUsername(It.IsAny<string>()))
+                .Returns((string username) => Task.FromResult(_usernameToLegacyUserDict[username]));
+            _migrationRepositoryMock.Setup(repo => repo.GetLegacyUserHospitalsByUsername(It.IsAny<string>()))
+                .Returns((string username) => Task.FromResult(_usernameToLegacyUserHospitalDict[username]));
+            _migrationRepositoryMock.Setup(repo => repo.GetNotificationsById(It.IsAny<List<string>>()))
+                .Returns((List<string> ids) => Task.FromResult(_idToNotificationDict[ids]));
+        }
+
+        private void SetupMockReferenceRepo()
+        {
+            _referenceDataRepositoryMock.Setup(repo => repo.GetCaseManagerTbServicesByUsernameAsync(It.IsAny<string>()))
+                .Returns((string username) => Task.FromResult(_usernameToCaseManagerTbServicesDict[username]));
+            _referenceDataRepositoryMock.Setup(repo => repo.GetTbServicesFromHospitalIdsAsync(It.IsAny<List<Guid>>()))
+                .Returns((List<Guid> ids) => Task.FromResult(_legacyUserHospitalsToTbServicesDict[ids]));
+        }
+    }
+}

--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -328,6 +328,16 @@ namespace ntbs_service_unit_tests.DataMigration
                 throw new NotImplementedException();
             }
 
+            public Task<IEnumerable<MigrationLegacyUser>> GetLegacyUserByUsername(string username)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<IEnumerable<MigrationLegacyUserHospital>> GetLegacyUserHospitalsByUsername(string username)
+            {
+                throw new NotImplementedException();
+            }
+            
             public IEnumerable<IGrouping<string, string>> GroupedNotificationsStub { get; set; }
 
             private static IEnumerable<T> CvsRecords<T>(string file, IEnumerable<string> legacyIds)

--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -328,7 +328,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 throw new NotImplementedException();
             }
 
-            public Task<IEnumerable<MigrationLegacyUser>> GetLegacyUserByUsername(string username)
+            public Task<MigrationLegacyUser> GetLegacyUserByUsername(string username)
             {
                 throw new NotImplementedException();
             }

--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -36,7 +36,7 @@ namespace ntbs_service.DataAccess
         Task<Hospital> GetHospitalByGuidAsync(Guid guid);
         Task<FilteredHospitalDetailsPageSelectLists> GetFilteredHospitalDetailsPageSelectListsByTbService(string tbServiceCode);
         Task<IList<User>> GetCaseManagersByTbServiceCodesAsync(IEnumerable<string> tbServiceCodes);
-        Task<IList<CaseManagerTbService>> GetCaseManagerTbServicesByUsername(string username);
+        Task<IList<CaseManagerTbService>> GetCaseManagerTbServicesByUsernameAsync(string username);
         Task<IList<Sex>> GetAllSexesAsync();
         Task<IList<Ethnicity>> GetAllOrderedEthnicitiesAsync();
         Task<IList<Site>> GetAllSitesAsync();
@@ -349,7 +349,7 @@ namespace ntbs_service.DataAccess
             return Postcode?.LocalAuthority?.LocalAuthorityToPHEC?.PHECCode;
         }
 
-        public async Task<IList<CaseManagerTbService>> GetCaseManagerTbServicesByUsername(string username)
+        public async Task<IList<CaseManagerTbService>> GetCaseManagerTbServicesByUsernameAsync(string username)
         {
             return await _context.CaseManagerTbService.Where(cmtb => cmtb.CaseManager.Username == username)
                 .ToListAsync();

--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -20,6 +20,7 @@ namespace ntbs_service.DataAccess
         Task<IList<TBService>> GetAllTbServicesAsync();
         Task<TBService> GetTbServiceByCodeAsync(string code);
         Task<TBService> GetTbServiceFromHospitalIdAsync(Guid hospitalId);
+        Task<IList<TBService>> GetTbServicesFromHospitalIdsAsync(IEnumerable<Guid> hospitalIds);
         Task<IList<TBService>> GetTbServicesFromPhecCodeAsync(string phecCode);
         Task<IList<TBService>> GetTbServicesWithCaseManagersFromPhecCodeAsync(string phecCode);
         IQueryable<TBService> GetDefaultTbServicesForPheUserQueryable(IEnumerable<string> roles);
@@ -35,6 +36,7 @@ namespace ntbs_service.DataAccess
         Task<Hospital> GetHospitalByGuidAsync(Guid guid);
         Task<FilteredHospitalDetailsPageSelectLists> GetFilteredHospitalDetailsPageSelectListsByTbService(string tbServiceCode);
         Task<IList<User>> GetCaseManagersByTbServiceCodesAsync(IEnumerable<string> tbServiceCodes);
+        Task<IList<CaseManagerTbService>> GetCaseManagerTbServicesByUsername(string username);
         Task<IList<Sex>> GetAllSexesAsync();
         Task<IList<Ethnicity>> GetAllOrderedEthnicitiesAsync();
         Task<IList<Site>> GetAllSitesAsync();
@@ -108,6 +110,15 @@ namespace ntbs_service.DataAccess
                 .Where(h => h.HospitalId == hospitalId)
                 .Select(h => h.TBService)
                 .SingleOrDefaultAsync();
+        }
+
+        public async Task<IList<TBService>> GetTbServicesFromHospitalIdsAsync(IEnumerable<Guid> hospitalIds)
+        {
+            return await _context.Hospital
+                .Where(h => hospitalIds.Contains(h.HospitalId))
+                .Select(h => h.TBService)
+                .Distinct()
+                .ToListAsync();
         }
 
         public async Task<IList<TBService>> GetTbServicesFromPhecCodeAsync(string phecCode)
@@ -336,6 +347,12 @@ namespace ntbs_service.DataAccess
                         .ThenInclude(pl => pl.PHEC)
                 .SingleOrDefaultAsync();
             return Postcode?.LocalAuthority?.LocalAuthorityToPHEC?.PHECCode;
+        }
+
+        public async Task<IList<CaseManagerTbService>> GetCaseManagerTbServicesByUsername(string username)
+        {
+            return await _context.CaseManagerTbService.Where(cmtb => cmtb.CaseManager.Username == username)
+                .ToListAsync();
         }
     }
 }

--- a/ntbs-service/DataMigration/CaseManagerImportService.cs
+++ b/ntbs-service/DataMigration/CaseManagerImportService.cs
@@ -45,11 +45,11 @@ namespace ntbs_service.DataMigration
 
             var existingCaseManager = await _userRepository.GetUserByUsername(legacyCaseManager.Username);
             var ntbsCaseManager = existingCaseManager ?? 
-                                              new User {IsActive = false, Username = legacyCaseManager.Username};
+                                              new User {IsActive = false, Username = legacyCaseManager.Username, CaseManagerTbServices = new List<CaseManagerTbService>()};
             
             ntbsCaseManager.GivenName = legacyCaseManager.GivenName;
             ntbsCaseManager.FamilyName = legacyCaseManager.FamilyName;
-            ntbsCaseManager.DisplayName = $"${ntbsCaseManager.GivenName} ${ntbsCaseManager.FamilyName}";
+            ntbsCaseManager.DisplayName = $"{ntbsCaseManager.GivenName} {ntbsCaseManager.FamilyName}";
             
             await AddTbServiceToUserBasedOnLegacyPermissions(ntbsCaseManager, notification, legacyCaseManager.Username);
 
@@ -73,7 +73,6 @@ namespace ntbs_service.DataMigration
         {
             var existingCaseManagerTbServices = await _referenceDataRepository.GetCaseManagerTbServicesByUsernameAsync
                 (ntbsCaseManager.Username);
-            var ntbsCaseManagerTbServices = existingCaseManagerTbServices.Select(e => e.TbService).ToList();
             if (!ntbsCaseManager.IsActive &&
                 existingCaseManagerTbServices.All(cmtb => cmtb.TbServiceCode != notification.HospitalDetails.TBServiceCode))
             {
@@ -84,7 +83,7 @@ namespace ntbs_service.DataMigration
                 var legacyMatchingTbService = legacyUserTbServices.SingleOrDefault(tb => tb.Code == notification.HospitalDetails.TBServiceCode);
                 if (legacyMatchingTbService != null) {
                     ntbsCaseManager.IsCaseManager = true;
-                    ntbsCaseManagerTbServices.Add(legacyMatchingTbService);
+                    ntbsCaseManager.CaseManagerTbServices.Add(new CaseManagerTbService{TbService = legacyMatchingTbService});
                 }
             }
         }

--- a/ntbs-service/DataMigration/CaseManagerImportService.cs
+++ b/ntbs-service/DataMigration/CaseManagerImportService.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hangfire.Server;
+using ntbs_service.DataAccess;
+using ntbs_service.DataMigration.RawModels;
+using ntbs_service.Models.Entities;
+
+namespace ntbs_service.DataMigration
+{
+    public interface ICaseManagerImportService
+    {
+        Task ImportOrUpdateCaseManager(Notification notification, PerformContext context, string requestId);
+    }
+    
+    public class CaseManagerImportService : ICaseManagerImportService
+    {
+        private readonly IUserRepository _userRepository;
+        private readonly IReferenceDataRepository _referenceDataRepository;
+        private readonly IMigrationRepository _migrationRepository;
+        private readonly IImportLogger _logger;
+
+        public CaseManagerImportService(
+            IUserRepository userRepository,
+            IReferenceDataRepository referenceDataRepository,
+            IMigrationRepository migrationRepository,
+            IImportLogger logger)
+        {
+            this._userRepository = userRepository;
+            this._referenceDataRepository = referenceDataRepository;
+            this._migrationRepository = migrationRepository;
+            _logger = logger;
+        }
+        
+        public async Task ImportOrUpdateCaseManager(Notification notification,
+            PerformContext context,
+            string requestId)
+        {
+            var legacyCaseManager = await GetLegacyNotificationCaseManager(notification.LegacyId);
+            if (legacyCaseManager == null)
+            {
+                return;
+            }
+
+            var existingCaseManager = await _userRepository.GetUserByUsername(legacyCaseManager.Username);
+            var ntbsCaseManager = existingCaseManager ?? 
+                                              new User {IsActive = false, Username = legacyCaseManager.Username};
+            
+            ntbsCaseManager.GivenName = legacyCaseManager.GivenName;
+            ntbsCaseManager.FamilyName = legacyCaseManager.FamilyName;
+            ntbsCaseManager.DisplayName = $"${ntbsCaseManager.GivenName} ${ntbsCaseManager.FamilyName}";
+            
+            await AddTbServiceToUserBasedOnLegacyPermissions(ntbsCaseManager, notification, legacyCaseManager.Username);
+
+            await _userRepository.AddOrUpdateUser(ntbsCaseManager, ntbsCaseManager.CaseManagerTbServices.Select(cmtb => cmtb.TbService));
+            _logger.LogInformation(context, requestId, "Added/Updated the case manager assigned to the notification.");
+        }
+
+        private async Task<MigrationLegacyUser> GetLegacyNotificationCaseManager(string legacyId)
+        {
+            var caseManagerUsername = (await _migrationRepository.GetNotificationsById(new List<string> {legacyId}))
+                .Select(n => n.CaseManager)
+                .SingleOrDefault();
+            if (caseManagerUsername == null)
+            {
+                return null;
+            }
+            return await _migrationRepository.GetLegacyUserByUsername(caseManagerUsername);
+        }
+
+        private async Task AddTbServiceToUserBasedOnLegacyPermissions(User ntbsCaseManager, Notification notification, string legacyCaseManagerUsername)
+        {
+            var existingCaseManagerTbServices = await _referenceDataRepository.GetCaseManagerTbServicesByUsernameAsync
+                (ntbsCaseManager.Username);
+            var ntbsCaseManagerTbServices = existingCaseManagerTbServices.Select(e => e.TbService).ToList();
+            if (!ntbsCaseManager.IsActive &&
+                existingCaseManagerTbServices.All(cmtb => cmtb.TbServiceCode != notification.HospitalDetails.TBServiceCode))
+            {
+                var legacyUserHospitals = (await _migrationRepository.GetLegacyUserHospitalsByUsername(legacyCaseManagerUsername))
+                    .Where(h => h.HospitalId != null).Select(h => h.HospitalId).OfType<Guid>();
+                var legacyUserTbServices =
+                    await _referenceDataRepository.GetTbServicesFromHospitalIdsAsync(legacyUserHospitals);
+                var legacyMatchingTbService = legacyUserTbServices.SingleOrDefault(tb => tb.Code == notification.HospitalDetails.TBServiceCode);
+                if (legacyMatchingTbService != null) {
+                    ntbsCaseManager.IsCaseManager = true;
+                    ntbsCaseManagerTbServices.Add(legacyMatchingTbService);
+                }
+            }
+        }
+    }
+}

--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -34,7 +34,7 @@ namespace ntbs_service.DataMigration
             Notification notification)
         {
             CleanData(notification, context, requestId);
-            return (await GetValidationErrors(context, requestId,notification)).ToList();
+            return (await GetValidationErrors(context, requestId, notification)).ToList();
         }
 
         /// <summary>

--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -34,7 +34,7 @@ namespace ntbs_service.DataMigration
             Notification notification)
         {
             CleanData(notification, context, requestId);
-            return (await GetValidationErrors(notification)).ToList();
+            return (await GetValidationErrors(context, requestId,notification)).ToList();
         }
 
         /// <summary>
@@ -95,7 +95,8 @@ namespace ntbs_service.DataMigration
             }
         }
 
-        private async Task<IEnumerable<ValidationResult>> GetValidationErrors(Notification notification)
+        private async Task<IEnumerable<ValidationResult>> GetValidationErrors(PerformContext context,
+            string requestId, Notification notification)
         {
             var singletonModels = new List<ModelBase>
             {
@@ -137,7 +138,7 @@ namespace ntbs_service.DataMigration
             validationsResults.AddRange(ValidateObject(notification));
             singletonModels.Select(ValidateObject)
                 .ForEach(results => validationsResults.AddRange(results));
-            validationsResults.AddRange(await ValidateAndSetCaseManager(notification.HospitalDetails));
+            validationsResults.AddRange(await ValidateAndSetCaseManager(context, requestId, notification.HospitalDetails));
             validationsResults.AddRange(
                 modelCollections.SelectMany(collection => collection.SelectMany(ValidateObject)));
 
@@ -154,7 +155,8 @@ namespace ntbs_service.DataMigration
             return validationsResults;
         }
 
-        private async Task<IEnumerable<ValidationResult>> ValidateAndSetCaseManager(HospitalDetails details)
+        private async Task<IEnumerable<ValidationResult>> ValidateAndSetCaseManager(PerformContext context,
+            string requestId,HospitalDetails details)
         {
             var validationsResults = new List<ValidationResult>();
 
@@ -163,10 +165,14 @@ namespace ntbs_service.DataMigration
                 return validationsResults;
             }
 
-            var caseManager =
-                await _referenceDataRepository.GetCaseManagerByUsernameAsync(details.CaseManagerUsername);
-            if (caseManager != null)
+            var possibleCaseManager =
+                await _referenceDataRepository.GetUserByUsernameAsync(details.CaseManagerUsername);
+            if (possibleCaseManager != null)
             {
+                if (!possibleCaseManager.IsCaseManager)
+                {
+                    _logger.LogWarning(context, requestId, "User set as case manager for notification is not a case manager.");
+                }
                 return validationsResults;
             }
 

--- a/ntbs-service/DataMigration/MigrationRepository.cs
+++ b/ntbs-service/DataMigration/MigrationRepository.cs
@@ -130,13 +130,13 @@ namespace ntbs_service.DataMigration
         ";
         const string LegacyUserByUsernameQuery = @"
             SELECT *
-            FROM MigrationLegacyUser u
+            FROM LegacyUser u
             WITH (NOLOCK)
             WHERE u.Username = @Username
         ";
         const string LegacyUserHospitalsByUsernameQuery = @"
             SELECT *
-            FROM MigrationLegacyUserHospital h
+            FROM LegacyUserHospital h
             WITH (NOLOCK)
             WHERE h.Username = @Username
         ";

--- a/ntbs-service/DataMigration/MigrationRepository.cs
+++ b/ntbs-service/DataMigration/MigrationRepository.cs
@@ -29,7 +29,7 @@ namespace ntbs_service.DataMigration
         Task<IEnumerable<MigrationDbMBovisKnownCase>> GetMigrationMBovisExposureToKnownCase(List<string> legacyIds);
         Task<IEnumerable<MigrationDbMBovisOccupation>> GetMigrationMBovisOccupationExposures(List<string> legacyIds);
         Task<IEnumerable<MigrationDbMBovisMilkConsumption>> GetMigrationMBovisUnpasteurisedMilkConsumption(List<string> legacyIds);
-        Task<IEnumerable<MigrationLegacyUser>> GetLegacyUserByUsername(string username);
+        Task<MigrationLegacyUser> GetLegacyUserByUsername(string username);
         Task<IEnumerable<MigrationLegacyUserHospital>> GetLegacyUserHospitalsByUsername(string username);
 
         Task<IEnumerable<(string LegacyId, string ReferenceLaboratoryNumber)>> GetReferenceLaboratoryMatches(
@@ -259,9 +259,9 @@ namespace ntbs_service.DataMigration
             }
         }
 
-        public async Task<IEnumerable<MigrationLegacyUser>> GetLegacyUserByUsername(string username)
+        public async Task<MigrationLegacyUser> GetLegacyUserByUsername(string username)
         {
-            return await ExecuteByUsernameQuery<MigrationLegacyUser>(LegacyUserByUsernameQuery, username);
+            return (await ExecuteByUsernameQuery<MigrationLegacyUser>(LegacyUserByUsernameQuery, username)).SingleOrDefault();
         }
 
         public async Task<IEnumerable<MigrationLegacyUserHospital>> GetLegacyUserHospitalsByUsername(string username)

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -263,7 +263,11 @@ namespace ntbs_service.DataMigration
             var legacyNotificationCaseManager =
                 (await _migrationRepository.GetNotificationsById(new List<string> {notification.LegacyId}))
                 .Select(n => n.CaseManager)
-                .First();
+                .SingleOrDefault();
+            if (legacyNotificationCaseManager == null)
+            {
+                return;
+            }
             var existingCaseManager = await _userRepository.GetUserByUsername(legacyNotificationCaseManager);
             var ntbsNotificationCaseManager = new User();
             if (existingCaseManager != null)

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -294,13 +294,11 @@ namespace ntbs_service.DataMigration
                     var legacyUserHospitals = (await _migrationRepository.GetLegacyUserHospitalsByUsername(legacyNotificationCaseManager))
                         .Where(h => h.HospitalId != null).Select(h => h.HospitalId).OfType<Guid>();
                     var legacyUserTbServices = await _referenceDataRepository.GetTbServicesFromHospitalIdsAsync(legacyUserHospitals);
-                    legacyUserTbServices.Where(tb => tb.Code == notification.HospitalDetails.TBServiceCode).Select(tbService =>
-                        {
-                            ntbsNotificationCaseManager.IsCaseManager = true;
-                            ntbsNotificationCaseManagerTbServices.Add(tbService);
-                            return tbService;
-                        }
-                    );
+                    foreach (var tbService in legacyUserTbServices.Where(tb => tb.Code == notification.HospitalDetails.TBServiceCode))
+                    {
+                        ntbsNotificationCaseManager.IsCaseManager = true;
+                        ntbsNotificationCaseManagerTbServices.Add(tbService);
+                    }
                 }
             }
             

--- a/ntbs-service/DataMigration/RawModels/MigrationLegacyUser.cs
+++ b/ntbs-service/DataMigration/RawModels/MigrationLegacyUser.cs
@@ -1,0 +1,11 @@
+﻿namespace ntbs_service.DataMigration.RawModels
+{
+    public class MigrationLegacyUser
+    {
+        public string Username { get; set; }
+        
+        public string GivenName { get; set; }
+        
+        public string FamilyName { get; set; }
+    }
+}

--- a/ntbs-service/DataMigration/RawModels/MigrationLegacyUserHospital.cs
+++ b/ntbs-service/DataMigration/RawModels/MigrationLegacyUserHospital.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ntbs_service.DataMigration.RawModels
+{
+    public class MigrationLegacyUserHospital
+    {
+        public string Username { get; set; }
+        
+        public Guid? HospitalId { get; set; }
+    }
+}

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -214,6 +214,7 @@ namespace ntbs_service
             services.AddScoped<INotificationCloningService, NotificationCloningService>();
             services.AddScoped<ICaseManagerSearchService, CaseManagerSearchService>();
             services.AddScoped<IClusterImportService, ClusterImportService>();
+            services.AddScoped<ICaseManagerImportService, CaseManagerImportService>();
 
             AddAuditService(services, auditDbConnectionString);
             AddReferenceLabResultServices(services);


### PR DESCRIPTION
## Description
When migrating a notification, migrate the case manager if they are not already in NTBS. If they are in NTBS then update the name. As migrated "case managers" are not always classed as what we define a case manager to be we have changed the validation logic to check that the user exists in NTBS, if this user is not a case manager then we output a warning but the notification is migrated anyway.

## Checklist:
- [x] Automated tests are passing locally.
