### PR TITLE
NTBS-2168 Saving M bovis questionnaire bugfix

### DIFF
--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -434,7 +434,7 @@ namespace ntbs_service.Services
         {
             _context.SetValues(notification.MBovisDetails, new
             {
-                HasExposureToKnownCases = mBovisDetails.ExposureToKnownCasesStatus
+                mBovisDetails.ExposureToKnownCasesStatus
             });
             await _notificationRepository.SaveChangesAsync();
         }
@@ -443,7 +443,7 @@ namespace ntbs_service.Services
         {
             _context.SetValues(notification.MBovisDetails, new
             {
-                HasUnpasteurisedMilkConsumption = mBovisDetails.UnpasteurisedMilkConsumptionStatus
+                mBovisDetails.UnpasteurisedMilkConsumptionStatus
             });
             await _notificationRepository.SaveChangesAsync();
         }
@@ -452,14 +452,17 @@ namespace ntbs_service.Services
         {
             _context.SetValues(notification.MBovisDetails, new
             {
-                HasOccupationExposure = mBovisDetails.OccupationExposureStatus
+                mBovisDetails.OccupationExposureStatus
             });
             await _notificationRepository.SaveChangesAsync();
         }
 
         public async Task UpdateMBovisDetailsAnimalExposureAsync(Notification notification, MBovisDetails mBovisDetails)
         {
-            _context.SetValues(notification.MBovisDetails, new {HasAnimalExposure = mBovisDetails.AnimalExposureStatus});
+            _context.SetValues(notification.MBovisDetails, new
+            {
+                mBovisDetails.AnimalExposureStatus
+            });
             await _notificationRepository.SaveChangesAsync();
         }
 


### PR DESCRIPTION
## Description
* Fix _M. bovis_ questionnaire saving: this was broken in NTBS-2168, #1135, and is now fixed.
* Regression tests for saving _M. bovis_ questionnaire forms. When a regression test saves an _M. bovis_ form, the pages are then checked to see that the submitted changes have actually been saved.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Tested editing each type of M. bovis event locally