### PR TITLE
NTBS-2171: Import treatment event case managers during migration

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
+++ b/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
@@ -16,16 +16,18 @@ namespace ntbs_service_unit_tests.DataMigration
     public class CaseManagerImportServiceTests : IDisposable
     {
         private const string NOTIFICATION_ID = "11111";
-        private const string CASE_MANAGER_USERNAME = "TestUser@nhs.net";
-        private static readonly Guid HOSPITAL_GUID = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A");
+        private const string CASE_MANAGER_USERNAME_1 = "TestUser@nhs.net";
+        private const string CASE_MANAGER_USERNAME_2 = "MartinUser@nhs.net";
+        private static readonly Guid HOSPITAL_GUID_1 = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A");
+        private static readonly Guid HOSPITAL_GUID_2 = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7B");
 
         private readonly NtbsContext _context;
         private readonly CaseManagerImportService _caseManagerImportService;
         private readonly Mock<IMigrationRepository> _migrationRepositoryMock = new Mock<IMigrationRepository>();
 
         private Dictionary<string, IEnumerable<MigrationDbNotification>> _idToNotificationDict;
-        private Dictionary<string, MigrationLegacyUser> _usernameToLegacyUserDict;
-        private Dictionary<string, IEnumerable<MigrationLegacyUserHospital>> _usernameToLegacyUserHospitalDict;
+        private Dictionary<string, MigrationLegacyUser> _usernameToLegacyUserDict = new Dictionary<string, MigrationLegacyUser>();
+        private Dictionary<string, IEnumerable<MigrationLegacyUserHospital>> _usernameToLegacyUserHospitalDict = new Dictionary<string, IEnumerable<MigrationLegacyUserHospital>>();
 
         public CaseManagerImportServiceTests()
         {
@@ -47,13 +49,12 @@ namespace ntbs_service_unit_tests.DataMigration
         public async Task WhenCaseManagerForLegacyNotificationWithCorrectPermissionsDoesNotExistInNtbs_AddsCaseManagerWithTbServices()
         {
             // Arrange
-            
-            var notification = GivenLegacyNotificationWithTbServiceCode("TBS00TEST");
-            GivenLegacyUserWithName("John", "Johnston");
-            await GivenLegacyUserHasPermissionsForTbService("TBS00TEST");
+            var notification = GivenLegacyNotificationWithCaseManagerAndTbServiceCode(CASE_MANAGER_USERNAME_1, "TBS00TEST");
+            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "John", "Johnston");
+            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS00TEST", HOSPITAL_GUID_1);
 
             // Act
-            await _caseManagerImportService.ImportOrUpdateCaseManager(notification, null, "test-request-1");
+            await _caseManagerImportService.ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(notification, null, "test-request-1");
 
             // Assert
             var addedUser = _context.User.SingleOrDefault();
@@ -69,12 +70,12 @@ namespace ntbs_service_unit_tests.DataMigration
         public async Task WhenCaseManagerForLegacyNotificationWithIncorrectPermissionsDoesNotExistInNtbs_AddsCaseManagerWithNoTbServices()
         {
             // Arrange
-            var notification = GivenLegacyNotificationWithTbServiceCode("TBS00TEST");
-            GivenLegacyUserWithName("John", "Johnston");
-            await GivenLegacyUserHasPermissionsForTbService("TBS11FAKE");
+            var notification = GivenLegacyNotificationWithCaseManagerAndTbServiceCode(CASE_MANAGER_USERNAME_1, "TBS00TEST");
+            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "John", "Johnston");
+            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS11FAKE", HOSPITAL_GUID_1);
 
             // Act
-            await _caseManagerImportService.ImportOrUpdateCaseManager(notification, null, "test-request-1");
+            await _caseManagerImportService.ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(notification, null, "test-request-1");
 
             // Assert
             var addedUser = _context.User.SingleOrDefault();
@@ -90,19 +91,77 @@ namespace ntbs_service_unit_tests.DataMigration
         public async Task WhenCaseManagerForLegacyNotificationExistsInNtbs_UserNotImportedButNameUpdated()
         {
             // Arrange
-            var notification = GivenLegacyNotificationWithTbServiceCode("TBS00TEST");
-            GivenLegacyUserWithName("John", "Johnston");
-            await GivenLegacyUserHasPermissionsForTbService("TBS99HULL");
+            var notification = GivenLegacyNotificationWithCaseManagerAndTbServiceCode(CASE_MANAGER_USERNAME_1, "TBS00TEST");
+            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "John", "Johnston");
+            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS99HULL", HOSPITAL_GUID_1);
             await GivenUserExistsInNtbsWithName("Jon", "Jonston");
 
             // Act
-            await _caseManagerImportService.ImportOrUpdateCaseManager(notification, null, "test-request-1");
+            await _caseManagerImportService.ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(notification, null, "test-request-1");
 
             // Assert
             var updatedUser = _context.User.Single();
             Assert.NotNull(updatedUser);
             Assert.Equal("John", updatedUser.GivenName);
             Assert.Equal("Johnston", updatedUser.FamilyName);
+        }
+
+        [Fact]
+        public async Task WhenCaseManagerForLegacyTreatmentEventWithCorrectPermissionsDoesNotExistInNtbs_UserImportedWithTbServices()
+        {
+            // Arrange
+            var notification = GivenLegacyNotificationWithCaseManagerAndTbServiceCode(CASE_MANAGER_USERNAME_1, "TBS00TEST");
+            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "Frank", "Ignored");
+            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_2, "Martin", "Francis");
+            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS00FAKE", HOSPITAL_GUID_1);
+            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_2, "TBS00TEST", HOSPITAL_GUID_2);
+            notification.TreatmentEvents =
+                new List<TreatmentEvent> {new TreatmentEvent {CaseManagerUsername = CASE_MANAGER_USERNAME_2, TbServiceCode = "TBS00TEST"}};
+
+            // Act
+            await _caseManagerImportService.ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(notification, null, "test-request-1");
+
+            // Assert
+            var addedUsers = _context.User.ToList();
+            var addedUserFromTreatmentEvent = addedUsers.SingleOrDefault(u => u.Username == CASE_MANAGER_USERNAME_2);
+            Assert.NotEmpty(addedUsers);
+            Assert.Equal(2, addedUsers.Count);
+            Assert.NotNull(addedUserFromTreatmentEvent);
+            Assert.Equal("Martin", addedUserFromTreatmentEvent.GivenName);
+            Assert.Equal("Francis", addedUserFromTreatmentEvent.FamilyName);
+            Assert.False(addedUserFromTreatmentEvent.IsActive);
+            Assert.True(addedUserFromTreatmentEvent.IsCaseManager);
+            Assert.Contains("TBS00TEST",
+                addedUserFromTreatmentEvent.CaseManagerTbServices.Select(cmtb => cmtb.TbServiceCode));
+        }
+
+        [Fact]
+        public async Task WhenCaseManagerForLegacyTreatmentEventWithIncorrectPermissionsDoesNotExistInNtbs_UserImportedWithNoTbServices()
+        {
+            // Arrange
+            var notification = GivenLegacyNotificationWithCaseManagerAndTbServiceCode(CASE_MANAGER_USERNAME_1, "TBS00TEST");
+            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "Frank", "Ignored");
+            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_2, "Martin", "Francis");
+            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS00FAKE", HOSPITAL_GUID_1);
+            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_2, "TBS00WRONG", HOSPITAL_GUID_2);
+            notification.TreatmentEvents =
+                new List<TreatmentEvent> {new TreatmentEvent {CaseManagerUsername = CASE_MANAGER_USERNAME_2, TbServiceCode = "TBS00TEST"}};
+
+            // Act
+            await _caseManagerImportService.ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(notification, null, "test-request-1");
+
+            // Assert
+            var addedUsers = _context.User.ToList();
+            var addedUserFromTreatmentEvent = addedUsers.SingleOrDefault(u => u.Username == CASE_MANAGER_USERNAME_2);
+            Assert.NotEmpty(addedUsers);
+            Assert.Equal(2, addedUsers.Count);
+            Assert.NotNull(addedUserFromTreatmentEvent);
+            Assert.Equal("Martin", addedUserFromTreatmentEvent.GivenName);
+            Assert.Equal("Francis", addedUserFromTreatmentEvent.FamilyName);
+            Assert.False(addedUserFromTreatmentEvent.IsActive);
+            Assert.False(addedUserFromTreatmentEvent.IsCaseManager);
+            Assert.DoesNotContain("TBS00TEST",
+                addedUserFromTreatmentEvent.CaseManagerTbServices.Select(cmtb => cmtb.TbServiceCode));
         }
 
         private void SetupMockMigrationRepo()
