### PR TITLE
NTBS-2059 Restructure AD config

### DIFF
--- a/ntbs-service-unit-tests/Services/UserServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/UserServiceTest.cs
@@ -20,13 +20,13 @@ namespace ntbs_service_unit_tests.Services
         private const string NationalTeam = "NTS";
         private const string ServicePrefix = "Service";
         private readonly IUserService _service;
-        private readonly AdfsOptions _options = new AdfsOptions
+        private readonly AdOptions _options = new AdOptions
         {
             NationalTeamAdGroup = NationalTeam,
             ServiceGroupAdPrefix = ServicePrefix,
         };
 
-        private readonly Mock<IOptionsMonitor<AdfsOptions>> _mockOptionsMonitor;
+        private readonly Mock<IOptionsMonitor<AdOptions>> _mockOptionsMonitor;
         private readonly Mock<IReferenceDataRepository> _mockReferenceDataRepository;
         private readonly Mock<IUserRepository> _mockUserRepository;
         private readonly Mock<ClaimsPrincipal> _mockUser;
@@ -34,7 +34,7 @@ namespace ntbs_service_unit_tests.Services
         public UserServiceTest()
         {
             _mockReferenceDataRepository = new Mock<IReferenceDataRepository>();
-            _mockOptionsMonitor = new Mock<IOptionsMonitor<AdfsOptions>>();
+            _mockOptionsMonitor = new Mock<IOptionsMonitor<AdOptions>>();
             _mockUserRepository = new Mock<IUserRepository>();
             _mockOptionsMonitor.Setup(o => o.CurrentValue).Returns(_options);
             _service = new UserService(_mockReferenceDataRepository.Object, _mockUserRepository.Object, _mockOptionsMonitor.Object);

--- a/ntbs-service/Authentication/DummyAuthHandler.cs
+++ b/ntbs-service/Authentication/DummyAuthHandler.cs
@@ -14,9 +14,9 @@ namespace ntbs_service.Authentication
     {
         public static readonly string Name = "DummyAuth";
 
-        private readonly ClaimsPrincipal id;
+        private readonly ClaimsPrincipal claimsPrincipal;
 
-        public DummyAuthHandler(IOptionsMonitor<AdfsOptions> AdfsOptionsMonitor,
+        public DummyAuthHandler(IOptionsMonitor<AdOptions> AdOptionsMonitor,
                               IOptionsMonitor<AuthenticationSchemeOptions> options,
                               ILoggerFactory logger,
                               UrlEncoder encoder,
@@ -25,24 +25,24 @@ namespace ntbs_service.Authentication
             var id = new ClaimsIdentity(Name);
             // Add name claim
             id.AddClaim(new Claim(ClaimTypes.Name, "Developer", ClaimValueTypes.String));
-            var adfsOptions = AdfsOptionsMonitor.CurrentValue;
+            var adOptions = AdOptionsMonitor.CurrentValue;
 
             // Add role claim for base user role
-            id.AddClaim(new Claim(ClaimTypes.Role, adfsOptions.BaseUserGroup, ClaimValueTypes.String));
+            id.AddClaim(new Claim(ClaimTypes.Role, adOptions.BaseUserGroup, ClaimValueTypes.String));
 
             // Add role claim for user role - as specified in appsettings.Development.json
-            string groupDev = adfsOptions.DevGroup ?? adfsOptions.NationalTeamAdGroup;
+            string groupDev = adOptions.DevGroup ?? adOptions.NationalTeamAdGroup;
             id.AddClaim(new Claim(ClaimTypes.Role, groupDev, ClaimValueTypes.String));
 
             // Add role claim for user role - Admin
-            string groupAdmin = adfsOptions.AdminUserGroup;
+            string groupAdmin = adOptions.AdminUserGroup;
             id.AddClaim(new Claim(ClaimTypes.Role, groupAdmin, ClaimValueTypes.String));
 
             id.AddClaim(new Claim(ClaimTypes.Upn, "Developer@ntbs.phe.com", ClaimValueTypes.String));
-            this.id = new ClaimsPrincipal(id);
+            claimsPrincipal = new ClaimsPrincipal(id);
         }
 
         protected override Task<AuthenticateResult> HandleAuthenticateAsync()
-            => Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(id, Name)));
+            => Task.FromResult(AuthenticateResult.Success(new AuthenticationTicket(claimsPrincipal, Name)));
     }
 }

