### PR TITLE
NTBS-2086: Fix search page and notification overview banner issue

### DIFF
--- a/ntbs-service/wwwroot/css/notification.scss
+++ b/ntbs-service/wwwroot/css/notification.scss
@@ -97,6 +97,10 @@
 
   border-top-width: 10px;
   border-top-style: solid;
+  
+  @media(max-width: 35em) {
+    flex-direction: column;
+  }
 
   &.notification-banner-links--draft {
     border-top-color: $banner-header--draft;

--- a/ntbs-service/wwwroot/css/search.scss
+++ b/ntbs-service/wwwroot/css/search.scss
@@ -115,7 +115,7 @@
 }
 
 .search-dropdown {
-    width: 400px;
+    width: 35ex;
     margin: 15px 0;
 }
 


### PR DESCRIPTION
## Description
Now use columns for the headers of the notification banner if we zoom in further than the banner container can handle.
Also change the width of the tb service and country field in advanced search to avoid horizontal scrolling at 400%. 
Tested on IE11, Mozilla and Chrome. 