@@ -115,54 +174,49 @@ namespace ntbs_service_unit_tests.DataMigration
                 .Returns((List<string> ids) => Task.FromResult(_idToNotificationDict[ids[0]]));
         }
 
-        private Notification GivenLegacyNotificationWithTbServiceCode(string TbServiceCode)
+        private Notification GivenLegacyNotificationWithCaseManagerAndTbServiceCode(string caseManager, string TbServiceCode)
         {
             _idToNotificationDict = new Dictionary<string, IEnumerable<MigrationDbNotification>>
             {
                 {
                     NOTIFICATION_ID,
-                    new List<MigrationDbNotification> {new MigrationDbNotification {CaseManager = CASE_MANAGER_USERNAME}}
+                    new List<MigrationDbNotification> {new MigrationDbNotification {CaseManager = caseManager}}
                 }
             };
             return new Notification
             {
                 IsLegacy = true,
                 LTBRID = NOTIFICATION_ID,
-                HospitalDetails = new HospitalDetails {TBServiceCode = TbServiceCode}
+                HospitalDetails = new HospitalDetails {TBServiceCode = TbServiceCode},
+                TreatmentEvents = new List<TreatmentEvent>()
             };
         }
 
-        private void GivenLegacyUserWithName(string givenName, string familyName)
+        private void GivenLegacyUserWithName(string username, string givenName, string familyName)
         {
-            _usernameToLegacyUserDict = new Dictionary<string, MigrationLegacyUser>
-            {
+            _usernameToLegacyUserDict.Add(
+                username,
+                new MigrationLegacyUser
                 {
-                    CASE_MANAGER_USERNAME,
-                    new MigrationLegacyUser {Username = CASE_MANAGER_USERNAME, GivenName = givenName, FamilyName = familyName}
+                    Username = username, GivenName = givenName, FamilyName = familyName
                 }
-            };
+            );
         }
 
