### PR TITLE
NTBS-2150 Correct the migration for an empty database

### DIFF
--- a/ntbs-service/Migrations/20210323082014_ReseedNotificationTable.cs
+++ b/ntbs-service/Migrations/20210323082014_ReseedNotificationTable.cs
@@ -7,7 +7,7 @@ namespace ntbs_service.Migrations
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.Sql(@"
-                IF ((SELECT last_value FROM sys.identity_columns WHERE object_id = OBJECT_ID('Notification')) < 300000)
+                IF ((IDENT_CURRENT('Notification')) < 300000)
                     DBCC CHECKIDENT('Notification', RESEED, 300000);
             ");
         }


### PR DESCRIPTION
I realised that the previous migration would not have worked for an empty database, because `last_value` would have been `NULL` and in SQL, `NULL < 300000` is `false`.

I've gone for a "revise history" approach, because this migration is equivalent to the previous one on all databases where it has been run. The only difference would be if we applied the migrations to a new database.