### PR TITLE
NTBS-2091 QA fix: Use new specimen care card on test results page

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/_SpecimenDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_SpecimenDetails.cshtml
@@ -6,104 +6,114 @@
     <div id="specimens-details">
         @foreach (var specimen in Model)
         {
-            <div class="notification-specimen-summary">
-                <h5 class="section-header-with-background">Specimen #@specimen.ReferenceLaboratoryNumber</h5>
-                <div>
-                    <nhs-grid-row>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.SpecimenDate) </dt>
-                            <dd class="cell-min-height"> @specimen.FormattedSpecimenDate </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.SpecimenTypeCode) </dt>
-                            <dd class="cell-min-height"> @specimen.SpecimenTypeCode </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Species) </dt>
-                            <dd class="cell-min-height"> @specimen.Species </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LaboratoryName) </dt>
-                            <dd class="cell-min-height"> @specimen.LaboratoryName </dd>
-                        </nhs-grid-column>
-                    </nhs-grid-row>
-                    <nhs-grid-row>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Isoniazid) </dt>
-                            <dd class="cell-min-height"> @specimen.Isoniazid </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Rifampicin) </dt>
-                            <dd class="cell-min-height"> @specimen.Rifampicin </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Pyrazinamide) </dt>
-                            <dd class="cell-min-height"> @specimen.Pyrazinamide </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Ethambutol) </dt>
-                            <dd class="cell-min-height"> @specimen.Ethambutol </dd>
-                        </nhs-grid-column>
-                    </nhs-grid-row>
-                    <nhs-grid-row>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Aminoglycoside) </dt>
-                            <dd class="cell-min-height"> @specimen.Aminoglycoside </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Quinolone) </dt>
-                            <dd class="cell-min-height"> @specimen.Quinolone </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.MDR) </dt>
-                            <dd class="cell-min-height"> @specimen.MDR </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.XDR) </dt>
-                            <dd class="cell-min-height"> @specimen.XDR </dd>
-                        </nhs-grid-column>
-                    </nhs-grid-row>
+            <div class="nhsuk-care-card nhsuk-care-card--specimen">
+                <div class="nhsuk-care-card__heading-container">
+                    <h5 class="nhsuk-care-card__heading">
+                        <span role="text">
+                            Specimen #@specimen.ReferenceLaboratoryNumber
+                        </span>
+                    </h5>
+                    <span class="nhsuk-care-card__arrow" aria-hidden="true"></span>
                 </div>
-                
-                <br>
-                <h6 class="section-header-with-background">Patient Details</h6>
 
