### PR TITLE
NTBS-2174 Remove extra label

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
@@ -54,9 +54,6 @@
                                   id="travel-country1Id-error" ref="country1IdErrorRef" has-error="@hasCountry1IdError"></span>
                             <div ref="country1Id" aria-describedby="travel-country1Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" inline-template>
-                                    <label asp-for="TravelDetails.Country1Id" nhs-label-type="Standard">
-                                        Most recent country travelled to
-                                    </label>
                                     <select asp-for="TravelDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
                                         <option value=""></option>
                                     </select>


### PR DESCRIPTION
Remove extra label that was accidentally committed.

## Checklist:
- [x] Automated tests are passing locally.
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Accessibility testing
Features with UI components should consider items on this list
- [x] Limited accessibility smoke testing, since this is a reversion to previous behaviour
