### PR TITLE
NTBS-2184 fieldsets and labels fixes

### DIFF
--- a/ntbs-service/Pages/Admin/Migration.cshtml
+++ b/ntbs-service/Pages/Admin/Migration.cshtml
@@ -19,7 +19,7 @@
                 to track the created jobs
             </nhs-inset-text>
         }
-        
+
         <label nhs-label-type="Standard" asp-for="NotificationIds">Notification Ids</label>
         <nhs-hint nhs-hint-type="Standard">Enter ids here, or upload a of ids with a single id per line</nhs-hint>
         <input nhs-input-type="Standard" asp-for="NotificationIds">
@@ -41,33 +41,36 @@
                     var notificationDateStartError = !Model.ValidationService.IsValid(nameof(Model.NotificationDateRangeStart));
                     var notificationDateStartGroupState = notificationDateStartError ? Error : Standard;
                 }
-                <nhs-form-group nhs-form-group-type=@notificationDateStartGroupState classes="nhs-form-group--import-by-date">
-                    <span nhs-span-type="ErrorMessage" id="notification-start-date-error" classes="import-error"
-                          asp-validation-for="NotificationDateRangeStart" has-error="@notificationDateStartError"></span>
-                    <label nhs-label-type="Standard" for="notification-start-date"> Start date </label>
-                    <nhs-date-input id="notification-start-date">
-                        <nhs-date-input-item>
-                            <nhs-form-group nhs-form-group-type="Standard">
-                                <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Day">Day</label>
-                                <input ref="dayInput" nhs-input-type="Date" fixed-width="Two"
-                                       is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Day"/>
-                            </nhs-form-group>
-                        </nhs-date-input-item>
-                        <nhs-date-input-item>
-                            <nhs-form-group nhs-form-group-type="Standard">
-                                <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Month">Month</label>
-                                <input ref="monthInput" nhs-input-type="Date" fixed-width="Two"
-                                       is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Month"/>
-                            </nhs-form-group>
-                        </nhs-date-input-item>
-                        <nhs-date-input-item>
-                            <nhs-form-group nhs-form-group-type="Standard">
-                                <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Year">Year</label>
-                                <input ref="yearInput" nhs-input-type="Date" fixed-width="Four"
-                                       is-error-input=@notificationDateStartError asp-for="NotificationDateRangeStart.Year"/>
-                            </nhs-form-group>
-                        </nhs-date-input-item>
-                    </nhs-date-input>
+                <nhs-form-group nhs-form-group-type="@notificationDateStartGroupState" classes="nhs-form-group--import-by-date">
+                    <nhs-fieldset aria-describedby="notification-start-date-error">
+                        <nhs-fieldset-legend nhs-legend-size="Standard"> Start date </nhs-fieldset-legend>
+                        <span nhs-span-type="ErrorMessage" id="notification-start-date-error" classes="import-error"
+                              asp-validation-for="NotificationDateRangeStart" has-error="@notificationDateStartError"></span>
+
+                        <nhs-date-input id="notification-start-date">
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Day">Day</label>
+                                    <input ref="dayInput" nhs-input-type="Date" fixed-width="Two"
+                                           is-error-input="@notificationDateStartError" asp-for="NotificationDateRangeStart.Day"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Month">Month</label>
+                                    <input ref="monthInput" nhs-input-type="Date" fixed-width="Two"
+                                           is-error-input="@notificationDateStartError" asp-for="NotificationDateRangeStart.Month"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="NotificationDateRangeStart.Year">Year</label>
+                                    <input ref="yearInput" nhs-input-type="Date" fixed-width="Four"
+                                           is-error-input="@notificationDateStartError" asp-for="NotificationDateRangeStart.Year"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                        </nhs-date-input>
+                    </nhs-fieldset>
                 </nhs-form-group>
             </date-input>
 
@@ -76,33 +79,35 @@
                     var notificationDateEndError = !Model.ValidationService.IsValid(nameof(Model.NotificationDateRangeEnd));
                     var notificationDateEndGroupState = notificationDateEndError ? Error : Standard;
                 }
