### PR TITLE
Ntbs 2146 remove task whenall

### DIFF
--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -123,7 +123,9 @@ namespace ntbs_service.DataMigration
             List<MigrationDbMBovisOccupation> mbovisOccupationExposures,
             List<MigrationDbMBovisMilkConsumption> mbovisUnpasteurisedMilkConsumption)
         {
-            return await Task.WhenAll(legacyIds.Select(async id =>
+            var notificationsToReturn = new List<Notification>();
+
+            foreach (var id in legacyIds)
             {
                 var rawNotification = notifications.Single(n => n.OldNotificationId == id);
                 var notificationSites = AsSites(sitesOfDisease
@@ -191,8 +193,10 @@ namespace ntbs_service.DataMigration
                     notificationMBovisUnpasteurisedMilkConsumption.Any();
                 notification.MBovisDetails.MBovisUnpasteurisedMilkConsumptions =
                     notificationMBovisUnpasteurisedMilkConsumption;
-                return notification;
-            }));
+                notificationsToReturn.Add(notification);
+            }
+
+            return notificationsToReturn;
         }
 
         private List<TreatmentEvent> CombineTreatmentEvents(Notification notification,

--- a/ntbs-service/Services/SpecimenService.cs
+++ b/ntbs-service/Services/SpecimenService.cs
@@ -212,10 +212,15 @@ namespace ntbs_service.Services
         public async Task<bool> UnmatchAllSpecimensForNotification(int notificationId, string auditUsername)
         {
             var existingMatches = await GetMatchedSpecimenDetailsForNotificationAsync(notificationId);
-            var resultsTasks = existingMatches.Select(match => match.ReferenceLaboratoryNumber)
-                .Select(labNumber => UnmatchSpecimenAsync(notificationId, labNumber, auditUsername));
-            var results = await Task.WhenAll(resultsTasks);
-            return results.All(result => result); // Check if all were successes
+            var labNumbers = existingMatches.Select(match => match.ReferenceLaboratoryNumber);
+
+            var overallResult = true;
+            foreach (var labNumber in labNumbers)
+            {
+                var resultForLabNumber = await UnmatchSpecimenAsync(notificationId, labNumber, auditUsername);
+                overallResult &= resultForLabNumber;
+            }
+            return overallResult; // Only true if all were successful
         }
 
         private class UnmatchedQueryResultRow


### PR DESCRIPTION
Remove remaining Task.WhenAll calls which can cause concurrent database requests.

I don't think there's any reasonable tests that could be written here - the 'behaviour' hasn't really changed, although we now avoid a race condition. I'm also not sure that the bug this fixes would be possible to occur against the in-memory database used by our tests as it wouldn't surprise me if calls to the in-memory database are actually evaluated synchronously.

## Checklist:
- [x] Automated tests are passing locally.