--- a/ntbs-service/Constants.cs
+++ b/ntbs-service/Constants.cs
@@ -13,7 +13,6 @@
         public const string ReferenceLabResultsConfig = "ReferenceLabResultsConfig";
         public const string ReferenceLabResultsConfigMockOut = "MockOutSpecimenMatching";
         public const string ScheduledJobsConfig = "ScheduledJobsConfig";
-        public const string AzureActiveDirectoryAuthEnabled = "AzureAdOptions:Enabled";
         public const string DbConnectionStringMigration = "migration";
         public const string DbConnectionStringSpecimenMatching = "specimenMatching";
 

--- a/ntbs-service/Pages/ContactDetails/Menu.cshtml
+++ b/ntbs-service/Pages/ContactDetails/Menu.cshtml
@@ -8,7 +8,7 @@
 }
 
 <nhs-width-container container-width="Standard">
-    <h2 class="nhsuk-heading-l"> @(await UserService.GetUserDisplayName(@User)) </h2>
+    <h2 class="nhsuk-heading-l"> @UserService.GetUserDisplayName(@User) </h2>
    
     <div>
         <a class="submenu-list-item-non-js" href="/ContactDetails">

--- a/ntbs-service/Pages/Logout.cshtml.cs
+++ b/ntbs-service/Pages/Logout.cshtml.cs
@@ -18,10 +18,11 @@ namespace ntbs_service.Pages
         {
             // We just want to return to the homepage (which will trigger going to login again)
             // Check to see if Azure Ad Auth is enabled.
-            if (azureAdOptions.CurrentValue.Enabled.ToLower() == "true")
+            if (azureAdOptions.CurrentValue.Enabled)
             {
                 BaseUrl = azureAdOptions.CurrentValue.Authority;
-                RedirectUrl = $"{BaseUrl}/oauth2/logout?client_id={azureAdOptions.CurrentValue.ClientId}&post_logout_redirect_uri={options.CurrentValue.Wtrealm}";
+                RedirectUrl =
+                    $"{BaseUrl}/oauth2/logout?client_id={azureAdOptions.CurrentValue.ClientId}&post_logout_redirect_uri={options.CurrentValue.Wtrealm}";
             }
             else
             {
@@ -29,7 +30,6 @@ namespace ntbs_service.Pages
                 BaseUrl = options.CurrentValue.AdfsUrl;
                 RedirectUrl = $"{BaseUrl}/adfs/ls/?wa=wsignout1.0&wreply={ReturnUrl}";
             }
-
         }
 
         public async Task<RedirectResult> OnGetAsync()

--- a/ntbs-service/Pages/Shared/_Header.cshtml
+++ b/ntbs-service/Pages/Shared/_Header.cshtml
@@ -93,7 +93,7 @@
                     <navigation-with-submenu inline-template>
                         <li class="nav-with-submenu-header govuk-header__navigation-item header-navigation-link">
                             <a v-on:click="toggleMenu" href="/ContactDetails/Menu" class="govuk-header__link header-navigation-list-item nav-with-submenu-header-link">
-                                @(await UserService.GetUserDisplayName(@User)) <i class="arrow down"></i>
+                                @UserService.GetUserDisplayName(@User) <i class="arrow down"></i>
                             </a>
                             <ul ref="navigation-submenu" v-if="showMenu" class="nav-submenu-list" >
                                 <li class="header-navigation-link nav-submenu-list-item">

--- a/ntbs-service/Properties/AdOptions.cs
+++ b/ntbs-service/Properties/AdOptions.cs
@@ -1,0 +1,22 @@
+﻿namespace ntbs_service.Properties
+{
+    public class AdOptions
+    {
+        public string NationalTeamAdGroup { get; set; }
+
+        /** TB service groups are of the format Global.NIS.NTBS.Service_<service-specifc-postfix> */
+        public string ServiceGroupAdPrefix { get; set; }
+
+        /** Group that contains all users of NTBS, used for authorizing access to the app */
+        public string BaseUserGroup { get; set; }
+
+        /** Group that contains admin users only, used for authorizing access protected pages of the app */
+        public string AdminUserGroup { get; set; }
+
+        /** Only used in development mode, allows developers to set their group membership via properties */
+        public string DevGroup { get; set; }
+
+        /** Only used in the CI environment to bypass authentication when running UI tests */
+        public bool UseDummyAuth { get; set; }
+    }
+}

