### PR TITLE
NTBS-2180: Audit when users print notification overview

### DIFF
--- a/ntbs-service/Helpers/UsernameHelper.cs
+++ b/ntbs-service/Helpers/UsernameHelper.cs
@@ -7,7 +7,7 @@ namespace ntbs_service.Helpers
         public static string GetUsername(HttpContext context)
         {
             // Identity name is a fallback for if user doesn't have an email associated with them - as is the case with our test users
-            return context.User.Username() ?? context.User.Identity.Name;
+            return string.IsNullOrEmpty(context.User.Username()) ? context.User.Identity.Name : context.User.Username();
         }
     }
 }

--- a/ntbs-service/Helpers/UsernameHelper.cs
+++ b/ntbs-service/Helpers/UsernameHelper.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace ntbs_service.Helpers
+{
+    public class UsernameHelper
+    {
+        public static string GetUsername(HttpContext context)
+        {
+            // Identity name is a fallback for if user doesn't have an email associated with them - as is the case with our test users
+            return context.User.Username() ?? context.User.Identity.Name;
+        }
+    }
+}

--- a/ntbs-service/Middleware/AuditGetRequestMiddleware.cs
+++ b/ntbs-service/Middleware/AuditGetRequestMiddleware.cs
@@ -43,12 +43,7 @@ namespace ntbs_service.Middleware
 
                 if (shouldAudit && int.TryParse(pathArray[notificationIndex + 1], out var id))
                 {
-                    var userName = context.User.Username();
-                    // Fallback if user doesn't have an email associated with them - as is the case with our test users
-                    if (string.IsNullOrEmpty(userName))
-                    {
-                        userName = context.User.Identity.Name;
-                    }
+                    var userName = UsernameHelper.GetUsername(context);
 
                     // TODO: Differentiate between Cluster and Full view.
                     await auditService.AuditNotificationReadAsync(id, NotificationAuditType.Full, userName);

--- a/ntbs-service/Pages/Notifications/Overview.cshtml
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml
@@ -1,4 +1,4 @@
-@page "/Notifications/{NotificationId:int}/{handler:regex(^(CreateLink)$)?}"
+@page "/Notifications/{NotificationId:int}/{handler?}"
 @using ntbs_service.Helpers
 @model OverviewModel
 

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -106,7 +106,7 @@ namespace ntbs_service.Pages.Notifications
         
         public async Task<ContentResult> OnPostAuditPrintAsync()
         {
-            await _auditService.AuditPrint(NotificationId, HttpContext.User.Username() ?? HttpContext.User.Identity.Name);
+            await _auditService.AuditPrint(NotificationId, UsernameHelper.GetUsername(HttpContext));
             return new ContentResult();
         }
     }

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
 using ntbs_service.Helpers;
@@ -14,6 +15,7 @@ namespace ntbs_service.Pages.Notifications
     {
         private readonly IAlertService _alertService;
         private readonly ICultureAndResistanceService _cultureAndResistanceService;
+        private readonly IAuditService _auditService;
 
         public CultureAndResistance CultureAndResistance { get; set; }
         public Dictionary<int, List<TreatmentEvent>> GroupedTreatmentEvents { get; set; }
@@ -30,10 +32,12 @@ namespace ntbs_service.Pages.Notifications
             IAuthorizationService authorizationService,
             IAlertService alertService,
             INotificationRepository notificationRepository,
-            ICultureAndResistanceService cultureAndResistanceService) : base(service, authorizationService, notificationRepository)
+            ICultureAndResistanceService cultureAndResistanceService,
+            IAuditService auditService) : base(service, authorizationService, notificationRepository)
         {
             _alertService = alertService;
             _cultureAndResistanceService = cultureAndResistanceService;
+            _auditService = auditService;
         }
 
         public async Task<IActionResult> OnGetAsync()
@@ -98,6 +102,12 @@ namespace ntbs_service.Pages.Notifications
         public async Task GetAlertsAsync()
         {
             Alerts = await _alertService.GetAlertsForNotificationAsync(NotificationId, User);
+        }
+        
+        public async Task<ContentResult> OnPostAuditPrintAsync()
+        {
+            await _auditService.AuditPrint(NotificationId, HttpContext.User.Username() ?? HttpContext.User.Identity.Name);
+            return new ContentResult();
         }
     }
 }

