### PR TITLE
NTBS-NONE Fix EF ownership issue for drug resistance job

### DIFF
--- a/ntbs-service-unit-tests/Services/DrugResistanceProfileServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/DrugResistanceProfileServiceTest.cs
@@ -47,16 +47,32 @@ namespace ntbs_service_unit_tests.Services
         };
 
         private readonly NotificationForDrugResistanceImport mockNotificationWithMdr =
-            new NotificationForDrugResistanceImport { NotificationId = 1, DrugResistanceProfile = drpWithMdr };
+            new NotificationForDrugResistanceImport
+            {
+                Notification = new Notification { NotificationId = 1 },
+                DrugResistanceProfile = drpWithMdr
+            };
 
         private readonly NotificationForDrugResistanceImport mockNotificationWithoutMdr =
-            new NotificationForDrugResistanceImport { NotificationId = 2, DrugResistanceProfile = drpWithoutMdr };
+            new NotificationForDrugResistanceImport
+            {
+                Notification = new Notification { NotificationId = 2 },
+                DrugResistanceProfile = drpWithoutMdr
+            };
 
         private readonly NotificationForDrugResistanceImport mockNotificationWithMbovis =
-            new NotificationForDrugResistanceImport { NotificationId = 3, DrugResistanceProfile = drpWithMbovis };
+            new NotificationForDrugResistanceImport
+            {
+                Notification = new Notification { NotificationId = 3 },
+                DrugResistanceProfile = drpWithMbovis
+            };
 
         private readonly NotificationForDrugResistanceImport mockNotificationWithoutMbovis =
-            new NotificationForDrugResistanceImport { NotificationId = 4, DrugResistanceProfile = drpWithoutMbovis };
+            new NotificationForDrugResistanceImport
+            {
+                Notification = new Notification { NotificationId = 4 },
+                DrugResistanceProfile = drpWithoutMbovis
+            };
 
         public DrugResistanceProfileServiceTest()
         {
@@ -253,7 +269,7 @@ namespace ntbs_service_unit_tests.Services
         {
             return Task.FromResult(new NotificationForDrugResistanceImport
             {
-                NotificationId = notificationId,
+                Notification = new Notification { NotificationId = notificationId },
                 DrugResistanceProfile = new DrugResistanceProfile()
             });
         }

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -113,12 +113,12 @@ namespace ntbs_service.DataAccess
                 .Select(
                     n => new NotificationForDrugResistanceImport
                     {
-                        NotificationId = n.NotificationId,
+                        Notification = n,
                         DrugResistanceProfile = n.DrugResistanceProfile,
                         TreatmentRegimen = n.ClinicalDetails.TreatmentRegimen,
                         ExposureToKnownCaseStatus = n.MDRDetails.ExposureToKnownCaseStatus
                     })
-                .SingleOrDefaultAsync(n => n.NotificationId == notificationId);
+                .SingleOrDefaultAsync(n => n.Notification.NotificationId == notificationId);
         }
 
         public async Task<bool> NotificationWithLegacyIdExistsAsync(string id)

--- a/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
+++ b/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
@@ -14,11 +14,13 @@ namespace ntbs_service.Models.Projections
 
     public class NotificationForDrugResistanceImport : INotificationForDrugResistanceImport
     {
-        public int NotificationId { get; set; }
+        public Notification Notification { get; set; }
+
         public DrugResistanceProfile DrugResistanceProfile { get; set; }
         public TreatmentRegimen? TreatmentRegimen { get; set; }
         public Status? ExposureToKnownCaseStatus { get; set; }
 
+        public int NotificationId => Notification.NotificationId;
         public bool IsMdr => DrugResistanceHelper.IsMdr(DrugResistanceProfile, TreatmentRegimen, ExposureToKnownCaseStatus);
 
         public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile);


### PR DESCRIPTION
## Description

Fixed an issue introduced when upgrading to .NET 5 (well the change was
made in v2 -> v3), where owned entities cannot be queried without the
owner using a tracking query. This has been causing some errors on
Sentry, but should now be fixed.

Fix by adding a notification to the NotificationForDrugResistanceImport
class, instead of just its ID, because this object is owned by the
Notification object.

## Checklist:
- [x] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.