### PR TITLE
NTBS-1999 Improve M. bovis alerts

### DIFF
--- a/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
@@ -74,9 +74,27 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Theory]
-        [InlineData("M. bovis", true, false)]
-        [InlineData("Non M. bovis", false, true)]
+        [InlineData("M. bovis", null, null, null, null, true, false)]
+        [InlineData("M. bovis", null, null, null, true, true, false)]
+        [InlineData("M. bovis", null, null, true, null, true, false)]
+        [InlineData("M. bovis", null, true, null, null, true, false)]
+        [InlineData("M. bovis", true, null, null, null, true, false)]
+        [InlineData("M. bovis", false, false, false, null, true, false)]
+        [InlineData("M. bovis", false, false, null, false, true, false)]
+        [InlineData("M. bovis", false, null, false, false, true, false)]
+        [InlineData("M. bovis", null, false, false, false, true, false)]
+        [InlineData("M. bovis", false, false, false, false, false, true)]
+        [InlineData("M. bovis", true, false, true, false, false, true)]
+        [InlineData("M. bovis", true, true, true, true, false, true)]
+        [InlineData("Non M. bovis", null, null, null, null, false, true)]
+        [InlineData("Non M. bovis", null, false, null, true, false, true)]
+        [InlineData("Non M. bovis", true, true, true, true, false, true)]
+        [InlineData("Non M. bovis", false, false, false, false, false, true)]
         public void CreateOrDismissMBovisAlert(string drugSpecies,
+            bool? hasExposureToKnownCases,
+            bool? hasUnpasteurisedMilkConsumption,
+            bool? hasOccupationExposure,
+            bool? hasAnimalExposure,
             bool shouldCreateAlert,
             bool shouldDismissAlert)
         {
@@ -87,7 +105,14 @@ namespace ntbs_service_unit_tests.Services
                 DrugResistanceProfile = new DrugResistanceProfile
                 {
                     Species = drugSpecies,
-                    DrugResistanceProfileString = "Random string"
+                    DrugResistanceProfileString = "Random string",
+                },
+                MBovisDetails = new MBovisDetails
+                {
+                    HasExposureToKnownCases = hasExposureToKnownCases,
+                    HasUnpasteurisedMilkConsumption = hasUnpasteurisedMilkConsumption,
+                    HasOccupationExposure = hasOccupationExposure,
+                    HasAnimalExposure = hasAnimalExposure,
                 }
             };
 

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -120,7 +120,8 @@ namespace ntbs_service.DataAccess
                         DrugResistanceProfile = n.DrugResistanceProfile,
                         MDRDetails = n.MDRDetails,
                         TreatmentRegimen = n.ClinicalDetails.TreatmentRegimen,
-                        ExposureToKnownCaseStatus = n.MDRDetails.ExposureToKnownCaseStatus
+                        ExposureToKnownMdrCaseStatus = n.MDRDetails.ExposureToKnownCaseStatus,
+                        MBovisDetails = n.MBovisDetails
                     })
                 .SingleOrDefaultAsync(n => n.Notification.NotificationId == notificationId);
         }

