### PR TITLE
NTBS-NONE Reduce the likelihood of a race in Selenium tests

### DIFF
--- a/ntbs-ui-tests/Hooks/DriverSetup.cs
+++ b/ntbs-ui-tests/Hooks/DriverSetup.cs
@@ -33,6 +33,7 @@ namespace ntbs_ui_tests.Hooks
             }
 
             Browser = new RemoteWebDriver(opts);
+            Browser.Manage().Timeouts().ImplicitWait = settings.ImplicitWait;
             objectContainer.RegisterInstanceAs(Browser);
         }
 

--- a/ntbs-ui-tests/Hooks/TestSettings.cs
+++ b/ntbs-ui-tests/Hooks/TestSettings.cs
@@ -1,8 +1,16 @@
+using System;
+
 namespace ntbs_ui_tests.Hooks
 {
     public class TestSettings
     {
         // set this to false if you want to see the browser window (locally only)
         public bool IsHeadless { get; set; } = true;
+
+        // The amount of time we will wait when failing to get an element before failing the test
+        // This allows JS adding an element into a page to do so before Selenium claims it is not there; it reduces
+        // the probability of a false-failure due to Selenium and JS on the site racing each other.
+        // If you are getting unexpected "element not found" errors, try increasing this timespan.
+        public TimeSpan ImplicitWait { get; set; } = TimeSpan.FromSeconds(5);
     }
 }


### PR DESCRIPTION
## Description
Add an implicit wait timespan to Selenium tests; which tells Selenium to wait some time before claiming an element is not on the page. This gives some time for JS to modify the page from the previous step, making JS much more likely to win its race against Selenium.

I was having issues with the "Fill in M. bovis occupation exposure page" scenario even though no relevant changes had happened recently. The issue was as described above, Selenium was not giving JS enough chance to add the "add-new-button" to the page before failing the test, but they now all work.

## Checklist:
- [x] Automated tests are passing locally.