-        private async Task GivenLegacyUserHasPermissionsForTbService(string tbServiceCode)
+        private async Task GivenLegacyUserHasPermissionsForTbServiceInHospital(string username, string tbServiceCode, Guid hospitalGuid)
         {
-            _usernameToLegacyUserHospitalDict = new Dictionary<string, IEnumerable<MigrationLegacyUserHospital>>
-            {
-                {
-                    CASE_MANAGER_USERNAME,
-                    new List<MigrationLegacyUserHospital>
-                    {
-                        new MigrationLegacyUserHospital {HospitalId = HOSPITAL_GUID}
-                    }
-                }
-            };
-            await _context.Hospital.AddAsync(new Hospital{HospitalId = HOSPITAL_GUID, TBService = new TBService{Code = tbServiceCode}});
+            _usernameToLegacyUserHospitalDict.Add(
+                username,
+                new List<MigrationLegacyUserHospital> {new MigrationLegacyUserHospital {HospitalId = hospitalGuid}}
+            );
+            await _context.Hospital.AddAsync(new Hospital{HospitalId = hospitalGuid, TBService = new TBService{Code = tbServiceCode}});
             await _context.SaveChangesAsync();
         }
 
         private async Task GivenUserExistsInNtbsWithName(string givenName, string familyName)
         {
             await _context.User.AddAsync(
-                new User {GivenName = givenName, FamilyName = familyName, Username = CASE_MANAGER_USERNAME, IsActive = true});
+                new User {GivenName = givenName, FamilyName = familyName, Username = CASE_MANAGER_USERNAME_1, IsActive = true});
             await _context.SaveChangesAsync();
         }
 

--- a/ntbs-service/DataMigration/CaseManagerImportService.cs
+++ b/ntbs-service/DataMigration/CaseManagerImportService.cs
@@ -11,7 +11,7 @@ namespace ntbs_service.DataMigration
 {
     public interface ICaseManagerImportService
     {
-        Task ImportOrUpdateCaseManager(Notification notification, PerformContext context, string requestId);
+        Task ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(Notification notification, PerformContext context, string requestId);
     }
     
     public class CaseManagerImportService : ICaseManagerImportService
@@ -33,25 +33,44 @@ namespace ntbs_service.DataMigration
             _logger = logger;
         }
         