--- a/ntbs-service/Helpers/DrugResistanceHelper.cs
+++ b/ntbs-service/Helpers/DrugResistanceHelper.cs
@@ -8,7 +8,7 @@ namespace ntbs_service.Helpers
     {
         public static bool IsMdr(DrugResistanceProfile profile, TreatmentRegimen? treatmentRegimen, Status? exposureToKnownCaseStatus)
         {
-            // If user-set treatment ... 
+            // If user-set treatment ...
             return treatmentRegimen == TreatmentRegimen.MdrTreatment
                 // ... or lab results indicate MDR, ...
                 || profile.DrugResistanceProfileString == "RR/MDR/XDR"
@@ -20,6 +20,14 @@ namespace ntbs_service.Helpers
         {
             // If the lab results point to M. bovis species ...
             return string.Equals("M. bovis", profile.Species, StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        public static bool IsMBovisQuestionnaireComplete(MBovisDetails mBovisDetails)
+        {
+            return mBovisDetails.HasExposureToKnownCases.HasValue
+                   && mBovisDetails.HasUnpasteurisedMilkConsumption.HasValue
+                   && mBovisDetails.HasOccupationExposure.HasValue
+                   && mBovisDetails.HasAnimalExposure.HasValue;
         }
     }
 }

--- a/ntbs-service/Models/Entities/NotificationDisplay.cs
+++ b/ntbs-service/Models/Entities/NotificationDisplay.cs
@@ -25,6 +25,9 @@ namespace ntbs_service.Models.Entities
 
         public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile);
 
+        public bool IsMBovisQuestionnaireComplete =>
+            DrugResistanceHelper.IsMBovisQuestionnaireComplete(MBovisDetails);
+
         public override bool? IsLegacy => LTBRID != null || ETSID != null;
 
         private string CreateSitesOfDiseaseString()

--- a/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
+++ b/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
@@ -11,6 +11,7 @@ namespace ntbs_service.Models.Projections
         MDRDetails MDRDetails { get; }
         bool IsMdr { get; }
         bool IsMBovis { get; }
+        bool IsMBovisQuestionnaireComplete { get; }
     }
 
     public class NotificationForDrugResistanceImport : INotificationForDrugResistanceImport
@@ -19,12 +20,14 @@ namespace ntbs_service.Models.Projections
 
         public DrugResistanceProfile DrugResistanceProfile { get; set; }
         public TreatmentRegimen? TreatmentRegimen { get; set; }
-        public Status? ExposureToKnownCaseStatus { get; set; }
+        public Status? ExposureToKnownMdrCaseStatus { get; set; }
         public MDRDetails MDRDetails { get; set; }
+        public MBovisDetails MBovisDetails { get; set; }
 
         public int NotificationId => Notification.NotificationId;
-        public bool IsMdr => DrugResistanceHelper.IsMdr(DrugResistanceProfile, TreatmentRegimen, ExposureToKnownCaseStatus);
-
+        public bool IsMdr => DrugResistanceHelper.IsMdr(DrugResistanceProfile, TreatmentRegimen, ExposureToKnownMdrCaseStatus);
         public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile);
+        public bool IsMBovisQuestionnaireComplete =>
+            DrugResistanceHelper.IsMBovisQuestionnaireComplete(MBovisDetails);
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/MBovisAnimalExposures.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisAnimalExposures.cshtml.cs
@@ -11,14 +11,18 @@ namespace ntbs_service.Pages.Notifications.Edit
 {
     public class MBovisAnimalExposuresModel : NotificationEditModelBase
     {
+        private readonly IEnhancedSurveillanceAlertsService _enhancedSurveillanceAlertsService;
+
         public MBovisAnimalExposuresModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
+            IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
             IAlertRepository alertRepository) : base(notificationService, authorizationService,
                 notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisAnimalExposures;
+            _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;
         }
 
         [BindProperty]
@@ -67,6 +71,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             if (TryValidateModel(MBovisDetails, nameof(MBovisDetails)))
             {
                 await Service.UpdateMBovisDetailsAnimalExposureAsync(Notification, MBovisDetails);
+
+                await _enhancedSurveillanceAlertsService.CreateOrDismissMBovisAlert(Notification);
             }
         }
         

--- a/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml.cs
@@ -11,14 +11,18 @@ namespace ntbs_service.Pages.Notifications.Edit
 {
     public class MBovisExposureToKnownCasesModel : NotificationEditModelBase
     {
+        private readonly IEnhancedSurveillanceAlertsService _enhancedSurveillanceAlertsService;
+
         public MBovisExposureToKnownCasesModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
+            IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
             IAlertRepository alertRepository) : base(notificationService, authorizationService,
                 notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisExposureToKnownCases;
+            _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;
         }
 
         [BindProperty]
@@ -67,6 +71,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             if (TryValidateModel(MBovisDetails, nameof(MBovisDetails)))
             {
                 await Service.UpdateMBovisDetailsExposureToKnownCasesAsync(Notification, MBovisDetails);
+
+                await _enhancedSurveillanceAlertsService.CreateOrDismissMBovisAlert(Notification);
             }
         }
         

