### PR TITLE
NTBS-2100 Make Health status page for admins only

### DIFF
--- a/ntbs-service/Pages/Health.cshtml.cs
+++ b/ntbs-service/Pages/Health.cshtml.cs
@@ -1,9 +1,11 @@
-﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Configuration;
 using ntbs_service.Properties;
 
 namespace ntbs_service.Pages
 {
+    [Authorize(Policy = "AdminOnly")]
     public class Health : PageModel
     {
         public Health(IConfiguration configuration)

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -143,7 +143,6 @@ namespace ntbs_service
             {
                 options.Conventions.AllowAnonymousToPage("/Account/AccessDenied");
                 options.Conventions.AllowAnonymousToPage("/Logout");
-                options.Conventions.AllowAnonymousToPage("/WhoAmI");
             });
 
             services.AddAuthorization(options =>

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -143,7 +143,6 @@ namespace ntbs_service
             {
                 options.Conventions.AllowAnonymousToPage("/Account/AccessDenied");
                 options.Conventions.AllowAnonymousToPage("/Logout");
-                options.Conventions.AllowAnonymousToPage("/Health");
                 options.Conventions.AllowAnonymousToPage("/WhoAmI");
             });
 


### PR DESCRIPTION
## Description
Stop anonymous access to the Health page, and require Admin user policy, based on security audit advice.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Cannot access `Health` when not logged in, and not logged in as an admin (using the Birmingham test user account)