--- a/ntbs-service/Properties/AdfsOptions.cs
+++ b/ntbs-service/Properties/AdfsOptions.cs
@@ -2,20 +2,6 @@
 {
     public class AdfsOptions
     {
-        public string NationalTeamAdGroup { get; set; }
-
-        /** TB service groups are of the format Global.NIS.NTBS.Service_<service-specifc-postfix> */
-        public string ServiceGroupAdPrefix { get; set; }
-
-        /** Group that contains all users of NTBS, used for authorizing access to the app */
-        public string BaseUserGroup { get; set; }
-
-        /** Group that contains admin users only, used for authorizing access protected pages of the app */
-        public string AdminUserGroup { get; set; }
-
-        /** Only used in development mode, allows developers to set their group membership via properties */
-        public string DevGroup { get; set; }
-
         /** Base url for the AD FS instace */
         public string AdfsUrl { get; set; }
         /** The ntbs url, used as identifier of the app to adfs */

--- a/ntbs-service/Properties/AzureAdOptions.cs
+++ b/ntbs-service/Properties/AzureAdOptions.cs
@@ -8,14 +8,11 @@
 
         /** The authentication endpoint for the Azure AD tenant hosting the Azure AD Application. e.g. https://login.microsoftonline.com/mydomain.com */
         public string Authority { get; set; }
-
-        /** The URL to send the id/access token back to. e.g. /Index */
+        
+        /** The URL to send the id/access token back to. */
         public string CallbackPath { get; set; }
-
-        /** Group that contains all users of NTBS, used for authorizing access to the app */
-        public string BaseUserGroup { get; set; }
-
+         
         /** This will override the use of Adfs with Azure Active Directory **/
-        public string Enabled { get; set; }
+        public bool Enabled { get; set; }
     }
 }

--- a/ntbs-service/Services/AdDirectoryService.cs
+++ b/ntbs-service/Services/AdDirectoryService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,14 +28,14 @@ namespace ntbs_service.Services
     public class AdDirectoryService : IAdDirectoryService
     {
         private readonly LdapSettings _settings;
-        private readonly AdfsOptions _adOptions;
+        private readonly AdOptions _adOptions;
 
         // ReSharper disable once UnusedMember.Global - constructor needed for mocking in tests
         public AdDirectoryService() { }
 
         private readonly LdapConnection _connection;
 
-        public AdDirectoryService(LdapSettings settings, AdfsOptions adOptions)
+        public AdDirectoryService(LdapSettings settings, AdOptions adOptions)
         {
             // TODO NTBS-1672 run a DNS query that does the foollwing:
             // dig +short -t srv _ldap._tcp.SP4-0JG._sites.dc._msdcs.phe.gov.uk

--- a/ntbs-service/Services/AdDirectoryServiceFactory.cs
+++ b/ntbs-service/Services/AdDirectoryServiceFactory.cs
@@ -11,19 +11,19 @@ namespace ntbs_service.Services
     public class AdDirectoryServiceServiceFactory : IAdDirectoryServiceFactory
     {
         private readonly LdapSettings _ldapSettings;
-        private readonly AdfsOptions _adfsOptions;
+        private readonly AdOptions _adOptions;
 
         public AdDirectoryServiceServiceFactory(
             IOptions<LdapSettings> LdapSettings,
-            IOptions<AdfsOptions> adfsOptions)
+            IOptions<AdOptions> adfsOptions)
         {
-            this._ldapSettings = LdapSettings.Value;
-            this._adfsOptions = adfsOptions.Value;
+            _ldapSettings = LdapSettings.Value;
+            _adOptions = adfsOptions.Value;
         }
 
         public IAdDirectoryService Create()
         {
-            return new AdDirectoryService(_ldapSettings, _adfsOptions);
+            return new AdDirectoryService(_ldapSettings, _adOptions);
         }
     }
 }

