### PR TITLE
NTBS-2102 Use minutes for session cookie timeout config

### DIFF
--- a/ntbs-service/Properties/AdOptions.cs
+++ b/ntbs-service/Properties/AdOptions.cs
@@ -20,6 +20,6 @@
         public bool UseDummyAuth { get; set; }
 
         /** The amount of time an authentication cookie is valid for */
-        public int MaxSessionCookieLifetimeInHours { get; set; }
+        public double MaxSessionCookieLifetimeInMinutes { get; set; }
     }
 }

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -294,7 +294,7 @@ namespace ntbs_service
                 .AddCookie(options =>
                 {
                     options.ForwardAuthenticate = setupDummyAuth ? DummyAuthHandler.Name : null;
-                    options.ExpireTimeSpan = TimeSpan.FromHours(adOptions.MaxSessionCookieLifetimeInHours);
+                    options.ExpireTimeSpan = TimeSpan.FromMinutes(adOptions.MaxSessionCookieLifetimeInMinutes);
                 });
 
 
@@ -317,7 +317,7 @@ namespace ntbs_service
                 .AddCookie(options =>
                 {
                     options.ForwardAuthenticate = setupDummyAuth ? DummyAuthHandler.Name : null;
-                    options.ExpireTimeSpan = TimeSpan.FromHours(adOptions.MaxSessionCookieLifetimeInHours);
+                    options.ExpireTimeSpan = TimeSpan.FromMinutes(adOptions.MaxSessionCookieLifetimeInMinutes);
                 })
                 .AddOpenIdConnect(options =>
                 {

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -5,7 +5,7 @@
     "AdminUserGroup": "App.Auth.NIS.NTBS.Admin",
     "NationalTeamAdGroup": "App.Auth.NIS.NTBS.NTS",
     "ServiceGroupAdPrefix": "App.Auth.NIS.NTBS.Service",
-    "MaxSessionCookieLifetimeInHours": 24
+    "MaxSessionCookieLifetimeInMinutes": 1440
   },
   "AdfsOptions": {
     "AdfsUrl": "https://fs-ntbs.uksouth.cloudapp.azure.com"


### PR DESCRIPTION
## Description
Use minutes for session cookie timeout config, instead of hours, as discussed today.