-                <nhs-form-group nhs-form-group-type=@notificationDateEndGroupState classes="nhs-form-group--import-by-date">
-                    <span nhs-span-type="ErrorMessage" id="notification-end-date-error" classes="import-error"
-                          asp-validation-for="NotificationDateRangeEnd" has-error="@notificationDateEndError"></span>
-                    <label nhs-label-type="Standard" for="notification-end-date"> End date </label>
-                    <nhs-date-input id="notification-end-date">
-                        <nhs-date-input-item>
-                            <nhs-form-group nhs-form-group-type="Standard">
-                                <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Day">Day</label>
-                                <input nhs-input-type="Date" fixed-width="Two" ref="dayInput"
-                                       is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Day"/>
-                            </nhs-form-group>
-                        </nhs-date-input-item>
-                        <nhs-date-input-item>
-                            <nhs-form-group nhs-form-group-type="Standard">
-                                <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Month">Month</label>
-                                <input nhs-input-type="Date" fixed-width="Two" ref="monthInput"
-                                       is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Month"/>
-                            </nhs-form-group>
-                        </nhs-date-input-item>
-                        <nhs-date-input-item>
-                            <nhs-form-group nhs-form-group-type="Standard">
-                                <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Year">Year</label>
-                                <input nhs-input-type="Date" fixed-width="Four" ref="yearInput"
-                                       is-error-input=@notificationDateEndError asp-for="NotificationDateRangeEnd.Year"/>
-                            </nhs-form-group>
-                        </nhs-date-input-item>
-                    </nhs-date-input>
+                <nhs-form-group nhs-form-group-type="@notificationDateEndGroupState" classes="nhs-form-group--import-by-date">
+                    <nhs-fieldset aria-describedby="notification-end-date-error">
+                        <nhs-fieldset-legend nhs-legend-size="Standard"> End date </nhs-fieldset-legend>
+                        <span nhs-span-type="ErrorMessage" id="notification-end-date-error" classes="import-error"
+                              asp-validation-for="NotificationDateRangeEnd" has-error="@notificationDateEndError"></span>
+                        <nhs-date-input id="notification-end-date">
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Day">Day</label>
+                                    <input nhs-input-type="Date" fixed-width="Two" ref="dayInput"
+                                           is-error-input="@notificationDateEndError" asp-for="NotificationDateRangeEnd.Day"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Month">Month</label>
+                                    <input nhs-input-type="Date" fixed-width="Two" ref="monthInput"
+                                           is-error-input="@notificationDateEndError" asp-for="NotificationDateRangeEnd.Month"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="NotificationDateRangeEnd.Year">Year</label>
+                                    <input nhs-input-type="Date" fixed-width="Four" ref="yearInput"
+                                           is-error-input="@notificationDateEndError" asp-for="NotificationDateRangeEnd.Year"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                        </nhs-date-input>
+                    </nhs-fieldset>
                 </nhs-form-group>
             </date-input>
         </nhs-fieldset>

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisExposureToKnownCase.cshtml
@@ -82,64 +82,66 @@
                         var pheNotifiedGroupState = pheNotifiedError ? Error : Standard;
                     }
                     <nhs-form-group nhs-form-group-type="@pheNotifiedGroupState" ref="formGroup">
