### PR TITLE
NTBS-2170 Show M bovis questions if data has been entered

### DIFF
--- a/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
@@ -88,7 +88,7 @@ namespace ntbs_service_unit_tests.Services
         [InlineData("M. bovis", Status.Yes, Status.Yes, Status.Yes, Status.Yes, false, true)]
         [InlineData("M. bovis", Status.Unknown, Status.Unknown, Status.Unknown, Status.Unknown, false, true)]
         [InlineData("Non M. bovis", null, null, null, null, false, true)]
-        [InlineData("Non M. bovis", null, Status.No, Status.Unknown, Status.Yes, false, true)]
+        [InlineData("Non M. bovis", null, Status.No, Status.Unknown, Status.Yes, true, false)]
         [InlineData("Non M. bovis", Status.Yes, Status.Yes, Status.Yes, Status.Yes, false, true)]
         [InlineData("Non M. bovis", Status.No, Status.No, Status.No, Status.No, false, true)]
         [InlineData("Non M. bovis", Status.Unknown, Status.Unknown, Status.Unknown, Status.Unknown, false, true)]

--- a/ntbs-service/Helpers/DrugResistanceHelper.cs
+++ b/ntbs-service/Helpers/DrugResistanceHelper.cs
@@ -18,10 +18,12 @@ namespace ntbs_service.Helpers
 
         public static bool MdrDetailsEntered(Status? exposureToKnownCaseStatus) => exposureToKnownCaseStatus.HasValue;
 
-        public static bool IsMbovis(DrugResistanceProfile profile)
+        public static bool IsMbovis(DrugResistanceProfile profile, MBovisDetails mBovisDetails)
         {
-            // If the lab results point to M. bovis species ...
-            return string.Equals("M. bovis", profile.Species, StringComparison.InvariantCultureIgnoreCase);
+            // If the lab results point to M. bovis species, or if some of the M. bovis questionnaire has already been filled in
+            // This might occur with non-M. bovis lab results if the questionnaire was done in a legacy system and migrated in.
+            return string.Equals("M. bovis", profile.Species, StringComparison.InvariantCultureIgnoreCase)
+                   || mBovisDetails.DataEntered;
         }
 
         public static bool IsMBovisQuestionnaireComplete(MBovisDetails mBovisDetails)

--- a/ntbs-service/Models/Entities/NotificationDisplay.cs
+++ b/ntbs-service/Models/Entities/NotificationDisplay.cs
@@ -25,7 +25,7 @@ namespace ntbs_service.Models.Entities
 
         public bool MdrDetailsEntered => DrugResistanceHelper.MdrDetailsEntered(MDRDetails.ExposureToKnownCaseStatus);
 
-        public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile);
+        public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile, MBovisDetails);
 
         public bool IsMBovisQuestionnaireComplete =>
             DrugResistanceHelper.IsMBovisQuestionnaireComplete(MBovisDetails);

--- a/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
+++ b/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
@@ -25,7 +25,7 @@ namespace ntbs_service.Models.Projections
         public bool IsMdr => DrugResistanceHelper.IsMdr(DrugResistanceProfile, TreatmentRegimen, ExposureToKnownMdrCaseStatus);
         public bool MdrDetailsEntered => DrugResistanceHelper.MdrDetailsEntered(ExposureToKnownMdrCaseStatus);
 
-        public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile);
+        public bool IsMBovis => DrugResistanceHelper.IsMbovis(DrugResistanceProfile, MBovisDetails);
         public bool IsMBovisQuestionnaireComplete =>
             DrugResistanceHelper.IsMBovisQuestionnaireComplete(MBovisDetails);
     }


### PR DESCRIPTION
## Description
Show _M. bovis_ questions if the notification has `Species = 'M. bovis'`, or if any of the _M. bovis_ questions have already been filled out.

This reverts the change made in 0be9dc06.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Tested with a notification with a filled in _M. bovis_ questionnaire but `Species = 'No result'`