### PR TITLE
NTBS-2074: Fix sentry warnings

### DIFF
--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -353,6 +353,7 @@ AND (N1.[GroupId] <> N2.[GroupId] OR N1.[GroupId] is NULL or N2.[GroupId] is NUL
                             && n.NotificationStatus != NotificationStatus.Denotified)
                 // And make sure it doesn't have this type of alert already
                 .Where(n => !n.Alerts.Any(a => a is T))
+                .OrderBy(n => n.NotificationId)
                 .AsSplitQuery();
         }
     }

--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -352,7 +352,8 @@ AND (N1.[GroupId] <> N2.[GroupId] OR N1.[GroupId] is NULL or N2.[GroupId] is NUL
                             && n.NotificationStatus != NotificationStatus.Deleted
                             && n.NotificationStatus != NotificationStatus.Denotified)
                 // And make sure it doesn't have this type of alert already
-                .Where(n => !n.Alerts.Any(a => a is T));
+                .Where(n => !n.Alerts.Any(a => a is T))
+                .AsSplitQuery();
         }
     }
 }

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using EFAuditer;
 using Microsoft.EntityFrameworkCore;
+using MoreLinq;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
@@ -329,6 +330,7 @@ namespace ntbs_service.DataAccess
                 .Include(g => g.Notifications)
                     .ThenInclude(n => n.HospitalDetails)
                         .ThenInclude(e => e.CaseManager)
+                .OrderBy(n => n.NotificationGroupId)
                 .AsSplitQuery()
                 .SingleOrDefaultAsync();
         }
@@ -344,6 +346,7 @@ namespace ntbs_service.DataAccess
                 .Include(n => n.SocialContextVenues)
                 .Include(n => n.TreatmentEvents)
                     .ThenInclude(t => t.TreatmentOutcome)
+                .OrderBy(n => n.NotificationId)
                 .AsSplitQuery();
         }
 

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -296,6 +296,7 @@ namespace ntbs_service.DataAccess
                     .ThenInclude(t => t.TreatmentOutcome)
                 .Where(n => n.NotificationStatus == NotificationStatus.Notified)
                 .Where(n => n.TreatmentEvents.Any(t => t.TreatmentOutcome != null))
+                .AsSplitQuery()
                 .ToListAsync())
                 .Where(n =>
                 {
@@ -346,8 +347,7 @@ namespace ntbs_service.DataAccess
                 .Include(n => n.SocialContextVenues)
                 .Include(n => n.TreatmentEvents)
                     .ThenInclude(t => t.TreatmentOutcome)
-                .OrderBy(n => n.NotificationId)
-                .AsSplitQuery();
+                .OrderBy(n => n.NotificationId);
         }
 
         // Gets Notification model with basic information for use in notifications homepage lists.
@@ -361,7 +361,8 @@ namespace ntbs_service.DataAccess
                             .ThenInclude(la => la.LocalAuthorityToPHEC)
                                 .ThenInclude(pl => pl.PHEC)
                 .Include(n => n.HospitalDetails.TBService.PHEC)
-                .Include(n => n.HospitalDetails.CaseManager);
+                .Include(n => n.HospitalDetails.CaseManager)
+                .AsSplitQuery();
         }
 
         public IQueryable<Notification> GetBaseNotificationsIQueryable()

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -362,6 +362,7 @@ namespace ntbs_service.DataAccess
                                 .ThenInclude(pl => pl.PHEC)
                 .Include(n => n.HospitalDetails.TBService.PHEC)
                 .Include(n => n.HospitalDetails.CaseManager)
+                .OrderBy(n => n.NotificationId)
                 .AsSplitQuery();
         }
 

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -296,6 +296,7 @@ namespace ntbs_service.DataAccess
                     .ThenInclude(t => t.TreatmentOutcome)
                 .Where(n => n.NotificationStatus == NotificationStatus.Notified)
                 .Where(n => n.TreatmentEvents.Any(t => t.TreatmentOutcome != null))
+                .OrderBy(n => n.NotificationId)
                 .AsSplitQuery()
                 .ToListAsync())
                 .Where(n =>

--- a/ntbs-service/Helpers/SessionStateHelper.cs
+++ b/ntbs-service/Helpers/SessionStateHelper.cs
@@ -12,8 +12,8 @@ namespace ntbs_service.Helpers
 
         public static bool IsUpdatedRecently(ISession session)
         {
-            var date = DateTime.Parse(session.GetString("LastActivityTimestamp"));
-            return date.AddMinutes(30) > DateTime.Now;
+            var activityTimestamp = session.GetString("LastActivityTimestamp");
+            return activityTimestamp == null || DateTime.Parse(activityTimestamp).AddMinutes(30) > DateTime.Now;
         }
     }
 }

--- a/ntbs-service/Helpers/SessionStateHelper.cs
+++ b/ntbs-service/Helpers/SessionStateHelper.cs
@@ -13,7 +13,7 @@ namespace ntbs_service.Helpers
         public static bool IsUpdatedRecently(ISession session)
         {
             var activityTimestamp = session.GetString("LastActivityTimestamp");
-            return activityTimestamp == null || DateTime.Parse(activityTimestamp).AddMinutes(30) > DateTime.Now;
+            return activityTimestamp != null && DateTime.Parse(activityTimestamp).AddMinutes(30) > DateTime.Now;
         }
     }
 }

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -575,16 +575,16 @@ namespace ntbs_service
             app.UseCookiePolicy();
             app.UseSession();
 
+            if (!Env.IsEnvironment("CI"))
+            {
+                app.UseMiddleware<ActivityDetectionMiddleware>();
+            }
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
                 endpoints.MapControllers();
             });
-
-            if (!Env.IsEnvironment("CI"))
-            {
-                app.UseMiddleware<ActivityDetectionMiddleware>();
-            }
 
             if (Configuration.GetValue<bool>(Constants.AuditEnabledConfigValue))
             {

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -580,16 +580,16 @@ namespace ntbs_service
                 app.UseMiddleware<ActivityDetectionMiddleware>();
             }
 
+            if (Configuration.GetValue<bool>(Constants.AuditEnabledConfigValue))
+            {
+                app.UseMiddleware<AuditGetRequestMiddleWare>();
+            }
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
                 endpoints.MapControllers();
             });
-
-            if (Configuration.GetValue<bool>(Constants.AuditEnabledConfigValue))
-            {
-                app.UseMiddleware<AuditGetRequestMiddleWare>();
-            }
 
             ConfigureHangfire(app);
 


### PR DESCRIPTION
## Description
I have fixed 3 warnings/errors we were getting on sentry due to the .NET upgrade.
Our heartbeat code wasn't checking for null, which meant if we hadn't set a "latest activity time" it would throw an error when trying to compare it. I have set this to default to true.
I have added query splitting where I had missed it previously.
I have fixed a warning about using skip/take without ordering. This one is a sort of "bug" in .NET, where using query splitting results in needing an orderby. (link to issue: https://github.com/dotnet/efcore/issues/23803). 

## Checklist:
- [x] Automated tests are passing locally.