-                        <label nhs-label-type="Standard" asp-for="MBovisExposureToKnownCase.NotifiedToPheStatus">
-                            @Html.DisplayNameFor(x => x.MBovisExposureToKnownCase.NotifiedToPheStatus)
-                        </label>
-                        <span nhs-span-type="ErrorMessage" id="notified-error"
-                            ref="errorField" asp-validation-for="MBovisExposureToKnownCase.NotifiedToPheStatus" has-error="@pheNotifiedError">
-                        </span>
-                        <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
-                            <div class="nhsuk-radios__item">
-                                <input asp-for="MBovisExposureToKnownCase.NotifiedToPheStatus" id="notified-yes" class="nhsuk-radios__input" type="radio" value="@Status.Yes" data-aria-controls="conditional-notified-to-phe">
-                                <label class="nhsuk-label nhsuk-radios__label" for="notified-yes">
-                                    Yes
-                                </label>
-                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-notified-to-phe">
-                                    @{
-                                        var hasRelatedNotificationError = !Model.IsValid($"{nameof(Model.MBovisExposureToKnownCase)}.{nameof(Model.MBovisExposureToKnownCase.ExposureNotificationId)}");
-                                        var relatedNotificationGroupState = hasRelatedNotificationError ? Error : Standard;
-                                    }
-                                    <validate-related-notification model="@nameof(Model.MBovisExposureToKnownCase)" allow-draft="false" allow-legacy-notifications="true" inline-template>
-                                        <nhs-form-group
-                                            id="@($"{nameof(MBovisExposureToKnownCase)}-{nameof(MBovisExposureToKnownCase.ExposureNotificationId)}")"
-                                            nhs-form-group-type="@relatedNotificationGroupState"
-                                            aria-describedby="related-notification-error">
-                                            <label nhs-label-type="Standard" asp-for="MBovisExposureToKnownCase.ExposureNotificationId">
-                                                @Html.DisplayNameFor(m => m.MBovisExposureToKnownCase.ExposureNotificationId)
-                                            </label>
-                                            <span
-                                                id="related-notification-error"
-                                                nhs-span-type="ErrorMessage"
-                                                ref="errorField"
-                                                has-error="@hasRelatedNotificationError"
-                                                asp-validation-for="MBovisExposureToKnownCase.ExposureNotificationId">
-                                            </span>
-                                            <input
-                                                nhs-input-type="Standard"
-                                                ref="inputField"
-                                                v-on:blur="validate"
-                                                is-error-input="@hasRelatedNotificationError"
-                                                fixed-width="Ten"
-                                                asp-for="MBovisExposureToKnownCase.ExposureNotificationId">
-                                            <notification-info v-if="isValid" v-bind:notification-info="relatedNotification"></notification-info>
-                                            <notification-warning v-if="hasWarningMessage" v-bind:warning-message="warningMessage"></notification-warning>
-                                        </nhs-form-group>
-                                    </validate-related-notification>
+                        <nhs-fieldset aria-describedby="notified-error">
+                            <nhs-fieldset-legend nhs-legend-size="Standard">
+                                @Html.DisplayNameFor(x => x.MBovisExposureToKnownCase.NotifiedToPheStatus)
+                            </nhs-fieldset-legend>
+                            <span nhs-span-type="ErrorMessage" id="notified-error"
+                                  ref="errorField" asp-validation-for="MBovisExposureToKnownCase.NotifiedToPheStatus" has-error="@pheNotifiedError">
+                            </span>
+                            <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
+                                <div class="nhsuk-radios__item">
+                                    <input asp-for="MBovisExposureToKnownCase.NotifiedToPheStatus" id="notified-yes" class="nhsuk-radios__input" type="radio" value="@Status.Yes" data-aria-controls="conditional-notified-to-phe">
+                                    <label class="nhsuk-label nhsuk-radios__label" for="notified-yes">
+                                        Yes
+                                    </label>
+                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-notified-to-phe">
+                                        @{
+                                            var hasRelatedNotificationError = !Model.IsValid($"{nameof(Model.MBovisExposureToKnownCase)}.{nameof(Model.MBovisExposureToKnownCase.ExposureNotificationId)}");
+                                            var relatedNotificationGroupState = hasRelatedNotificationError ? Error : Standard;
+                                        }
+                                        <validate-related-notification model="@nameof(Model.MBovisExposureToKnownCase)" allow-draft="false" allow-legacy-notifications="true" inline-template>
+                                            <nhs-form-group
+                                                id="@($"{nameof(MBovisExposureToKnownCase)}-{nameof(MBovisExposureToKnownCase.ExposureNotificationId)}")"
+                                                nhs-form-group-type="@relatedNotificationGroupState"
+                                                aria-describedby="related-notification-error">
+                                                <label nhs-label-type="Standard" asp-for="MBovisExposureToKnownCase.ExposureNotificationId">
+                                                    @Html.DisplayNameFor(m => m.MBovisExposureToKnownCase.ExposureNotificationId)
+                                                </label>
+                                                <span
+                                                    id="related-notification-error"
+                                                    nhs-span-type="ErrorMessage"
+                                                    ref="errorField"
+                                                    has-error="@hasRelatedNotificationError"
+                                                    asp-validation-for="MBovisExposureToKnownCase.ExposureNotificationId">
+                                                </span>
+                                                <input
+                                                    nhs-input-type="Standard"
+                                                    ref="inputField"
+                                                    v-on:blur="validate"
+                                                    is-error-input="@hasRelatedNotificationError"
+                                                    fixed-width="Ten"
+                                                    asp-for="MBovisExposureToKnownCase.ExposureNotificationId">
+                                                <notification-info v-if="isValid" v-bind:notification-info="relatedNotification"></notification-info>
+                                                <notification-warning v-if="hasWarningMessage" v-bind:warning-message="warningMessage"></notification-warning>
+                                            </nhs-form-group>
+                                        </validate-related-notification>
+                                    </div>
+                                </div>
+                                <div class="nhsuk-radios__item">
+                                    <input asp-for="MBovisExposureToKnownCase.NotifiedToPheStatus" id="notified-no" class="nhsuk-radios__input" type="radio" value="@Status.No">
+                                    <label class="nhsuk-label nhsuk-radios__label" for="notified-no">
+                                        No
+                                    </label>
+                                </div>
+                                <div class="nhsuk-radios__item">
+                                    <input asp-for="MBovisExposureToKnownCase.NotifiedToPheStatus" id="notified-unknown" class="nhsuk-radios__input" type="radio" value="@Status.Unknown">
+                                    <label class="nhsuk-label nhsuk-radios__label" for="notified-unknown">
+                                        Unknown
+                                    </label>
                                 </div>
                             </div>
