### PR TITLE
NTBS-1987 Split transfer events into own period

### DIFF
--- a/ntbs-service/Models/PaginationParametersBase.cs
+++ b/ntbs-service/Models/PaginationParametersBase.cs
@@ -1,4 +1,4 @@
-using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations.Schema;
 
 namespace ntbs_service.Models
 {

--- a/ntbs-service/Models/TreatmentPeriod.cs
+++ b/ntbs-service/Models/TreatmentPeriod.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using ntbs_service.Models.Entities;
+
+namespace ntbs_service.Models
+{
+    [NotMapped]
+    public class TreatmentPeriod
+    {
+        public int? PeriodNumber { get; }
+        public bool IsTransfer { get; }
+        public List<TreatmentEvent> TreatmentEvents { get; }
+
+        private TreatmentPeriod(int? periodNumber, bool isTransfer, TreatmentEvent treatmentEvent)
+        {
+            PeriodNumber = periodNumber;
+            IsTransfer = isTransfer;
+            TreatmentEvents = new List<TreatmentEvent> { treatmentEvent };
+        }
+
+        public static TreatmentPeriod CreateTreatmentPeriod(int? periodNumber, TreatmentEvent treatmentEvent)
+        {
+            return new TreatmentPeriod(periodNumber, false, treatmentEvent);
+        }
+
+        public static TreatmentPeriod CreateTransferPeriod(TreatmentEvent treatmentEvent)
+        {
+            return new TreatmentPeriod(null, true, treatmentEvent);
+        }
+    }
+}

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
 using ntbs_service.Helpers;
+using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
 using ntbs_service.Models.ReferenceEntities;
@@ -16,7 +17,7 @@ namespace ntbs_service.Pages.Notifications
         private readonly ICultureAndResistanceService _cultureAndResistanceService;
 
         public CultureAndResistance CultureAndResistance { get; set; }
-        public Dictionary<int, List<TreatmentEvent>> GroupedTreatmentEvents { get; set; }
+        public List<TreatmentPeriod> TreatmentPeriods { get; set; }
 
         public bool Should12MonthOutcomeBeDisplayed { get; set; }
         public bool Should24MonthOutcomeBeDisplayed { get; set; }
@@ -62,7 +63,7 @@ namespace ntbs_service.Pages.Notifications
             }
 
             CultureAndResistance = await _cultureAndResistanceService.GetCultureAndResistanceDetailsAsync(NotificationId);
-            GroupedTreatmentEvents = Notification.TreatmentEvents.GroupByEpisode();
+            TreatmentPeriods = Notification.TreatmentEvents.GroupEpisodesIntoPeriods();
 
             CalculateTreatmentOutcomes();
             return Page();

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -17,7 +17,7 @@
     }
 </div>
 
-@if (Model.GroupedTreatmentEvents.Count > 0)
+@if (Model.TreatmentPeriods.Count > 0)
 {
      <div class="notification-overview-details-container">
         <div class="event-outcome-at-dates">
@@ -43,19 +43,20 @@
             }
         </div>
 
-        @for (var episodeNumber = 1; episodeNumber <= Model.GroupedTreatmentEvents.Count; episodeNumber++)
+        @foreach (var period in Model.TreatmentPeriods)
         {
-            var treatmentEvents = Model.GroupedTreatmentEvents[episodeNumber];
-
             <div>
-                <h4 class="episode-grouping-overview-heading">Treatment period @episodeNumber</h4>
-                @if (treatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
+                <h4 class="episode-grouping-overview-heading">
+                    @(period.IsTransfer ? "Transfer" :  $"Treatment period {period.PeriodNumber}")
+                </h4>
+
+                @if (period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
                 {
-                    <span>@treatmentEvents.First().FormattedEventDate to @treatmentEvents.Last().FormattedEventDate</span>
+                    <span>@period.TreatmentEvents.First().FormattedEventDate to @period.TreatmentEvents.Last().FormattedEventDate</span>
                 }
                 else
                 {
-                    <span>@treatmentEvents.First().FormattedEventDate to Present</span>
+                    <span>@period.TreatmentEvents.First().FormattedEventDate to Present</span>
                 }
             </div>
             <nhs-table classes="nhsuk-table--reduced-font" responsive>
@@ -66,7 +67,7 @@
                     <nhs-table-item classes="one-sixth-column">Case Manager</nhs-table-item>
                 </nhs-table-head>
                 <nhs-table-body>
-                    @foreach (var treatmentEvent in treatmentEvents)
+                    @foreach (var treatmentEvent in period.TreatmentEvents)
                     {
                         <nhs-table-body-row>
                             <nhs-table-item heading-text="Date">


### PR DESCRIPTION
## Description
Visually separate transfer out events from the other treatment events in their period. To this end, make a TreatmentPeriod class that contains a list of events, corresponding to each period on the website. These TreatmentPeriod objects are numbered, and a flag to denote a transfer-out-only period, to be displayed separately but without a number.

Amend unit tests to reflect the new way treatment episodes are grouped.

## Checklist:
- [x] Automated tests are passing locally.