### PR TITLE
NTBS-2161: Fix MDR issue when importing notification

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
@@ -12,8 +12,10 @@ using Xunit;
 
 namespace ntbs_service_unit_tests.DataMigration
 {
-    // This test suite is not designed to test that the validation is correct, only that the validation is happening on
-    // all parts of a notification that we expect it to happen on - which is why it isn't testing many validation cases.
+    // This test suite is not designed to test that all validation is correct, only that the validation is
+    // happening on all parts of a notification that we expect it to happen on.
+    // We aim to write much more in depth tests for services that are missing them, including validation,
+    // with this test suite being the start of that process.
     public class ImportValidatorTest
     {
         private readonly IImportValidator _importValidator;

--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
@@ -12,6 +12,8 @@ using Xunit;
 
 namespace ntbs_service_unit_tests.DataMigration
 {
+    // This test suite is not designed to test that the validation is correct, only that the validation is happening on
+    // all parts of a notification that we expect it to happen on - which is why it isn't testing many validation cases.
     public class ImportValidatorTest
     {
         private readonly IImportValidator _importValidator;

--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Moq;
+using ntbs_service.DataAccess;
+using ntbs_service.DataMigration;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Enums;
+using ntbs_service.Models.Validations;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataMigration
+{
+    public class ImportValidatorTest
+    {
+        private readonly IImportValidator _importValidator;
+        private readonly Mock<IReferenceDataRepository> _referenceDataRepositoryMock =
+            new Mock<IReferenceDataRepository>();
+
+        public ImportValidatorTest()
+        {
+            var importLogger = new ImportLogger();
+            _importValidator = new ImportValidator(importLogger, _referenceDataRepositoryMock.Object);
+        }
+
+        [Fact]
+        public async Task ImportValidatorValidatesBaseModels()
+        {
+            // Arrange
+            var notification = new Notification
+            {
+                NotificationDate = new DateTime(2020,1,1),
+                TestData = new TestData{ManualTestResults = new List<ManualTestResult>()},
+                MDRDetails =
+                {
+                    RelationshipToCase = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+                },
+                PatientDetails = new PatientDetails {FamilyName = "<>Davis<>"},
+                ClinicalDetails = new ClinicalDetails{DiagnosisDate = new DateTime(2000,1,1)},
+                TravelDetails = new TravelDetails{HasTravel = Status.Yes, TotalNumberOfCountries = 51},
+                ImmunosuppressionDetails = new ImmunosuppressionDetails{HasOther = true, OtherDescription = "<><>"},
+                HospitalDetails = new HospitalDetails{Consultant = "<>Fred<>"},
+                VisitorDetails = new VisitorDetails{HasVisitor = Status.Yes, StayLengthInMonths1 = 3},
+                ContactTracing = new ContactTracing{AdultsIdentified = -1},
+                PreviousTbHistory = new PreviousTbHistory{PreviousTbDiagnosisYear = 1899},
+                MBovisDetails = new MBovisDetails{MBovisExposureToKnownCases = 
+                    new List<MBovisExposureToKnownCase>{new MBovisExposureToKnownCase()}, HasExposureToKnownCases = false},
+                DrugResistanceProfile = new DrugResistanceProfile{Species = "M. bovis"}
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Contains("The field Relationship of the current case to the contact must be a string or array type with a maximum length of '90'.", 
+                errorMessages);
+            Assert.Contains(String.Format(ValidationMessages.StandardStringFormat, "Family name"), 
+                errorMessages);
+            Assert.Contains(ValidationMessages.DateValidityRangeStart("Diagnosis date", "01/01/2010"), 
+                errorMessages);
+            Assert.Contains("The field total number of countries must be between 1 and 50.", 
+                errorMessages);
+            Assert.Contains(String.Format(ValidationMessages.InvalidCharacter, "Immunosuppression type description"), 
+                errorMessages);
+            Assert.Contains(String.Format(ValidationMessages.InvalidCharacter, "Consultant"), 
+                errorMessages);
+            Assert.Contains(ValidationMessages.TravelOrVisitDurationHasCountry,
+                errorMessages);
+            Assert.Contains(ValidationMessages.ValidYear,
+                errorMessages);
+            Assert.Contains(String.Format(ValidationMessages.RequiredSelect, "Exposure setting"),
+                errorMessages);
+        }
+
+        [Fact]
+        public async Task ImportValidatorValidatesCollectionModels()
+        {
+            // Arrange
+            var notification = new Notification
+            {
+                NotificationDate = new DateTime(2020,1,1),
+                TestData = new TestData{ManualTestResults = new List<ManualTestResult>()},
+                SocialContextAddresses = new List<SocialContextAddress>{new SocialContextAddress()},
+                SocialContextVenues = new List<SocialContextVenue>{new SocialContextVenue()},
+                TreatmentEvents = new List<TreatmentEvent>{new TreatmentEvent{EventDate = new DateTime(1899, 3, 3)}},
+                MBovisDetails = new MBovisDetails
+                {
+                    HasOccupationExposure = true, MBovisOccupationExposures = new List<MBovisOccupationExposure>(),
+                    HasExposureToKnownCases = true, MBovisExposureToKnownCases = new List<MBovisExposureToKnownCase>(),
+                    HasAnimalExposure = true, MBovisAnimalExposures = new List<MBovisAnimalExposure>(),
+                    HasUnpasteurisedMilkConsumption = true, MBovisUnpasteurisedMilkConsumptions = new List<MBovisUnpasteurisedMilkConsumption>()
+                }
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            
+            Assert.Contains("Event Date must not be before 01/01/2010", 
+                errorMessages);
+            Assert.Contains(ValidationMessages.SupplyOneOfTheAddressFields,
+                errorMessages);
+            Assert.Contains(ValidationMessages.SupplyOneOfTheVenueFields,
+                errorMessages);
+            Assert.Contains(ValidationMessages.HasNoExposureRecords,
+                errorMessages);
+            Assert.Contains(ValidationMessages.HasNoAnimalExposureRecords,
+                errorMessages);
+            Assert.Contains(ValidationMessages.HasNoOccupationExposureRecords,
+                errorMessages);
+            Assert.Contains(ValidationMessages.HasNoUnpasteurisedMilkConsumptionRecords,
+                errorMessages);
+        }
+
+        [Fact]
+        public async Task ImportValidatorCleansContactTracingValues()
+        {
+            // Arrange
+            var notification = new Notification
+            {
+                NotificationDate = new DateTime(2020,1,1),
+                TestData = new TestData{ManualTestResults = new List<ManualTestResult>()},
+                ContactTracing = new ContactTracing{AdultsIdentified = 1, AdultsScreened = 3} // these values would fail validation
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            
+            Assert.Empty(errorMessages);
+        }
+
+        [Fact]
+        public async Task ImportValidatorCleansTestDataValues()
+        {
+            // Arrange
+            var notification = new Notification
+            {
+                NotificationDate = new DateTime(2020,1,1),
+                TestData = new TestData 
+                { 
+                    ManualTestResults = new List<ManualTestResult> 
+                    {
+                        new ManualTestResult { Result = Result.Positive, TestDate = null } // these values would fail validation
+                    }
+                }
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            
+            Assert.Empty(errorMessages);
+        }
+    }
+}

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -468,6 +468,8 @@ namespace ntbs_service.DataAccess
                         i.Property(e => e.NotifiedToPheStatus)
                             .HasConversion(statusEnumConverter)
                             .HasMaxLength(EnumMaxLength);
+                        i.Property(e => e.RelationshipToCase)
+                            .HasMaxLength(90);
                         i.ToTable("MDRDetails");
                     });
                 entity.OwnsOne(e => e.DrugResistanceProfile)

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -468,8 +468,6 @@ namespace ntbs_service.DataAccess
                         i.Property(e => e.NotifiedToPheStatus)
                             .HasConversion(statusEnumConverter)
                             .HasMaxLength(EnumMaxLength);
-                        i.Property(e => e.RelationshipToCase)
-                            .HasMaxLength(90);
                         i.ToTable("MDRDetails");
                     });
                 entity.OwnsOne(e => e.DrugResistanceProfile)

--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -111,7 +111,8 @@ namespace ntbs_service.DataMigration
                 notification.ContactTracing,
                 notification.PreviousTbHistory,
                 notification.TestData,
-                notification.MBovisDetails
+                notification.MBovisDetails,
+                notification.MDRDetails
             };
             var modelCollections = new List<IEnumerable<ModelBase>>
             {

--- a/ntbs-service/Migrations/20210317174112_ChangeMdrRelationshipMaxLength.Designer.cs
+++ b/ntbs-service/Migrations/20210317174112_ChangeMdrRelationshipMaxLength.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210317174112_ChangeMdrRelationshipMaxLength")]
+    partial class ChangeMdrRelationshipMaxLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210317174112_ChangeMdrRelationshipMaxLength.cs
+++ b/ntbs-service/Migrations/20210317174112_ChangeMdrRelationshipMaxLength.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class ChangeMdrRelationshipMaxLength : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "RelationshipToCase",
+                table: "MDRDetails",
+                type: "nvarchar(90)",
+                maxLength: 90,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(40)",
+                oldMaxLength: 40,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "RelationshipToCase",
+                table: "MDRDetails",
+                type: "nvarchar(40)",
+                maxLength: 40,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(90)",
+                oldMaxLength: 90,
+                oldNullable: true);
+        }
+    }
+}

