### PR TITLE
NBTS-1997 and 1958 Add automatic MDR alert dismissal

### DIFF
--- a/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
@@ -19,12 +19,25 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Theory]
-        [InlineData("RR/MDR/XDR", false, true, false)]
-        [InlineData("RR/MDR/XDR", true, true, false)]
-        [InlineData("NonMDR", false, false, true)]
-        [InlineData("NonMDR", true, true, false)]
+        [InlineData("RR/MDR/XDR", false, null, true, false)]
+        [InlineData("RR/MDR/XDR", false, Status.Unknown, false, true)]
+        [InlineData("RR/MDR/XDR", false, Status.No, false, true)]
+        [InlineData("RR/MDR/XDR", false, Status.Yes, false, true)]
+        [InlineData("RR/MDR/XDR", true, null, true, false)]
+        [InlineData("RR/MDR/XDR", true, Status.Unknown, false, true)]
+        [InlineData("RR/MDR/XDR", true, Status.No, false, true)]
+        [InlineData("RR/MDR/XDR", true, Status.Yes, false, true)]
+        [InlineData("NonMDR", false, null, false, true)]
+        [InlineData("NonMDR", false, Status.Unknown, false, true)]
+        [InlineData("NonMDR", false, Status.No, false, true)]
+        [InlineData("NonMDR", false, Status.Yes, false, true)]
+        [InlineData("NonMDR", true, null, true, false)]
+        [InlineData("NonMDR", true, Status.Unknown, false, true)]
+        [InlineData("NonMDR", true, Status.No, false, true)]
+        [InlineData("NonMDR", true, Status.Yes, false, true)]
         public void CreateOrDismissMdrAlert(string drugResistance,
             bool isMdrPlanned,
+            Status? mdrExposureStatus,
             bool shouldCreateAlert,
             bool shouldDismissAlert)
         {
@@ -40,6 +53,10 @@ namespace ntbs_service_unit_tests.Services
                 ClinicalDetails = new ClinicalDetails
                 {
                     TreatmentRegimen = isMdrPlanned ? TreatmentRegimen.MdrTreatment : TreatmentRegimen.StandardTherapy
+                },
+                MDRDetails = new MDRDetails
+                {
+                    ExposureToKnownCaseStatus = mdrExposureStatus
                 }
             };
 

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -117,6 +117,7 @@ namespace ntbs_service.DataAccess
                     {
                         Notification = n,
                         DrugResistanceProfile = n.DrugResistanceProfile,
+                        MDRDetails = n.MDRDetails,
                         TreatmentRegimen = n.ClinicalDetails.TreatmentRegimen,
                         ExposureToKnownCaseStatus = n.MDRDetails.ExposureToKnownCaseStatus
                     })

--- a/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
+++ b/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
@@ -8,6 +8,7 @@ namespace ntbs_service.Models.Projections
     {
         int NotificationId { get; }
         DrugResistanceProfile DrugResistanceProfile { get; }
+        MDRDetails MDRDetails { get; }
         bool IsMdr { get; }
         bool IsMBovis { get; }
     }
@@ -19,6 +20,7 @@ namespace ntbs_service.Models.Projections
         public DrugResistanceProfile DrugResistanceProfile { get; set; }
         public TreatmentRegimen? TreatmentRegimen { get; set; }
         public Status? ExposureToKnownCaseStatus { get; set; }
+        public MDRDetails MDRDetails { get; set; }
 
         public int NotificationId => Notification.NotificationId;
         public bool IsMdr => DrugResistanceHelper.IsMdr(DrugResistanceProfile, TreatmentRegimen, ExposureToKnownCaseStatus);

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -16,6 +16,7 @@ namespace ntbs_service.Pages.Notifications.Edit
     public class MDRDetailsModel : NotificationEditModelBase
     {
         private readonly IReferenceDataRepository _referenceDataRepository;
+        private readonly IEnhancedSurveillanceAlertsService _enhancedSurveillanceAlertsService;
         public List<string> RenderConditionalCountryFieldIds;
 
         public MDRDetailsModel(
@@ -23,6 +24,7 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
+            IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
             IAlertRepository alertRepository) : base(service,
             authorizationService,
             notificationRepository,
@@ -30,6 +32,7 @@ namespace ntbs_service.Pages.Notifications.Edit
         {
             CurrentPage = NotificationSubPaths.EditMDRDetails;
             _referenceDataRepository = referenceDataRepository;
+            _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;
         }
 
         [BindProperty]
@@ -89,6 +92,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             if (TryValidateModel(MDRDetails, nameof(MDRDetails)))
             {
                 await Service.UpdateMDRDetailsAsync(Notification, MDRDetails);
+
+                await _enhancedSurveillanceAlertsService.CreateOrDismissMdrAlert(Notification);
             }
         }
 

--- a/ntbs-service/Services/EnhancedSurveillanceAlertsService.cs
+++ b/ntbs-service/Services/EnhancedSurveillanceAlertsService.cs
@@ -21,7 +21,7 @@ namespace ntbs_service.Services
 
         public async Task CreateOrDismissMdrAlert(INotificationForDrugResistanceImport notification)
         {
-            if (notification.IsMdr)
+            if (notification.IsMdr && !notification.MDRDetails.MDRDetailsEntered)
             {
                 await CreateMdrAlert(notification);
             }


### PR DESCRIPTION
This PR is primarily to fix NTBS-1997, but the changes to `CreateOrDismissAlert` should also fix NTBS-1958 for free.

## Description
Dismiss a notification's MDR alert when the user fills in its MDR questionnaire. Do this by running `EnhancedSurveillanceAlertsService.CreateOrDismissMdrAlert` after editing the MDR questionnaire.

Modify the `CreateOrDismissAlert` service method to check whether the questionnaire has been filled out when deciding whether to create or dismiss the alert. To do this, also add MDR data to the `NotificationForDrugResistanceImport` projection. This adds in a few fields but hopefully will not have a significant impact on the performance of the `DrugResistanceProfileUpdateJob`.

Amend the `EnhancedSurveillanceAlertsService` tests to cover this new logic.

## Checklist:
- [x] Automated tests are passing locally.
- [ ] Check performance of the `DrugResistanceProfileUpdateJob`, for a model that it depends on has had some fields added. I don't know how to do this, please could someone give me a hand with this?