-                            <div class="nhsuk-radios__item">
-                                <input asp-for="MBovisExposureToKnownCase.NotifiedToPheStatus" id="notified-no" class="nhsuk-radios__input" type="radio" value="@Status.No">
-                                <label class="nhsuk-label nhsuk-radios__label" for="notified-no">
-                                    No
-                                </label>
-                            </div>
-                            <div class="nhsuk-radios__item">
-                                <input asp-for="MBovisExposureToKnownCase.NotifiedToPheStatus" id="notified-unknown" class="nhsuk-radios__input" type="radio" value="@Status.Unknown">
-                                <label class="nhsuk-label nhsuk-radios__label" for="notified-unknown">
-                                    Unknown
-                                </label>
-                            </div>
-                        </div>
+                        </nhs-fieldset>
                     </nhs-form-group>
                 </nhs-grid-column>
 

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
@@ -51,7 +51,7 @@
                         </nhs-form-group>
                     </validate-input>
                     <br/>
-                    
+
                     <conditional-select-wrapper :value-condition-function='@countryConditionFunctionString' inline-template>
                         <nhs-fieldset>
                             <nhs-fieldset-legend nhs-legend-size="Standard">
@@ -88,64 +88,66 @@
                                 }
                                 <validate-input model="MDRDetails" property="NotifiedToPheStatus" inline-template>
                                     <nhs-form-group nhs-form-group-type="@pheNotifiedGroupState" ref="formGroup">