--- a/ntbs-service/Migrations/README.md
+++ b/ntbs-service/Migrations/README.md
@@ -1,0 +1,18 @@
+# Migrations
+
+## NTBS database migrations
+
+To minimize friction in development and deployments, the app uses Entity Framework migrations.
+The simplest way to make a schema change is to make the appropriate changes in the model (e.g. [Notification](Models/Entities/Notification.cs) and the [database context](DataAccess/NtbsContext.cs) and run 
+`dotnet ef migrations add <NameOfMigration> --context=NtbsContext`
+This will create a migration file, that can be edited further to match needs. It will be run at application startup,
+or can be evoked by hand using
+`dotnet ef database update`
+
+[See more information on migration](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/)
+
+## DACPAC files
+
+Other NTBS repositories such as [ntbs-reporting](https://github.com/publichealthengland/ntbs-reporting) include DACPAC files of the databases they are reliant on.
+If you have made changes to the NTBS database then these files need to be updated in the corresponding repository.
+The easiest way to create the DACPAC file is through SSMS, instructions can be found [here.](https://sqlplayer.net/2018/10/how-to-create-dacpac-file/)

--- a/ntbs-service/Models/Entities/MDRDetails.cs
+++ b/ntbs-service/Models/Entities/MDRDetails.cs
@@ -15,7 +15,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Has the patient been exposed to a known RR/MDR/XDR case?")]
         public Status? ExposureToKnownCaseStatus { get; set; }
 
-        [MaxLength(40)]
+        [MaxLength(90)]
         [RegularExpression(ValidationRegexes.CharacterValidation, ErrorMessage = ValidationMessages.StandardStringFormat)]
         [RequiredIf(@"ExposureToKnownCaseStatus == Enums.Status.Yes", ErrorMessage = ValidationMessages.RelationshipToCaseIsRequired)]
         [Display(Name = "Relationship of the current case to the contact")]

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -157,7 +157,7 @@
         public const string HasNoOccupationExposureRecords =
             "Please add a record of occupation exposure or confirm no exposure has occurred";
         public const string HasNoAnimalExposureRecords =
-            "Please add a record of occupation exposure or confirm no exposure has occurred";
+            "Please add a record of animal exposure or confirm no exposure has occurred";
 
         #endregion
     }

--- a/ntbs-service/README.md
+++ b/ntbs-service/README.md
@@ -79,14 +79,7 @@ You can also make the tests log to a file by un-commenting the appropriate lines
 
 ## Database migrations
 
-To minimize friction in development and deployments, the app uses Entity Framework migrations.
-The simplest way to make a schema change is to make the appropriate changes in the model (e.g. [Notification](Models/Entities/Notification.cs) and the [database context](DataAccess/NtbsContext.cs) and run
-`dotnet ef migrations add <NameOfMigration> --context=NtbsContext`
-This will create a migration file, that can be edited further to match needs. It will be run at application startup,
-or can be evoked by hand using
-`dotnet ef database update`
-
-[See more information on migration](https://docs.microsoft.com/en-us/ef/core/managing-schemas/migrations/)
+See [the dedicated migrations readme.](Migrations/README.md) for information on migrations.
 
 # Jobs
 The project includes Hangfire for managing jobs, with a console available to admin users at `/Hangfire`. It's


### PR DESCRIPTION
## Description
We were getting a strange error when our character limit was being hit on RelationToCase in MDR details when importing a notification. It turns out that no validation was occurring on MDR Details during import and so the uncaught error happened when we tried to save the notification.
I have now made validation happen on MDR details and increased the length limit of RelationToCase to 90. 
This area should be high priority in terms of adding tests I think, as this bug was meaning a whole section of all imported notifications was missing validation.
I could add tests as part of this ticket, but it will take some time to mock out the whole notification import service, so depends if we want to spend time at the moment on that or not. 

## Checklist:
- [x] Automated tests are passing locally.
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [x] EF migrations created and committed. Snapshot committed
- [x] On-demand migration impact considered
- [x] Reporting database DACPAC updated ( not sure if needed? ) 