-        public async Task ImportOrUpdateCaseManager(Notification notification,
+        public async Task ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(Notification notification,
             PerformContext context,
             string requestId)
         {
-            var legacyCaseManager = await GetLegacyNotificationCaseManager(notification.LegacyId);
-            if (legacyCaseManager == null)
+            var legacyNotificationCaseManager = await GetLegacyNotificationCaseManager(notification.LegacyId);
+            if (legacyNotificationCaseManager == null)
             {
                 return;
             }
 
+            await ImportOrUpdateLegacyUser(legacyNotificationCaseManager, notification.HospitalDetails.TBServiceCode, context, requestId);
+            
+            foreach (var treatmentEvent in notification.TreatmentEvents)
+            {
+                if (treatmentEvent.CaseManagerUsername == null)
+                {
+                    continue;
+                }
+                
+                var legacyTreatmentCaseManager = await _migrationRepository.GetLegacyUserByUsername(treatmentEvent.CaseManagerUsername);
+                await ImportOrUpdateLegacyUser(legacyTreatmentCaseManager, treatmentEvent.TbServiceCode, context, requestId);
+            }
+        }
+
+        private async Task ImportOrUpdateLegacyUser(MigrationLegacyUser legacyCaseManager,
+            string legacyTbServiceCode,
+            PerformContext context,
+            string requestId)
+        {
             var existingCaseManager = await _userRepository.GetUserByUsername(legacyCaseManager.Username);
             var ntbsCaseManager = existingCaseManager ?? 
-                                              new User {IsActive = false, Username = legacyCaseManager.Username, CaseManagerTbServices = new List<CaseManagerTbService>()};
+                                  new User {IsActive = false, Username = legacyCaseManager.Username, CaseManagerTbServices = new List<CaseManagerTbService>()};
             
             ntbsCaseManager.GivenName = legacyCaseManager.GivenName;
             ntbsCaseManager.FamilyName = legacyCaseManager.FamilyName;
             ntbsCaseManager.DisplayName = $"{ntbsCaseManager.GivenName} {ntbsCaseManager.FamilyName}";
             
-            await AddTbServiceToUserBasedOnLegacyPermissions(ntbsCaseManager, notification, legacyCaseManager.Username);
+            await AddTbServiceToUserBasedOnLegacyPermissions(ntbsCaseManager, legacyTbServiceCode, legacyCaseManager.Username);
 
             await _userRepository.AddOrUpdateUser(ntbsCaseManager, ntbsCaseManager.CaseManagerTbServices.Select(cmtb => cmtb.TbService));
             _logger.LogInformation(context, requestId, "Added/Updated the case manager assigned to the notification.");
@@ -69,18 +88,18 @@ namespace ntbs_service.DataMigration
             return await _migrationRepository.GetLegacyUserByUsername(caseManagerUsername);
         }
 
-        private async Task AddTbServiceToUserBasedOnLegacyPermissions(User ntbsCaseManager, Notification notification, string legacyCaseManagerUsername)
+        private async Task AddTbServiceToUserBasedOnLegacyPermissions(User ntbsCaseManager, string legacyTbServiceCode, string legacyCaseManagerUsername)
         {
             var existingCaseManagerTbServices = await _referenceDataRepository.GetCaseManagerTbServicesByUsernameAsync
                 (ntbsCaseManager.Username);
             if (!ntbsCaseManager.IsActive &&
-                existingCaseManagerTbServices.All(cmtb => cmtb.TbServiceCode != notification.HospitalDetails.TBServiceCode))
+                existingCaseManagerTbServices.All(cmtb => cmtb.TbServiceCode != legacyTbServiceCode))
             {
                 var legacyUserHospitals = (await _migrationRepository.GetLegacyUserHospitalsByUsername(legacyCaseManagerUsername))
                     .Where(h => h.HospitalId != null).Select(h => h.HospitalId).OfType<Guid>();
                 var legacyUserTbServices =
                     await _referenceDataRepository.GetTbServicesFromHospitalIdsAsync(legacyUserHospitals);
-                var legacyMatchingTbService = legacyUserTbServices.SingleOrDefault(tb => tb.Code == notification.HospitalDetails.TBServiceCode);
+                var legacyMatchingTbService = legacyUserTbServices.SingleOrDefault(tb => tb.Code == legacyTbServiceCode);
                 if (legacyMatchingTbService != null) {
                     ntbsCaseManager.IsCaseManager = true;
                     ntbsCaseManager.CaseManagerTbServices.Add(new CaseManagerTbService{TbService = legacyMatchingTbService});

--- a/ntbs-service/DataMigration/CaseManagerImportService.cs
+++ b/ntbs-service/DataMigration/CaseManagerImportService.cs
@@ -38,14 +38,12 @@ namespace ntbs_service.DataMigration
             string requestId)
         {
             var legacyNotificationCaseManager = await GetLegacyNotificationCaseManager(notification.LegacyId);
-            if (legacyNotificationCaseManager == null)
+            if (legacyNotificationCaseManager != null)
             {
-                return;
+                await ImportOrUpdateLegacyUser(legacyNotificationCaseManager, notification.HospitalDetails.TBServiceCode, context, requestId);
+                _logger.LogInformation(context, requestId, "Added/Updated the case manager assigned to the notification.");
             }
 
-            await ImportOrUpdateLegacyUser(legacyNotificationCaseManager, notification.HospitalDetails.TBServiceCode, context, requestId);
-            _logger.LogInformation(context, requestId, "Added/Updated the case manager assigned to the notification.");
-            
             foreach (var treatmentEvent in notification.TreatmentEvents)
             {
                 if (treatmentEvent.CaseManagerUsername == null)

--- a/ntbs-service/DataMigration/CaseManagerImportService.cs
+++ b/ntbs-service/DataMigration/CaseManagerImportService.cs
@@ -44,6 +44,7 @@ namespace ntbs_service.DataMigration
             }
 
             await ImportOrUpdateLegacyUser(legacyNotificationCaseManager, notification.HospitalDetails.TBServiceCode, context, requestId);
+            _logger.LogInformation(context, requestId, "Added/Updated the case manager assigned to the notification.");
             
             foreach (var treatmentEvent in notification.TreatmentEvents)
             {
@@ -55,6 +56,7 @@ namespace ntbs_service.DataMigration
                 var legacyTreatmentCaseManager = await _migrationRepository.GetLegacyUserByUsername(treatmentEvent.CaseManagerUsername);
                 await ImportOrUpdateLegacyUser(legacyTreatmentCaseManager, treatmentEvent.TbServiceCode, context, requestId);
             }
+            _logger.LogInformation(context, requestId, "Added/Updated the case managers assigned to the notification's transfer events.");
         }
 
         private async Task ImportOrUpdateLegacyUser(MigrationLegacyUser legacyCaseManager,
@@ -73,7 +75,6 @@ namespace ntbs_service.DataMigration
             await AddTbServiceToUserBasedOnLegacyPermissions(ntbsCaseManager, legacyTbServiceCode, legacyCaseManager.Username);
 
             await _userRepository.AddOrUpdateUser(ntbsCaseManager, ntbsCaseManager.CaseManagerTbServices.Select(cmtb => cmtb.TbService));
-            _logger.LogInformation(context, requestId, "Added/Updated the case manager assigned to the notification.");
         }
 
         private async Task<MigrationLegacyUser> GetLegacyNotificationCaseManager(string legacyId)

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -149,7 +149,7 @@ namespace ntbs_service.DataMigration
             var isAnyNotificationInvalid = false;
             foreach (var notification in notifications)
             {
-                await _caseManagerImportService.ImportOrUpdateCaseManager(notification, context, requestId);
+                await _caseManagerImportService.ImportOrUpdateCaseManagersFromNotificationAndTreatmentEvents(notification, context, requestId);
                 var linkedNotificationId = notification.LegacyId;
                 _logger.LogInformation(context, requestId, $"Validating notification with Id={linkedNotificationId}");
 


### PR DESCRIPTION
## Description
When attempting to import legacy notifications we were sometimes getting foreign key errors. This was due to case managers for a notification's transfer events not being present in NTBS.
This issue was spotted by Nancy in live data - where some legacy notification contain transfer events with case managers. All the ntbs migration legacy data has null case managers for transfer events.

Now import all case mangers relating to a legacy notification's transfer events.

## Checklist:
- [x] Automated tests are passing locally.