-                                        <label nhs-label-type="Standard" asp-for="MDRDetails.NotifiedToPheStatus">
-                                            @Html.DisplayNameFor(x => x.MDRDetails.NotifiedToPheStatus)
-                                        </label>
-                                        <span nhs-span-type="ErrorMessage" id="notified-to-phe-error"
-                                            ref="errorField" asp-validation-for="MDRDetails.NotifiedToPheStatus" has-error="@pheNotifiedError">
-                                        </span>
-                                        <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios" v-on:change="validate">
-                                            <div class="nhsuk-radios__item">
-                                                <input asp-for="MDRDetails.NotifiedToPheStatus" id="notified-yes" class="nhsuk-radios__input" type="radio" value="@Status.Yes" data-aria-controls="conditional-related-notification">
-                                                <label class="nhsuk-label nhsuk-radios__label" for="notified-yes">
-                                                    Yes
-                                                </label>
-                                                <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-related-notification">
-                                                    @{
-                                                        var hasRelatedNotificationError = !Model.IsValid("MDRDetails.RelatedNotificationId");
-                                                        var relatedNotificationGroupState = hasRelatedNotificationError ? Error : Standard;
-                                                    }
-                                                    <validate-related-notification allow-draft="true" allow-legacy-notifications="true" inline-template>
-                                                        <nhs-form-group
-                                                            id="@($"{nameof(Model.MDRDetails.RelatedNotificationId)}")"
-                                                            nhs-form-group-type="@relatedNotificationGroupState"
-                                                            aria-describedby="related-notification-error">
-                                                            <label nhs-label-type="Standard" asp-for="MDRDetails.RelatedNotificationId">
-                                                                @Html.DisplayNameFor(m => m.MDRDetails.RelatedNotificationId)
-                                                            </label>
-                                                            <span
-                                                                id="related-notification-error"
-                                                                nhs-span-type="ErrorMessage"
-                                                                ref="errorField"
-                                                                has-error="@hasRelatedNotificationError"
-                                                                asp-validation-for="MDRDetails.RelatedNotificationId">
-                                                            </span>
-                                                            <input
-                                                                nhs-input-type="Standard"
-                                                                ref="inputField"
-                                                                v-on:blur="validate"
-                                                                is-error-input="@hasRelatedNotificationError"
-                                                                fixed-width="Ten"
-                                                                asp-for="MDRDetails.RelatedNotificationId">
-                                                            <notification-info v-if="isValid" v-bind:notification-info="relatedNotification"></notification-info>
-                                                            <notification-warning v-if="hasWarningMessage" v-bind:warning-message="warningMessage"></notification-warning>
-                                                        </nhs-form-group>
-                                                    </validate-related-notification>
+                                        <nhs-fieldset aria-describedby="notified-to-phe-error">
+                                            <nhs-fieldset-legend nhs-legend-size="Standard">
+                                                @Html.DisplayNameFor(x => x.MDRDetails.NotifiedToPheStatus)
+                                            </nhs-fieldset-legend>
+                                            <span nhs-span-type="ErrorMessage" id="notified-to-phe-error"
+                                                  ref="errorField" asp-validation-for="MDRDetails.NotifiedToPheStatus" has-error="@pheNotifiedError">
+                                            </span>
+                                            <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios" v-on:change="validate">
+                                                <div class="nhsuk-radios__item">
+                                                    <input asp-for="MDRDetails.NotifiedToPheStatus" id="notified-yes" class="nhsuk-radios__input" type="radio" value="@Status.Yes" data-aria-controls="conditional-related-notification">
+                                                    <label class="nhsuk-label nhsuk-radios__label" for="notified-yes">
+                                                        Yes
+                                                    </label>
+                                                    <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-related-notification">
+                                                        @{
+                                                            var hasRelatedNotificationError = !Model.IsValid("MDRDetails.RelatedNotificationId");
+                                                            var relatedNotificationGroupState = hasRelatedNotificationError ? Error : Standard;
+                                                        }
+                                                        <validate-related-notification allow-draft="true" allow-legacy-notifications="true" inline-template>
+                                                            <nhs-form-group
+                                                                id="@($"{nameof(Model.MDRDetails.RelatedNotificationId)}")"
+                                                                nhs-form-group-type="@relatedNotificationGroupState"
+                                                                aria-describedby="related-notification-error">
+                                                                <label nhs-label-type="Standard" asp-for="MDRDetails.RelatedNotificationId">
+                                                                    @Html.DisplayNameFor(m => m.MDRDetails.RelatedNotificationId)
+                                                                </label>
+                                                                <span
+                                                                    id="related-notification-error"
+                                                                    nhs-span-type="ErrorMessage"
+                                                                    ref="errorField"
+                                                                    has-error="@hasRelatedNotificationError"
+                                                                    asp-validation-for="MDRDetails.RelatedNotificationId">
+                                                                </span>
+                                                                <input
+                                                                    nhs-input-type="Standard"
+                                                                    ref="inputField"
+                                                                    v-on:blur="validate"
+                                                                    is-error-input="@hasRelatedNotificationError"
+                                                                    fixed-width="Ten"
+                                                                    asp-for="MDRDetails.RelatedNotificationId">
+                                                                <notification-info v-if="isValid" v-bind:notification-info="relatedNotification"></notification-info>
+                                                                <notification-warning v-if="hasWarningMessage" v-bind:warning-message="warningMessage"></notification-warning>
+                                                            </nhs-form-group>
+                                                        </validate-related-notification>
+                                                    </div>
+                                                </div>
+                                                <div class="nhsuk-radios__item">
+                                                    <input asp-for="MDRDetails.NotifiedToPheStatus" id="notified-no" class="nhsuk-radios__input" type="radio" value="@Status.No">
+                                                    <label class="nhsuk-label nhsuk-radios__label" for="notified-no">
+                                                        No
+                                                    </label>
+                                                </div>
+                                                <div class="nhsuk-radios__item">
+                                                    <input asp-for="MDRDetails.NotifiedToPheStatus" id="notified-unknown" class="nhsuk-radios__input" type="radio" value="@Status.Unknown">
+                                                    <label class="nhsuk-label nhsuk-radios__label" for="notified-unknown">
+                                                        Unknown
+                                                    </label>
                                                 </div>
                                             </div>