--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -1,6 +1,7 @@
 @using ntbs_service.Helpers
 @using ntbs_service.Models.Enums
 @model ntbs_service.Pages.Notifications.NotificationModelBase
+@Html.AntiForgeryToken()
 
 <nhs-grid-row classes="no-print">
     @{
@@ -66,13 +67,11 @@
 
                 @if (Model.Notification.NotificationStatus != NotificationStatus.Draft)
                 {
-                    <form method="post">
-                        <print-button inline-template>
-                            <a role="button" draggable="false" class="nhsuk-button ntbsuk-button--secondary hidden" v-on:click="print" id="print-notification-overview-button">
-                                Print notification overview
-                            </a>
-                        </print-button>
-                    </form>
+                    <print-button inline-template>
+                        <button nhs-button-type="Standard" classes="ntbsuk-button--secondary hidden" v-on:click="print" id="print-notification-overview-button">
+                            Print notification overview
+                        </button>
+                    </print-button>
                 }
 
                 @if (Model.Notification.NotificationStatus == NotificationStatus.Notified && Model.PermissionLevel == PermissionLevel.Edit)

--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -66,11 +66,13 @@
 
                 @if (Model.Notification.NotificationStatus != NotificationStatus.Draft)
                 {
-                    <print-button inline-template>
-                        <button nhs-button-type="Standard" classes="ntbsuk-button--secondary hidden" v-on:click="print" id="print-notification-overview-button">
-                            Print notification overview
-                        </button>
-                    </print-button>
+                    <form method="post">
+                        <print-button inline-template>
+                            <a role="button" draggable="false" class="nhsuk-button ntbsuk-button--secondary hidden" v-on:click="print" id="print-notification-overview-button">
+                                Print notification overview
+                            </a>
+                        </print-button>
+                    </form>
                 }
 
                 @if (Model.Notification.NotificationStatus == NotificationStatus.Notified && Model.PermissionLevel == PermissionLevel.Edit)

--- a/ntbs-service/Services/AuditService.cs
+++ b/ntbs-service/Services/AuditService.cs
@@ -18,6 +18,8 @@ namespace ntbs_service.Services
             string labReferenceNumber,
             string userName,
             NotificationAuditType auditType);
+        Task AuditPrint(int notificationId,
+            string userName);
         Task<IList<AuditLog>> GetWriteAuditsForNotification(int notificationId);
     }
 
@@ -30,6 +32,7 @@ namespace ntbs_service.Services
         private const string UNMATCH_EVENT = "Unmatch";
         private const string MATCH_EVENT = "Match";
         private const string SPECIMEN_ENTITY_TYPE = "Specimen";
+        private const string PRINT_EVENT = "Print";
 
         public AuditService(AuditDatabaseContext auditContext)
         {
@@ -87,6 +90,18 @@ namespace ntbs_service.Services
                 .Where(log => log.RootEntity == RootEntities.Notification)
                 .Where(log => log.RootId == notificationId.ToString())
                 .ToListAsync();
+        }
+
+        public async Task AuditPrint(int notificationId, string userName)
+        {
+            await _auditContext.AuditOperationAsync(
+                notificationId.ToString(),
+                RootEntities.Notification,
+                null,
+                PRINT_EVENT,
+                userName,
+                RootEntities.Notification,
+                notificationId.ToString());
         }
     }
 }

--- a/ntbs-service/wwwroot/source/Components/PrintButton.ts
+++ b/ntbs-service/wwwroot/source/Components/PrintButton.ts
@@ -1,4 +1,6 @@
 ﻿import Vue from "vue";
+import axios, {Method} from "axios";
+import {buildPath, getHeaders} from "../helpers";
 
 const PrintButton = Vue.extend({
     mounted:  function () {
@@ -7,6 +9,15 @@ const PrintButton = Vue.extend({
     methods: {
         print: function () {
             window.print();
+            const requestConfig = {
+                method: "post" as Method,
+                url: buildPath('AuditPrint'),
+                headers: getHeaders()
+            };
+            axios.request(requestConfig)
+                .catch((error: any) => {
+                    console.log(error.response);
+                });
         }
     }
 });


### PR DESCRIPTION
## Description
Now audit when a user prints the notification overview. Added a form wrapping the print button (so that the request verification token exists) and also changed the nhs-button to a link tag which is styled as a button (which is documented in the nhs frontend button readme) so that the button didn't submit the form - all the nhs buttons are submit.

## Checklist:
- [x] Automated tests are passing locally.
