### PR TITLE
NTBS-NONE Use Sqlite instead of in memory database in tests

### DIFF
--- a/ntbs-integration-tests/TestRunnerBase.cs
+++ b/ntbs-integration-tests/TestRunnerBase.cs
@@ -17,7 +17,8 @@ namespace ntbs_integration_tests
         protected TestRunnerBase(NtbsWebApplicationFactory<Startup> factory)
         {
             Factory = factory;
-            Factory.ConfigureLogger(GetType().Name);
+            Factory.ConfigureTestClassName(GetType().Name);
+            Factory.ConfigureLogger();
             Client = Factory.CreateClientWithoutRedirects();
         }
 

--- a/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
@@ -1,6 +1,7 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AngleSharp.Html.Dom;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
 using ntbs_service.Helpers;
@@ -132,7 +133,9 @@ namespace ntbs_integration_tests.TransferPage
 
             var formData = new Dictionary<string, string>
             {
-                ["AcceptTransfer"] = "true"
+                ["AcceptTransfer"] = "true",
+                ["TargetCaseManagerUsername"] = Utilities.CASEMANAGER_ABINGDON_EMAIL,
+                ["TargetHospitalId"] = Utilities.HOSPITAL_ABINGDON_COMMUNITY_HOSPITAL_ID
             };
 
             // Act

--- a/ntbs-integration-tests/ntbs-integration-tests.csproj
+++ b/ntbs-integration-tests/ntbs-integration-tests.csproj
@@ -12,7 +12,9 @@
     <PackageReference Include="AngleSharp" Version="0.14.0" />
     <PackageReference Include="Audit.EntityFramework.Core" Version="16.5.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.4" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -225,8 +225,8 @@ namespace ntbs_service.DataAccess
                     .IsRequired(false);
 
                 entity.HasOne(e => e.PHEC)
-                    .WithOne()
-                    .HasForeignKey<LocalAuthorityToPHEC>(la => la.PHECCode)
+                    .WithMany()
+                    .HasForeignKey(la => la.PHECCode)
                     .OnDelete(DeleteBehavior.Cascade)
                     .IsRequired(false);
 
@@ -806,11 +806,8 @@ namespace ntbs_service.DataAccess
                 entity.HasData(Models.SeedData.TreatmentOutcomes.GetTreatmentOutcomes());
             });
 
-            modelBuilder.HasSequence<int>("OrderIndex", schema: "shared");
             modelBuilder.Entity<FrequentlyAskedQuestion>(entity =>
             {
-                entity.Property(e => e.OrderIndex)
-                    .HasDefaultValueSql("NEXT VALUE FOR shared.OrderIndex");
             });
 
             modelBuilder.Entity<UserLoginEvent>(entity =>

--- a/ntbs-service/Migrations/20210323115845_RemoveSequence.Designer.cs
+++ b/ntbs-service/Migrations/20210323115845_RemoveSequence.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210319123545_RemoveSequence")]
+    partial class RemoveSequence
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -24503,8 +24505,8 @@ namespace ntbs_service.Migrations
                                 .HasColumnType("int");
 
                             b1.Property<string>("RelationshipToCase")
-                                .HasMaxLength(90)
-                                .HasColumnType("nvarchar(90)");
+                                .HasMaxLength(40)
+                                .HasColumnType("nvarchar(40)");
 
                             b1.HasKey("NotificationId");
 

--- a/ntbs-service/Migrations/20210323115845_RemoveSequence.cs
+++ b/ntbs-service/Migrations/20210323115845_RemoveSequence.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class RemoveSequence : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_LocalAuthorityToPHEC_PHECCode",
+                schema: "ReferenceData",
+                table: "LocalAuthorityToPHEC");
+
+            migrationBuilder.DropSequence(
+                name: "OrderIndex",
+                schema: "shared");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "OrderIndex",
+                table: "FrequentlyAskedQuestion",
+                type: "int",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldDefaultValueSql: "NEXT VALUE FOR shared.OrderIndex");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "shared");
+
+            migrationBuilder.CreateSequence<int>(
+                name: "OrderIndex",
+                schema: "shared");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "OrderIndex",
+                table: "FrequentlyAskedQuestion",
+                type: "int",
+                nullable: false,
+                defaultValueSql: "NEXT VALUE FOR shared.OrderIndex",
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LocalAuthorityToPHEC_PHECCode",
+                schema: "ReferenceData",
+                table: "LocalAuthorityToPHEC",
+                column: "PHECCode",
+                unique: true);
+        }
+    }
+}


### PR DESCRIPTION
This is a change that I think would be good for the project - using a Sqlite database instead of the in memory database we currently use.

The main advantages are:
* The implementation is closer to that of a MSSQL database
* It will support testing of the raw SQL queries that we use in some places

The main disadvantages are:
* It doesn't support sequences. However, I don't consider this to be a deal-breaker because we only had one, for the FAQs page, and it really isn't necessary.
* It may cause the tests to run more slowly. I've tested this locally and it doesn't make much difference, but there's definitely a possibility that it will make more difference on whatever server github uses. If this is the case, then I'll revert the change.

## Checklist:
- [x] Automated tests are passing locally.
