### PR TITLE
NTBS-2119: Re-add accidentally removed alert details on index

### DIFF
--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -69,6 +69,11 @@
                                     @Html.DisplayFor(_ => item.FormattedCreationDate)
                                 </nhs-table-item>
                                 <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.AlertType)">
+                                <a href="@item.ActionLink">
+                                    @Html.DisplayFor(_ => item.AlertType)
+                                    </a>
+                                    <br />
+                                    @Html.DisplayFor(_ => item.Action)
                                 </nhs-table-item>
                                 <nhs-table-item heading-text="@Html.DisplayNameFor(_ => item.CaseManagerName)<br />@Html.DisplayNameFor(model => model.Alerts[0].TbServiceName)">
                                     @if (!string.IsNullOrWhiteSpace(item.CaseManagerName))


### PR DESCRIPTION
## Description
Benji accidentally removed alert type and action from the alert table on index. Not sure how this didn't break any tests - maybe something to look into. 

## Checklist:
- [x] Automated tests are passing locally.
