### PR TITLE
NTBS-NONE Fix issues with migrations caused by .NET 5 upgrade

### DIFF
--- a/ntbs-service/Migrations/20191217111302_UpdateSampleTbServiceMappings.cs
+++ b/ntbs-service/Migrations/20191217111302_UpdateSampleTbServiceMappings.cs
@@ -7,20 +7,20 @@ namespace ntbs_service.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             //                          table, key column,   key value, change column, change value
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0040", "ServiceAdGroup", "Global.NIS.NTBS.Service_Hull");
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0107", "ServiceAdGroup", "Global.NIS.NTBS.Service_Leicester");
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0116", "ServiceAdGroup", "Global.NIS.NTBS.Service_Luton");
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0178", "ServiceAdGroup", "Global.NIS.NTBS.Service_Bolton");
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0040", "ServiceAdGroup", "Global.NIS.NTBS.Service_Hull");
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0107", "ServiceAdGroup", "Global.NIS.NTBS.Service_Leicester");
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0116", "ServiceAdGroup", "Global.NIS.NTBS.Service_Luton");
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0178", "ServiceAdGroup", "Global.NIS.NTBS.Service_Bolton");
 
             migrationBuilder.UpdateData("PHEC", "Code", "PHECNI", "AdGroup", "Global.NIS.NTBS.NI");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0040", "ServiceAdGroup", null);
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0107", "ServiceAdGroup", null);
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0116", "ServiceAdGroup", null);
-            migrationBuilder.UpdateData("TBService", "Code", "TBS0178", "ServiceAdGroup", null);
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0040", "ServiceAdGroup", null);
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0107", "ServiceAdGroup", null);
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0116", "ServiceAdGroup", null);
+            migrationBuilder.UpdateData("TbService", "Code", "TBS0178", "ServiceAdGroup", null);
 
             migrationBuilder.UpdateData("PHEC", "Code", "PHECNI", "AdGroup", null);
         }

--- a/ntbs-service/Migrations/20200422211917_AddPCTtoPostcodesTable.Designer.cs
+++ b/ntbs-service/Migrations/20200422211917_AddPCTtoPostcodesTable.Designer.cs
@@ -15677,6 +15677,8 @@ namespace ntbs_service.Migrations
 
                     b.Property<string>("LocalAuthorityCode");
 
+                    b.Property<string>("PCT");
+
                     b.HasKey("Postcode");
 
                     b.HasIndex("LocalAuthorityCode");

--- a/ntbs-service/Migrations/20200422211917_AddPCTtoPostcodesTable.cs
+++ b/ntbs-service/Migrations/20200422211917_AddPCTtoPostcodesTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using CsvHelper;
@@ -10,8 +10,8 @@ namespace ntbs_service.Migrations
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql("ALTER TABLE [ReferenceData].PostcodeLookup ADD PCT varchar(10)");
-            
+            migrationBuilder.AddColumn<string>("PCT", table: "PostcodeLookup", type: "varchar(10)", schema: "ReferenceData", nullable: true);
+
             var pathToFile = Path.Combine(Environment.CurrentDirectory, "Models/SeedData/Postcodes.csv");
             const int itemsPerUpdate = 1000;
 
@@ -56,13 +56,13 @@ namespace ntbs_service.Migrations
                     keyValues: postcodeArray,
                     column: "PCT",
                     values: pctArray
-                );             
+                );
             }
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.Sql(@"ALTER TABLE ReferenceData.PostcodeLookup DROP PCT");
+            migrationBuilder.DropColumn("PCT", "PostcodeLookup", schema: "ReferenceData");
         }
     }
 }

--- a/ntbs-service/Migrations/20200604214722_AddAnchorLinkToFAQ.Designer.cs
+++ b/ntbs-service/Migrations/20200604214722_AddAnchorLinkToFAQ.Designer.cs
@@ -88,6 +88,8 @@ namespace ntbs_service.Migrations
                         .ValueGeneratedOnAdd()
                         .HasAnnotation("SqlServer:ValueGenerationStrategy", SqlServerValueGenerationStrategy.IdentityColumn);
 
+                    b.Property<string>("AnchorLink");
+
                     b.Property<string>("Answer");
 
                     b.Property<int>("OrderIndex")


### PR DESCRIPTION
I have confirmed that we can now run through all the migrations when setting up a new environment.