### PR TITLE
NTBS-2085 QA - Fix heading size for post mortem question

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
@@ -421,7 +421,9 @@
         </nhs-form-group>
 
     <nhs-fieldset>
-        <nhs-fieldset-legend nhs-legend-size="Standard">@Html.DisplayNameFor(m => m.ClinicalDetails.IsPostMortem)</nhs-fieldset-legend>
+        <nhs-fieldset-legend nhs-legend-size="Standard">
+            <h2> @Html.DisplayNameFor(m => m.ClinicalDetails.IsPostMortem) </h2>
+        </nhs-fieldset-legend>
         <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
             <div class="nhsuk-radios__item">
                 <input asp-for="ClinicalDetails.IsPostMortem" id="postmortem-yes" class="nhsuk-radios__input" type="radio" value="true" data-aria-controls="conditional-postmortem-conditional">


### PR DESCRIPTION
## Description
Change to it having its own section header (h2) instead of a small (p)
(p) question label as it was before.

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
This is such a trivial change (just wrapping a small amount of text in a `<h2>` tag it didn't need a full set of accessibility testing.
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
