### PR TITLE
NTBS-2102 Turn off authentication cookie sliding expiration

### DIFF
--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -295,6 +295,7 @@ namespace ntbs_service
                 .AddCookie(options =>
                 {
                     options.ForwardAuthenticate = setupDummyAuth ? DummyAuthHandler.Name : null;
+                    options.SlidingExpiration = false;
                     options.ExpireTimeSpan = TimeSpan.FromMinutes(adOptions.MaxSessionCookieLifetimeInMinutes);
                 });
 
@@ -318,6 +319,7 @@ namespace ntbs_service
                 .AddCookie(options =>
                 {
                     options.ForwardAuthenticate = setupDummyAuth ? DummyAuthHandler.Name : null;
+                    options.SlidingExpiration = false;
                     options.ExpireTimeSpan = TimeSpan.FromMinutes(adOptions.MaxSessionCookieLifetimeInMinutes);
                 })
                 .AddOpenIdConnect(options =>


### PR DESCRIPTION
## Description
Sliding cookie expiration means that an authentication cookie halfway through its life will get replaced automatically when you make a request to the server with this cookie.

This allows an attacker to maintain an authentication cookie forever if they were to steal one. Because of this, we need to turn this feature off.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Tested locally: cookies now automatically expire based on app setting, regardless of the amount of user interaction during the cookie's life.