### PR TITLE
NTBS-2062: Set users as legacy during user sync job

### DIFF
--- a/ntbs-service-unit-tests/Services/AdImportServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AdImportServiceTest.cs
@@ -30,11 +30,12 @@ namespace ntbs_service_unit_tests.Services
 
             var referenceRepo = new ReferenceDataRepository(_context);
             var userRepo = new UserRepository(_context);
+            var adUserService = new AdUserService(userRepo);
             
             _adImportService = new AdImportService(
                 _adDirectoryServiceFactoryMock.Object,
                 referenceRepo,
-                userRepo);
+                adUserService);
         }
 
         public void Dispose()

--- a/ntbs-service-unit-tests/Services/AdImportServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AdImportServiceTest.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Novell.Directory.Ldap;
+using ntbs_service.DataAccess;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.ReferenceEntities;
+using ntbs_service.Services;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Services
+{
+    public class AdImportServiceTest : IDisposable
+    {
+        private readonly AdImportService _adImportService;
+        private readonly Mock<IAdDirectoryServiceFactory> _adDirectoryServiceFactoryMock = new Mock<IAdDirectoryServiceFactory>();
+        private readonly Mock<AdDirectoryService> _adDirectoryServiceMock = new Mock<AdDirectoryService> { CallBase = true };
+        private List<LdapEntry> _adUsers;
+        private NtbsContext _context;
+
+        public AdImportServiceTest()
+        {
+            _context = SetupTestContext();
+            
+            _adUsers = new List<LdapEntry>();
+            var adDirectoryService = SetupMockAdDirectoryService();
+            _adDirectoryServiceFactoryMock.Setup(s => s.Create()).Returns(adDirectoryService);
+
+            var referenceRepo = new ReferenceDataRepository(_context);
+            var userRepo = new UserRepository(_context);
+            
+            _adImportService = new AdImportService(
+                _adDirectoryServiceFactoryMock.Object,
+                referenceRepo,
+                userRepo);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+        [Fact]
+        public async void UserSyncJobImportsUserFromAd()
+        {
+            // Arrange
+            GivenUserInAdWithUsernameAndTbService("testerson@phe.ntbs.com", "Global.NIS.NTBS.Service_Nottingham");
+            GivenTbServicesExist(new List<TBService>{new TBService{ServiceAdGroup = "Global.NIS.NTBS.Service_Nottingham"}});
+            
+            // Act
+            await _adImportService.RunCaseManagerImportAsync();
+
+            // Assert
+            var userImported = _context.User.Single();
+            Assert.Equal("testerson@phe.ntbs.com", userImported.Username);
+            Assert.True(userImported.IsActive);
+            Assert.Contains("Global.NIS.NTBS.Service_Nottingham", userImported.AdGroups);
+        }
+        
+        [Fact]
+        public async void UserSyncJobSetsNtbsUserAsLegacyIfNotPresentInAd()
+        {
+            // Arrange
+            GivenUserExistsInNtbs(new User{Username = "ghost@phe.nhs.uk", IsActive = true, AdGroups = "Global.NIS.NTBS.Service_Leeds"});
+            
+            // Act
+            await _adImportService.RunCaseManagerImportAsync();
+
+            // Assert
+            var legacyUser = _context.User.Single(u => u.Username == "ghost@phe.nhs.uk");
+            Assert.False(legacyUser.IsActive);
+            Assert.Null(legacyUser.AdGroups);
+        }
+
+        private void GivenUserExistsInNtbs(User user)
+        {
+            _context.User.Add(user);
+            _context.SaveChanges();
+        }
+
+        private void GivenTbServicesExist(List<TBService> tbServices)
+        {
+            _context.TbService.AddRange(tbServices);
+            _context.SaveChanges();
+        }
+
+        private void GivenUserInAdWithUsernameAndTbService(string username, string tbService)
+        {
+            var userPrincipal = new LdapEntry("CN=First,CN=Users,DC=ntbs,DC=phe,DC=com", new LdapAttributeSet
+            {
+                new LdapAttribute("userPrincipalName", username),
+                new LdapAttribute("givenName", "Test"),
+                new LdapAttribute("sn", "Test Testerson"),
+                new LdapAttribute("displayName", "Test Testerson"),
+                new LdapAttribute("userAccountControl", "512"),
+                new LdapAttribute("memberof",new[] {
+                    $"CN={tbService},CN=Users,DC=ntbs,DC=phe,DC=com"
+                })
+            });
+
+            _adUsers.Add(userPrincipal);
+        }
+
+        private AdDirectoryService SetupMockAdDirectoryService()
+        {
+            _adDirectoryServiceMock.Setup(s => s.GetAllDirectoryEntries()).Returns
+            (
+                _adUsers
+            );
+            return _adDirectoryServiceMock.Object;
+        }
+        
+        private NtbsContext SetupTestContext()
+        {
+            // Generating a unique database name makes sure the database is not shared between tests.
+            string dbName = Guid.NewGuid().ToString();
+            return new NtbsContext(new DbContextOptionsBuilder<NtbsContext>()
+                .UseInMemoryDatabase(dbName)
+                .Options
+            );
+        }
+    }
+}

--- a/ntbs-service/DataAccess/UserRepository.cs
+++ b/ntbs-service/DataAccess/UserRepository.cs
@@ -12,7 +12,7 @@ namespace ntbs_service.DataAccess
         Task AddOrUpdateUser(User user, IEnumerable<TBService> tbServices);
         Task AddUserLoginEvent(UserLoginEvent userLoginEvent);
         Task<User> GetUserByUsername(string username);
-        IQueryable<User> GetUserIQueryable();
+        IQueryable<User> GetUserQueryable();
         Task UpdateUserContactDetails(User user);
         Task<Dictionary<string, string>> GetUsernameDictionary();
     }
