### PR TITLE
Add specimen matching DACPAC to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@ If the NTBS schema changes, that might affect the related components!
 - [ ] EF migrations created and committed. Snapshot committed
 - [ ] On-demand migration impact considered
 - [ ] Reporting database DACPAC updated
+- [ ] Specimen matching database DACPAC updated
 - [ ] Reporting database ingestion considered (uspGenerateReusableNotification)
 ### Accessibility testing
 Features with UI components should consider items on this list

--- a/ntbs-service/Migrations/README.md
+++ b/ntbs-service/Migrations/README.md
@@ -13,6 +13,6 @@ or can be evoked by hand using
 
 ## DACPAC files
 
-Other NTBS repositories such as [ntbs-reporting](https://github.com/publichealthengland/ntbs-reporting) include DACPAC files of the databases they are reliant on.
+Other NTBS repositories such as [ntbs-specimen-matching](https://github.com/publichealthengland/ntbs-specimen-matching) and [ntbs-reporting](https://github.com/publichealthengland/ntbs-reporting) include DACPAC files of the databases they are reliant on.
 If you have made changes to the NTBS database then these files need to be updated in the corresponding repository.
 The easiest way to create the DACPAC file is through SSMS, instructions can be found [here.](https://sqlplayer.net/2018/10/how-to-create-dacpac-file/)


### PR DESCRIPTION
Based on a conversation with Nancy:

When we change the NTBS schema, we need to update the specimen matching DACPAC as well as the reporting DACPAC. Add this fact to the PR template and EF migration README.