-                                            <div class="nhsuk-radios__item">
-                                                <input asp-for="MDRDetails.NotifiedToPheStatus" id="notified-no" class="nhsuk-radios__input" type="radio" value="@Status.No">
-                                                <label class="nhsuk-label nhsuk-radios__label" for="notified-no">
-                                                    No
-                                                </label>
-                                            </div>
-                                            <div class="nhsuk-radios__item">
-                                                <input asp-for="MDRDetails.NotifiedToPheStatus" id="notified-unknown" class="nhsuk-radios__input" type="radio" value="@Status.Unknown">
-                                                <label class="nhsuk-label nhsuk-radios__label" for="notified-unknown">
-                                                    Unknown
-                                                </label>
-                                            </div>
-                                        </div>
+                                        </nhs-fieldset>
                                     </nhs-form-group>
                                 </validate-input>
                             </div>

--- a/ntbs-service/Pages/ServiceDirectory/Index.cshtml
+++ b/ntbs-service/Pages/ServiceDirectory/Index.cshtml
@@ -9,7 +9,7 @@
 <nhs-width-container container-width="Standard">
     <h1 class="nhsuk-heading-xl">Service directory</h1>
     <p>Search for a service or case manager</p>
-    
+
     <form method="get" autocomplete="off">
         @{
             var hasSearchKeywordError = !Model.IsValid("SearchKeyword");
@@ -19,7 +19,8 @@
             <span ref="errorField" nhs-span-type="ErrorMessage" id="search-keyword-error"
                   asp-validation-for="SearchKeyword" has-error="@hasSearchKeywordError">
             </span>
-            <input is-error-input=@hasSearchKeywordError
+            <label class="nhsuk-u-visually-hidden" for="search-field">Search for a service or case manager</label>
+            <input is-error-input=@hasSearchKeywordError id="search-field"
                    nhs-input-type="Standard" asp-for="SearchKeyword" fixed-width="Twenty">
             
             <button class="nhsuk-search__submit case-manager-search-button" type="submit">
@@ -30,9 +31,9 @@
             </button>
         </nhs-form-group>
     </form>
-    
+
     <h2 class="nhsuk-heading-l">Regions</h2>
-    
+
     <div>
         @foreach (var region in Model.AllRegions)
         {

--- a/ntbs-service/Pages/ServiceDirectory/Index.cshtml
+++ b/ntbs-service/Pages/ServiceDirectory/Index.cshtml
@@ -22,8 +22,8 @@
             <label class="nhsuk-u-visually-hidden" for="search-field">Search for a service or case manager</label>
             <input is-error-input=@hasSearchKeywordError id="search-field"
                    nhs-input-type="Standard" asp-for="SearchKeyword" fixed-width="Twenty">
-            
-            <button class="nhsuk-search__submit case-manager-search-button" type="submit">
+
+            <button class="case-manager-search-button" type="submit">
                 <svg class="nhsuk-icon nhsuk-icon__search" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                     <path d="M19.71 18.29l-4.11-4.1a7 7 0 1 0-1.41 1.41l4.1 4.11a1 1 0 0 0 1.42 0 1 1 0 0 0 0-1.42zM5 10a5 5 0 1 1 5 5 5 5 0 0 1-5-5z"></path>
                 </svg>

--- a/ntbs-service/wwwroot/css/caseManager.scss
+++ b/ntbs-service/wwwroot/css/caseManager.scss
@@ -27,12 +27,12 @@
     width: 70%;
     margin-bottom: 18px;
     border-bottom: 1px solid #cccccc;
-  
+
     a {
         text-decoration: none;
         color: #005eb8;
     }
-  
+
     .case-manager-search-result-name {
         font-size: 19px;
     }
@@ -49,7 +49,7 @@
 
     .nhsuk-summary-list__row {
         font-size: 16px;
-      
+
         .nhsuk-summary-list__key {
             width: 10%;
             min-width: 100px;
@@ -72,9 +72,58 @@
     display: flex;
 }
 
+// This is based on the nhsuk-search__submit class for wide viewports
+// However the narrow-viewport version is not a style that we want, so we have our own class that just uses the styles
+// for wide viewports. The original can be found at:
+// https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/components/header/_header.scss
 .case-manager-search-button {
-  padding-top: 4px;
-  border-bottom: 2px solid #4c6272;
-  border-top: 2px solid #4c6272;
-  border-right: 2px solid #4c6272;
+    padding-top: 4px;
+    border-bottom: 2px solid #4c6272;
+    border-top: 2px solid #4c6272;
+    border-right: 2px solid #4c6272;
+    border-left: 0;
+    background-color: $color_nhsuk-grey-5;
+    border-radius: 0 $nhsuk-border-radius $nhsuk-border-radius 0;
+
+    display: block;
+    float: right;
+    font-size: inherit;
+    height: 40px;
+    line-height: inherit;
+    outline: none;
+    width: 44px;
+
+    .nhsuk-icon__search {
+        fill: $color_nhsuk-blue;
+        height: 27px;
+        width: 27px;
+    }
+
+    &::-moz-focus-inner {
+        border: 0;
+    }
+
+    &:hover {
+        background-color: $color_shade_nhsuk-blue-35;
+        border: 1px solid $color_nhsuk-white;
+        cursor: pointer;
+
+      .nhsuk-icon__search {
+          fill: $color_nhsuk-white;
+      }
+    }
+
+    &:focus {
+        @include nhsuk-focused-button();
+        box-shadow: 0 -2px $nhsuk-focus-color, 0 $nhsuk-focus-width $nhsuk-focus-text-color;
+    }
+
+    &:active {
+        background-color: $color_shade_nhsuk-blue-50;
+        border: 0;
+
+        .nhsuk-icon__search {
+            fill: $color_nhsuk-white;
+        }
+    }
 }


### PR DESCRIPTION
## Description
* Fix the fieldsets and labels of a few pages, to improve site accessibility. Changes were made to:
    * M. bovis exposure to known cases - add case form
    * MDR details form
    * Import Legacy Notifications form
    * Search box and button for Service Directory Search
* Fix search button for narrow screens: the search button style for narrow screens is different to what we need, it is larger and green. We are not really using the button in the context that is written for. Instead, make our own search button style based on the NHS search button style, without the unwanted style change for narrow screens.

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