--- a/ntbs-service/Services/AzureAdDirectoryServiceFactory.cs
+++ b/ntbs-service/Services/AzureAdDirectoryServiceFactory.cs
@@ -14,20 +14,22 @@ namespace ntbs_service.Services
     public class AzureAdDirectoryServiceFactory : IAzureAdDirectoryServiceFactory
     {
         private IGraphServiceClient _graphServiceClient;
+        private readonly AdOptions _adSettings;
         private readonly AzureAdOptions _azureAdSettings;
 
         public AzureAdDirectoryServiceFactory(
-            IOptions<AzureAdOptions> AzureAdSettings
-            )
+            IOptions<AdOptions> AdSettings,
+            IOptions<AzureAdOptions> AzureAdSettings)
         {
-            this._azureAdSettings = AzureAdSettings.Value;
+            _azureAdSettings = AzureAdSettings.Value;
+            _adSettings = AdSettings.Value;
         }
 
         public IAzureAdDirectoryService Create()
         {
             IConfidentialClientApplication clientApplication = ConfidentialClientApplicationBuilder
             .Create(_azureAdSettings.ClientId)
-            .WithAuthority(this._azureAdSettings.Authority)
+            .WithAuthority(_azureAdSettings.Authority)
             .WithClientSecret(_azureAdSettings.ClientSecret)
             .Build();
 
@@ -35,8 +37,8 @@ namespace ntbs_service.Services
             var authProvider = new ClientCredentialProvider(clientApplication, scopes);
 
 
-            this._graphServiceClient = new GraphServiceClient(authProvider);
-            return new AzureAdDirectoryService(this._graphServiceClient, this._azureAdSettings);
+            _graphServiceClient = new GraphServiceClient(authProvider);
+            return new AzureAdDirectoryService(_graphServiceClient, _adSettings);
         }
     }
 }

--- a/ntbs-service/Services/UserService.cs
+++ b/ntbs-service/Services/UserService.cs
@@ -24,20 +24,19 @@ namespace ntbs_service.Services
         Task<IEnumerable<string>> GetPhecCodesAsync(ClaimsPrincipal user);
         Task RecordUserLoginAsync(string username);
         Task<User> GetUser(ClaimsPrincipal user);
-
-        Task<string> GetUserDisplayName(ClaimsPrincipal user);
+        string GetUserDisplayName(ClaimsPrincipal user);
     }
 
     public class UserService : IUserService
     {
-        private readonly AdfsOptions _config;
+        private readonly AdOptions _config;
         private readonly IReferenceDataRepository _referenceDataRepository;
         private readonly IUserRepository _userRepository;
 
         public UserService(
             IReferenceDataRepository referenceDataRepository,
             IUserRepository userRepository,
-            IOptionsMonitor<AdfsOptions> options)
+            IOptionsMonitor<AdOptions> options)
         {
             _referenceDataRepository = referenceDataRepository;
             _userRepository = userRepository;
@@ -116,9 +115,9 @@ namespace ntbs_service.Services
             });
         }
 