@@ -26,7 +26,7 @@ namespace ntbs_service.DataAccess
             _context = context;
         }
 
-        public IQueryable<User> GetUserIQueryable()
+        public IQueryable<User> GetUserQueryable()
         {
             return this._context.User
                 .Include(u => u.CaseManagerTbServices)
@@ -36,7 +36,7 @@ namespace ntbs_service.DataAccess
 
         public async Task AddOrUpdateUser(User user, IEnumerable<TBService> tbServices)
         {
-            var existingUser = await GetUserIQueryable()
+            var existingUser = await GetUserQueryable()
                 .SingleOrDefaultAsync(u => u.Username == user.Username);
 
             if (existingUser != null)
@@ -57,7 +57,7 @@ namespace ntbs_service.DataAccess
 
         public async Task<User> GetUserByUsername(string username)
         {
-            var user = await GetUserIQueryable()
+            var user = await GetUserQueryable()
                 .FirstOrDefaultAsync(u => u.Username.ToLower() == username.ToLower());
             return user;
         }

--- a/ntbs-service/DataAccess/UserRepository.cs
+++ b/ntbs-service/DataAccess/UserRepository.cs
@@ -12,6 +12,7 @@ namespace ntbs_service.DataAccess
         Task AddOrUpdateUser(User user, IEnumerable<TBService> tbServices);
         Task AddUserLoginEvent(UserLoginEvent userLoginEvent);
         Task<User> GetUserByUsername(string username);
+        IQueryable<User> GetUserIQueryable();
         Task UpdateUserContactDetails(User user);
         Task<Dictionary<string, string>> GetUsernameDictionary();
     }
@@ -25,9 +26,17 @@ namespace ntbs_service.DataAccess
             _context = context;
         }
 
