### PR TITLE
NTBS-2150 Update yml files for test and uat

### DIFF
--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -52,8 +52,8 @@ spec:
           - name: ConnectionStrings__migration
             valueFrom:
               secretKeyRef:
-                name: migration-connection-string
-                key: connectionString
+                name: test-connection-strings
+                key: migrationDb
           - name: AdOptions__BaseUserGroup
             value: "Global.NIS.NTBS"
           - name: AdOptions__AdminUserGroup

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -52,8 +52,8 @@ spec:
           - name: ConnectionStrings__migration
             valueFrom:
               secretKeyRef:
-                name: migration-connection-string
-                key: connectionString
+                name: uat-connection-strings
+                key: migrationDb
           - name: AdOptions__BaseUserGroup
             value: "Global.NIS.NTBS"
           - name: AdOptions__AdminUserGroup


### PR DESCRIPTION
Use separate secrets for the migration database in the `test` and `uat` environments.

In practice their values will be the same most of the time, but the changing collation exercise has proved that it's good to have the flexibility to point them at different databases when we need to.
