### PR TITLE
NTBS-2216 Add the NHS polyfills

### DIFF
--- a/ntbs-service/wwwroot/source/app.ts
+++ b/ntbs-service/wwwroot/source/app.ts
@@ -12,6 +12,7 @@ import * as Sentry from '@sentry/browser';
 import * as SentryIntegrations from '@sentry/integrations';
 // @ts-ignore
 import Details from '../../node_modules/nhsuk-frontend/packages/components/details/details';
+import '../../node_modules/nhsuk-frontend/packages/polyfills';
 import VueAccessibleModal from 'vue-accessible-modal'
 import cssVars from 'css-vars-ponyfill';
 // Components


### PR DESCRIPTION
## Description
We should add the NHS polyfills, else components will break in IE11. This is part of the [instructions for setting up the NHS frontend](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/installation/installing-with-npm.md#option-2-import-javascript-using-modules) but this had been missed until now.


## Checklist:
- [x] Automated tests are passing locally.
- [x] Checked rendering in IE11 and Chrome