+        public IQueryable<User> GetUserIQueryable()
+        {
+            return this._context.User
+                .Include(u => u.CaseManagerTbServices)
+                .ThenInclude(c => c.TbService)
+                .ThenInclude(tb => tb.PHEC);
+        }
+
         public async Task AddOrUpdateUser(User user, IEnumerable<TBService> tbServices)
         {
-            var existingUser = await _context.User.Include(u => u.CaseManagerTbServices)
+            var existingUser = await GetUserIQueryable()
                 .SingleOrDefaultAsync(u => u.Username == user.Username);
 
             if (existingUser != null)
@@ -48,10 +57,7 @@ namespace ntbs_service.DataAccess
 
         public async Task<User> GetUserByUsername(string username)
         {
-            var user = await _context.User
-                .Include(u => u.CaseManagerTbServices)
-                .ThenInclude(c => c.TbService)
-                .ThenInclude(tb => tb.PHEC)
+            var user = await GetUserIQueryable()
                 .FirstOrDefaultAsync(u => u.Username.ToLower() == username.ToLower());
             return user;
         }

--- a/ntbs-service/Services/AdDirectoryService.cs
+++ b/ntbs-service/Services/AdDirectoryService.cs
@@ -63,7 +63,7 @@ namespace ntbs_service.Services
 
         public void Dispose()
         {
-            _connection.Dispose();
+            _connection?.Dispose();
         }
 
         public IEnumerable<(User user, List<TBService> tbServicesMatchingGroups)> LookupUsers(

--- a/ntbs-service/Services/AdDirectoryServiceFactory.cs
+++ b/ntbs-service/Services/AdDirectoryServiceFactory.cs
@@ -8,12 +8,12 @@ namespace ntbs_service.Services
         IAdDirectoryService Create();
     }
 
-    public class AdDirectoryServiceServiceFactory : IAdDirectoryServiceFactory
+    public class AdDirectoryServiceFactory : IAdDirectoryServiceFactory
     {
         private readonly LdapSettings _ldapSettings;
         private readonly AdOptions _adOptions;
 
-        public AdDirectoryServiceServiceFactory(
+        public AdDirectoryServiceFactory(
             IOptions<LdapSettings> LdapSettings,
             IOptions<AdOptions> adfsOptions)
         {

--- a/ntbs-service/Services/AdImportService.cs
+++ b/ntbs-service/Services/AdImportService.cs
@@ -30,19 +30,19 @@ namespace ntbs_service.Services
             var tbServices = await _referenceDataRepository.GetAllTbServicesAsync();
             using (var adDirectoryService = _adDirectoryServiceFactory.Create())
             {
-                var users = adDirectoryService.LookupUsers(tbServices);
+                var users = adDirectoryService.LookupUsers(tbServices).ToList();
                 foreach (var (user, tbServicesMatchingGroups) in users)
                 {
                     Log.Information($"Updating user {user.Username}");
                     await _userRepository.AddOrUpdateUser(user, tbServicesMatchingGroups);
                 }
                 
-                var ntbsUsersNotInAd = (await this._userRepository.GetUsernameDictionary()).Keys
-                    .Where(username => !users.Select(u => u.user.Username).Contains(username));
-                foreach (var username in ntbsUsersNotInAd)
+                var ntbsUsersNotInAd = this._userRepository.GetUserIQueryable()
+                    .Where(user => !users.Select(u => u.user.Username)
+                        .Contains(user.Username)).ToList();
+                foreach (var user in ntbsUsersNotInAd)
                 {
-                    Log.Information($"Removing AD groups from user {username}");
-                    var user = await _userRepository.GetUserByUsername(username);
+                    Log.Information($"Updating user {user.Username}");
                     user.IsActive = false;
                     user.AdGroups = null;
                     await _userRepository.AddOrUpdateUser(user, user.CaseManagerTbServices.Select(cmtb => cmtb.TbService));

--- a/ntbs-service/Services/AdImportService.cs
+++ b/ntbs-service/Services/AdImportService.cs
@@ -14,15 +14,15 @@ namespace ntbs_service.Services
     {
         private readonly IAdDirectoryServiceFactory _adDirectoryServiceFactory;
         private readonly IReferenceDataRepository _referenceDataRepository;
-        private readonly IUserRepository _userRepository;
+        private readonly IAdUserService _adUserService;
 
         public AdImportService(IAdDirectoryServiceFactory adDirectoryServiceFactory,
             IReferenceDataRepository referenceDataRepository,
-            IUserRepository userRepository)
+            IAdUserService adUserService)
         {
             _adDirectoryServiceFactory = adDirectoryServiceFactory;
             _referenceDataRepository = referenceDataRepository;
-            _userRepository = userRepository;
+            _adUserService = adUserService;
         }
 
         public async Task RunCaseManagerImportAsync()
@@ -30,23 +30,8 @@ namespace ntbs_service.Services
             var tbServices = await _referenceDataRepository.GetAllTbServicesAsync();
             using (var adDirectoryService = _adDirectoryServiceFactory.Create())
             {
-                var users = adDirectoryService.LookupUsers(tbServices).ToList();
-                var ntbsUsersNotInAd = this._userRepository.GetUserQueryable()
-                    .Where(user => !users.Select(u => u.user.Username).Contains(user.Username)).ToList();
-                var ntbsUsersNotInAdWithTbServices = ntbsUsersNotInAd.Select(u =>
-                    (u, u.CaseManagerTbServices.Select(cmtb => cmtb.TbService).ToList()));
-                users.AddRange(ntbsUsersNotInAdWithTbServices);
-                foreach (var (user, tbServicesMatchingGroups) in users)
-                {
-                    Log.Information($"Updating user {user.Username}");
-                    if (ntbsUsersNotInAd.Select(u => u.Username).Contains(user.Username))
-                    {
-                        user.IsActive = false;
-                        user.AdGroups = null;
-                    }
-
-                    await _userRepository.AddOrUpdateUser(user, tbServicesMatchingGroups);
-                }
+                var usersInAd = adDirectoryService.LookupUsers(tbServices).ToList();
+                await _adUserService.AddAndUpdateUsers(usersInAd);
             }
         }
     }

--- a/ntbs-service/Services/AdUserService.cs
+++ b/ntbs-service/Services/AdUserService.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ntbs_service.DataAccess;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.ReferenceEntities;
+using Serilog;
+
+namespace ntbs_service.Services
+{
+    public interface IAdUserService
+    {
+        Task AddAndUpdateUsers(List<(User user, List<TBService>)> usersInAd);
+    }
+    public class AdUserService : IAdUserService
+    {
+        private readonly IUserRepository _userRepository;
+        
+        public AdUserService(IUserRepository userRepository)
+        {
+            _userRepository = userRepository;
+        }
+
+        public async Task AddAndUpdateUsers(List<(User user, List<TBService>)> usersInAd)
+        {
+            foreach (var (user, tbServicesMatchingGroups) in usersInAd)
+            {
+                Log.Information($"Updating user {user.Username}");
+                await _userRepository.AddOrUpdateUser(user, tbServicesMatchingGroups);
+            }
+                
+            var ntbsUsersNotInAd = this._userRepository.GetUserQueryable()
+                .Where(user => !usersInAd.Select(u => u.user.Username)
+                    .Contains(user.Username)).ToList();
+            foreach (var user in ntbsUsersNotInAd)
+            {
+                Log.Information($"Updating user {user.Username}");
+                user.IsActive = false;
+                user.AdGroups = null;
+                await _userRepository.AddOrUpdateUser(user, user.CaseManagerTbServices.Select(cmtb => cmtb.TbService));
+            }
+        }
+    }
+}

--- a/ntbs-service/Services/AzureAdImportService.cs
+++ b/ntbs-service/Services/AzureAdImportService.cs
@@ -26,21 +26,20 @@ namespace ntbs_service.Services
             using (var azureAdDirectoryService = _azureAdDirectoryServiceFactory.Create())
             {
                 var users = (await azureAdDirectoryService.LookupUsers(tbServices)).ToList();
+                var ntbsUsersNotInAd = this._userRepository.GetUserQueryable()
+                    .Where(user => !users.Select(u => u.user.Username).Contains(user.Username)).ToList();
+                var ntbsUsersNotInAdWithTbServices = ntbsUsersNotInAd.Select
+                    (u => (u, u.CaseManagerTbServices.Select(cmtb => cmtb.TbService).ToList()));
+                users.AddRange(ntbsUsersNotInAdWithTbServices);
                 foreach (var (user, tbServicesMatchingGroups) in users)
                 {
                     Log.Information($"Updating user {user.Username}");
+                    if (ntbsUsersNotInAd.Select(u => u.Username).Contains(user.Username))
+                    {
+                        user.IsActive = false;
+                        user.AdGroups = null;
+                    }
                     await _userRepository.AddOrUpdateUser(user, tbServicesMatchingGroups);
-                }
-
-                var ntbsUsersNotInAd = this._userRepository.GetUserIQueryable()
-                    .Where(user => !users.Select(u => u.user.Username)
-                        .Contains(user.Username)).ToList();
-                foreach (var user in ntbsUsersNotInAd)
-                {
-                    Log.Information($"Updating user {user.Username}");
-                    user.IsActive = false;
-                    user.AdGroups = null;
-                    await _userRepository.AddOrUpdateUser(user, user.CaseManagerTbServices.Select(cmtb => cmtb.TbService));
                 }
             }
         }

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -215,6 +215,7 @@ namespace ntbs_service
             services.AddScoped<ICaseManagerSearchService, CaseManagerSearchService>();
             services.AddScoped<IClusterImportService, ClusterImportService>();
             services.AddScoped<ICaseManagerImportService, CaseManagerImportService>();
+            services.AddScoped<IAdUserService, AdUserService>();
 
             AddAuditService(services, auditDbConnectionString);
             AddReferenceLabResultServices(services);

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -209,7 +209,7 @@ namespace ntbs_service
             services.AddScoped<IPostcodeService, PostcodeService>();
             services.AddScoped<Services.IAuthorizationService, AuthorizationService>();
             services.AddScoped<ILegacySearchService, LegacySearchService>();
-            services.AddScoped<IAdDirectoryServiceFactory, AdDirectoryServiceServiceFactory>();
+            services.AddScoped<IAdDirectoryServiceFactory, AdDirectoryServiceFactory>();
             services.AddScoped<IEnhancedSurveillanceAlertsService, EnhancedSurveillanceAlertsService>();
             services.AddScoped<INotificationCloningService, NotificationCloningService>();
             services.AddScoped<ICaseManagerSearchService, CaseManagerSearchService>();


### PR DESCRIPTION
## Description
If a user is not found in the AD during user sync we set the user as legacy (`isActive = false`) and remove their AD groups.

## Checklist:
- [x] Automated tests are passing locally.
