### PR TITLE
NTBS-2101 Use Antiforgery tokens in Hangfire dashboard

### DIFF
--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -611,9 +611,6 @@ namespace ntbs_service
             {
                 Authorization = new[] { new HangfireAuthorisationFilter(GetAdminRoleName()) },
                 DisplayStorageConnectionString = false,
-                // Added to squash intermittent 'The required antiforgery cookie token must be provided' exceptions
-                // Does not pose a significant attack vector as all jobs are essentially idempotent.
-                IgnoreAntiforgeryToken = true
             };
             app.UseHangfireDashboard("/hangfire", dashboardOptions);
             app.UseHangfireServer(new BackgroundJobServerOptions

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -6,7 +6,7 @@ spec:
   selector:
     matchLabels:
       app: ntbs-int
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Description

Stop ignoring antiforgery tokens for Hangfire requests. This may cause issues with multiple instances of the app behind a load balancer, if they do not share the same keys, but this should not be the case.

I believe this workaround was added because keys were not shared between instances of an app at the time, but this was added a few weeks later, so should just work now. I've not managed to test this locally, though I think I might be able to give it a go. Otherwise, maybe we could edit one of the running environments to have multiple replicas of the app behind the existing load balancer for testing? I believe the issue that was experienced in the past was that the page was being served by one replica, but the POST requests received by another, and they didn't know how to verify CSRF tokens from the other sites, but they should do now.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Reproduced a CRSF attack on the Hangfire dashboard, that then failed after I made this change