### PR TITLE
NTBS-2074: Fix notification cloning service for dotnet 5.0

### DIFF
--- a/ntbs-service/Services/NotificationCloningService.cs
+++ b/ntbs-service/Services/NotificationCloningService.cs
@@ -26,7 +26,6 @@ namespace ntbs_service.Services
             // 2. wiping the id (setting to 0)
             // 3. being added to the context anew
             
-            _context.Entry(notification).State = EntityState.Detached;
             _context.Entry(notification.ClinicalDetails).State = EntityState.Detached;
             _context.Entry(notification.ComorbidityDetails).State = EntityState.Detached;
             _context.Entry(notification.ContactTracing).State = EntityState.Detached;
@@ -37,13 +36,14 @@ namespace ntbs_service.Services
             _context.Entry(notification.MBovisDetails).State = EntityState.Detached;
             _context.Entry(notification.PatientDetails).State = EntityState.Detached;
             _context.Entry(notification.PreviousTbHistory).State = EntityState.Detached;
-            _context.Entry(notification.SocialRiskFactors).State = EntityState.Detached;
             _context.Entry(notification.SocialRiskFactors.RiskFactorDrugs).State = EntityState.Detached;
             _context.Entry(notification.SocialRiskFactors.RiskFactorHomelessness).State = EntityState.Detached;
             _context.Entry(notification.SocialRiskFactors.RiskFactorImprisonment).State = EntityState.Detached;
             _context.Entry(notification.SocialRiskFactors.RiskFactorSmoking).State = EntityState.Detached;
+            _context.Entry(notification.SocialRiskFactors).State = EntityState.Detached;
             _context.Entry(notification.TravelDetails).State = EntityState.Detached;
             _context.Entry(notification.VisitorDetails).State = EntityState.Detached;
+            _context.Entry(notification).State = EntityState.Detached;
             notification.NotificationId = 0;
             notification.GroupId = null;
             


### PR DESCRIPTION
## Description
Not sure why this didn't show up before the merge into master, looks like a change in tracking means we needed to detach the notification after navigating to it's properties.

## Checklist:
- [ ] Automated tests are passing locally.