--- a/ntbs-service/Pages/Notifications/Edit/MBovisOccupationExposures.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisOccupationExposures.cshtml.cs
@@ -11,14 +11,18 @@ namespace ntbs_service.Pages.Notifications.Edit
 {
     public class MBovisOccupationExposuresModel : NotificationEditModelBase
     {
+        private readonly IEnhancedSurveillanceAlertsService _enhancedSurveillanceAlertsService;
+
         public MBovisOccupationExposuresModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
+            IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
             IAlertRepository alertRepository) : base(notificationService, authorizationService,
                 notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisOccupationExposures;
+            _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;
         }
 
         [BindProperty]
@@ -67,6 +71,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             if (TryValidateModel(MBovisDetails, nameof(MBovisDetails)))
             {
                 await Service.UpdateMBovisDetailsOccupationExposureAsync(Notification, MBovisDetails);
+
+                await _enhancedSurveillanceAlertsService.CreateOrDismissMBovisAlert(Notification);
             }
         }
         

--- a/ntbs-service/Pages/Notifications/Edit/MBovisUnpasteurisedMilkConsumptions.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisUnpasteurisedMilkConsumptions.cshtml.cs
@@ -11,14 +11,18 @@ namespace ntbs_service.Pages.Notifications.Edit
 {
     public class MBovisUnpasteurisedMilkConsumptionsModel : NotificationEditModelBase
     {
+        private readonly IEnhancedSurveillanceAlertsService _enhancedSurveillanceAlertsService;
+
         public MBovisUnpasteurisedMilkConsumptionsModel(
             INotificationService notificationService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
+            IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
             IAlertRepository alertRepository) : base(notificationService, authorizationService,
                 notificationRepository, alertRepository)
         {
             CurrentPage = NotificationSubPaths.EditMBovisUnpasteurisedMilkConsumptions;
+            _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;
         }
 
         [BindProperty]
@@ -67,6 +71,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             if (TryValidateModel(MBovisDetails, nameof(MBovisDetails)))
             {
                 await Service.UpdateMBovisDetailsUnpasteurisedMilkConsumptionAsync(Notification, MBovisDetails);
+
+                await _enhancedSurveillanceAlertsService.CreateOrDismissMBovisAlert(Notification);
             }
         }
         

--- a/ntbs-service/Services/EnhancedSurveillanceAlertsService.cs
+++ b/ntbs-service/Services/EnhancedSurveillanceAlertsService.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.Services
 
         public async Task CreateOrDismissMBovisAlert(INotificationForDrugResistanceImport notification)
         {
-            if (notification.IsMBovis)
+            if (notification.IsMBovis && !notification.IsMBovisQuestionnaireComplete)
             {
                 await CreateMBovisAlert(notification);
             }


### PR DESCRIPTION
## Description
* Check M. bovis questionnaire before raising alert: when raising M. bovis alerts as part of the `DrugResistanceProfileUpdateJob`, check whether the M. bovis questionnaire has been filled out or not. It may have been filled out if this is notification recently migrated from a legacy system, where the questionnaire was filled out there. Note that disease species is not transferred as part of notification migration; it is done by the `DrugResistanceProfileUpdateJob`.
* Check M. bovis questionnaire alert after editing: after editing an M. bovis questionnaire page, check the M. bovis alert status, and auto-remove it if editing this page means that the questionnaire has now been fully filled out.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Tested raising/removing of an M. bovis notification when editing the notification pages
- [ ] Not tested this with the `DrugResistanceProfileUpdateJob`, I don't know how add in a new specimen to the lab base DB that would trigger this change.