-                <div>
-                    <nhs-grid-row>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabNhsNumber) </dt>
-                            <dd class="cell-min-height"> @specimen.FormattedNhsNumber </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneHalf">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabName) </dt>
-                            <dd class="cell-min-height"> @specimen.LabName </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabSex) </dt>
-                            <dd class="cell-min-height"> @specimen.LabSex </dd>
-                        </nhs-grid-column>
-                    </nhs-grid-row>
-                    <nhs-grid-row>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabBirthDate) </dt>
-                            <dd class="cell-min-height"> @specimen.FormattedLabDob </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneHalf">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabAddress) </dt>
-                            <dd class="cell-min-height"> @specimen.LabAddress </dd>
-                        </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="OneQuarter">
-                            <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabPostcode) </dt>
-                            <dd class="cell-min-height"> @specimen.LabPostcode </dd>
-                        </nhs-grid-column>
-                    </nhs-grid-row>                
+                <div class="nhsuk-care-card__content">
+                    <div>
+                        <nhs-grid-row>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.SpecimenDate) </dt>
+                                <dd class="cell-min-height"> @specimen.FormattedSpecimenDate </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.SpecimenTypeCode) </dt>
+                                <dd class="cell-min-height"> @specimen.SpecimenTypeCode </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Species) </dt>
+                                <dd class="cell-min-height"> @specimen.Species </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LaboratoryName) </dt>
+                                <dd class="cell-min-height"> @specimen.LaboratoryName </dd>
+                            </nhs-grid-column>
+                        </nhs-grid-row>
+                        <nhs-grid-row>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Isoniazid) </dt>
+                                <dd class="cell-min-height"> @specimen.Isoniazid </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Rifampicin) </dt>
+                                <dd class="cell-min-height"> @specimen.Rifampicin </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Pyrazinamide) </dt>
+                                <dd class="cell-min-height"> @specimen.Pyrazinamide </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Ethambutol) </dt>
+                                <dd class="cell-min-height"> @specimen.Ethambutol </dd>
+                            </nhs-grid-column>
+                        </nhs-grid-row>
+                        <nhs-grid-row>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Aminoglycoside) </dt>
+                                <dd class="cell-min-height"> @specimen.Aminoglycoside </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.Quinolone) </dt>
+                                <dd class="cell-min-height"> @specimen.Quinolone </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.MDR) </dt>
+                                <dd class="cell-min-height"> @specimen.MDR </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.XDR) </dt>
+                                <dd class="cell-min-height"> @specimen.XDR </dd>
+                            </nhs-grid-column>
+                        </nhs-grid-row>
+                    </div>
+
+                    <br>
+                    <h6 class="section-header-with-background">Patient Details</h6>
+
+                    <div>
+                        <nhs-grid-row>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabNhsNumber) </dt>
+                                <dd class="cell-min-height"> @specimen.FormattedNhsNumber </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneHalf">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabName) </dt>
+                                <dd class="cell-min-height"> @specimen.LabName </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabSex) </dt>
+                                <dd class="cell-min-height"> @specimen.LabSex </dd>
+                            </nhs-grid-column>
+                        </nhs-grid-row>
+                        <nhs-grid-row>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabBirthDate) </dt>
+                                <dd class="cell-min-height"> @specimen.FormattedLabDob </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneHalf">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabAddress) </dt>
+                                <dd class="cell-min-height"> @specimen.LabAddress </dd>
+                            </nhs-grid-column>
+                            <nhs-grid-column grid-column-width="OneQuarter">
+                                <dt class="notification-test-results-label"> @Html.DisplayNameFor(m => m.LabPostcode) </dt>
+                                <dd class="cell-min-height"> @specimen.LabPostcode </dd>
+                            </nhs-grid-column>
+                        </nhs-grid-row>
+                    </div>
+                    <button nhs-button-type="Standard"
+                        classes="ntbsuk-button--secondary unmatch-button"
+                        asp-page-handler="Unmatch"
+                        asp-route-labReferenceNumber="@specimen.ReferenceLaboratoryNumber">
+                            Unmatch
+                    </button>
                 </div>
-                <button nhs-button-type="Standard"
-                    classes="ntbsuk-button--secondary unmatch-button" 
-                    asp-page-handler="Unmatch" 
-                    asp-route-labReferenceNumber="@specimen.ReferenceLaboratoryNumber">
-                        Unmatch
-                </button>
             </div>
         }
     </div>

--- a/ntbs-service/wwwroot/css/labResults.scss
+++ b/ntbs-service/wwwroot/css/labResults.scss
@@ -75,4 +75,7 @@
       border-color: $phe-navy;
     }
   }
+
+  @include nhsuk-responsive-margin(4, 'bottom');
+  @include nhsuk-responsive-margin(4, 'top');
 }

--- a/ntbs-service/wwwroot/css/testResults.scss
+++ b/ntbs-service/wwwroot/css/testResults.scss
@@ -8,12 +8,6 @@
     background-color: $shaded-background-color;
 }
 
-.notification-specimen-summary {
-    padding: 10px 5px 10px 5px;
-    border: 1px solid black;
-    margin-bottom: 20px;
-}
-
 .notification-test-results-label {
     font-weight: 600;
 }


### PR DESCRIPTION
## Description
Use the new care card introduced in NHS v4 for reference lab specimens on the edit test result page, matching the lab results page formatting for specimens from the reference lab.

This was suggested in QA where the lab result page had been updated to use this new care card formatting.

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))