-        public async Task<string> GetUserDisplayName(ClaimsPrincipal user)
+        public string GetUserDisplayName(ClaimsPrincipal user)
         {
-            string displayName = NameFormattingHelper.FormatDisplayName(user.Identity.Name);
+            var displayName = NameFormattingHelper.FormatDisplayName(user.Identity.Name);
 
             if (displayName.Contains("@"))
             {

--- a/ntbs-service/appsettings.CI.json
+++ b/ntbs-service/appsettings.CI.json
@@ -3,7 +3,7 @@
     "AuditingEnabled": false,
     "LegacySearchEnabled": false
   },
-  "AdfsOptions": {
+  "AdOptions": {
     "UseDummyAuth": true
   },
   "Hangfire": {

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -1,9 +1,11 @@
 {
-  "AdfsOptions": {
-    "Wtrealm": "https://localhost:5001/",
+  "AdOptions": {
     "DevGroup": "Global.NIS.NTBS.NTS",
     "AdminUserGroup": "Global.NIS.NTBS.Admin",
     "UseDummyAuth": false
+  },
+  "AdfsOptions": {
+    "Wtrealm": "https://localhost:5001/"
   },
   "AzureAdOptions": {
     "ClientId": "<Provided by deployment secrets>",

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -1,19 +1,20 @@
 {
   "AllowedHosts": "*",
+  "AdOptions": {
+      "BaseUserGroup": "Global.NIS.NTBS",
+      "AdminUserGroup": "Global.NIS.NTBS.ADMIN",
+      "NationalTeamAdGroup": "Global.NIS.NTBS.NTS",
+      "ServiceGroupAdPrefix": "Global.NIS.NTBS.Service"
+  },
   "AdfsOptions": {
-    "AdfsUrl": "https://fs-ntbs.uksouth.cloudapp.azure.com",
-    "BaseUserGroup": "Global.NIS.NTBS",
-    "AdminUserGroup": "Global.NIS.NTBS.ADMIN",
-    "NationalTeamAdGroup": "Global.NIS.NTBS.NTS",
-    "ServiceGroupAdPrefix": "Global.NIS.NTBS.Service"
+    "AdfsUrl": "https://fs-ntbs.uksouth.cloudapp.azure.com"
   },
   "AzureAdOptions": {
-    "ClientId":"<Provided by deployment secrets>",
+    "ClientId": "<Provided by deployment secrets>",
     "ClientSecret": "<Provided by deployment secrets>",
     "Authority": "<Provided by deployment secrets>",
     "CallbackPath": "/signin-oidc",
-    "Enabled": false,
-    "BaseUserGroup": "Global.NIS.NTBS"
+    "Enabled": false
   },
   "AppConfig": {
     "AuditingEnabled": true,

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -42,6 +42,23 @@ spec:
               value: "https://fs.caduceus.phe.gov.uk"
             - name: AdfsOptions__Wtrealm
               value: "https://ntbs.phe.nhs.uk/"
+            - name: AzureAdOptions__ClientId
+              valueFrom:
+                secretKeyRef:
+                  name: uat-phe-azuread-options
+                  key: clientId
+            - name: AzureAdOptions__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: uat-phe-azuread-options
+                  key: clientSecret
+            - name: AzureAdOptions__Authority
+              valueFrom:
+                secretKeyRef:
+                  name: uat-phe-azuread-options
+                  key: authority
+            - name: AzureAdOptions__Enabled
+              value: "true"
             - name: AppConfig__AuditingEnabled
               value: "true"
             - name: ConnectionStrings__ntbsContext
@@ -82,7 +99,7 @@ spec:
             - name: ExternalLinks__ReportingUri
               value: ""
             - name: HttpBasicAuth__Enabled
-              value: "true"
+              value: "false"
             - name: HttpBasicAuth__Username
               valueFrom:
                 secretKeyRef:

--- a/ntbs-service/deployments/uat-phe.yml
+++ b/ntbs-service/deployments/uat-phe.yml
@@ -42,6 +42,23 @@ spec:
               value: "https://fs.caduceus.phe.gov.uk"
             - name: AdfsOptions__Wtrealm
               value: "https://ntbs-uat.phe.nhs.uk/"
+            - name: AzureAdOptions__ClientId
+              valueFrom:
+                secretKeyRef:
+                  name: uat-phe-azuread-options
+                  key: clientId
+            - name: AzureAdOptions__ClientSecret
+              valueFrom:
+                secretKeyRef:
+                  name: uat-phe-azuread-options
+                  key: clientSecret
+            - name: AzureAdOptions__Authority
+              valueFrom:
+                secretKeyRef:
+                  name: uat-phe-azuread-options
+                  key: authority
+            - name: AzureAdOptions__Enabled
+              value: "true"
             - name: ConnectionStrings__ntbsContext
               valueFrom:
                 secretKeyRef:
@@ -80,7 +97,7 @@ spec:
             - name: ExternalLinks__ReportingUri
               value: ""
             - name: HttpBasicAuth__Enabled
-              value: "true"
+              value: "false"
             - name: HttpBasicAuth__Username
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Move the AD groups into their own section of the config
Update the deployment files for live and phe-uat to use Azure AD (they're already using it, but the deployment files don't reflect that).

## Checklist:
- [x] Automated tests are passing locally.
