### PR TITLE
NTBS-2125: Show release version in the footer

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -5,6 +5,7 @@ using ntbs_integration_tests.LabResultsPage;
 using ntbs_integration_tests.NotificationPages;
 using ntbs_integration_tests.TransferPage;
 using ntbs_service.DataAccess;
+using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
@@ -128,6 +129,7 @@ namespace ntbs_integration_tests.Helpers
             context.User.AddRange(GetCaseManagers());
             context.CaseManagerTbService.AddRange(GetCaseManagerTbServicesJoinEntries());
             context.Alert.AddRange(GetSeedingAlerts());
+            context.ReleaseVersion.Add(new ReleaseVersion {Version = "test-version", Date = DateTime.UtcNow});
 
             // Entities required for specific test suites
             context.Notification.AddRange(OverviewPageTests.GetSeedingNotifications());

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -65,6 +65,8 @@ namespace ntbs_service.DataAccess
         public virtual DbSet<MBovisOccupationExposure> MBovisOccupationExposures { get; set; }
         public virtual DbSet<MBovisAnimalExposure> MBovisAnimalExposure { get; set; }
         public DbSet<NotificationAndDuplicateIds> NotificationAndDuplicateIds { get; set; }
+        
+        public DbSet<ReleaseVersion> ReleaseVersion { get; set; }
 
         public virtual void SetValues<TEntityClass>(TEntityClass entity, TEntityClass values)
         {
@@ -118,6 +120,10 @@ namespace ntbs_service.DataAccess
             var treatmentRegimentEnumConverter = new EnumToStringConverter<TreatmentRegimen>();
 
             #endregion
+
+            modelBuilder.Entity<ReleaseVersion>(entity =>
+                entity.HasKey(rv => rv.Version)
+            );
 
             modelBuilder.Entity<Country>(entity =>
             {

--- a/ntbs-service/Migrations/20210408092956_AddReleaseVersion.Designer.cs
+++ b/ntbs-service/Migrations/20210408092956_AddReleaseVersion.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210408092956_AddReleaseVersion")]
+    partial class AddReleaseVersion
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210408092956_AddReleaseVersion.cs
+++ b/ntbs-service/Migrations/20210408092956_AddReleaseVersion.cs
@@ -18,6 +18,10 @@ namespace ntbs_service.Migrations
                 {
                     table.PrimaryKey("PK_ReleaseVersion", x => x.Version);
                 });
+            migrationBuilder.InsertData(
+                table: "ReleaseVersion",
+                columns: new[] { "Version", "Date" },
+                values: new object[] { "pre-release", DateTime.UtcNow });
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/ntbs-service/Migrations/20210408092956_AddReleaseVersion.cs
+++ b/ntbs-service/Migrations/20210408092956_AddReleaseVersion.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class AddReleaseVersion : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ReleaseVersion",
+                columns: table => new
+                {
+                    Version = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    Date = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ReleaseVersion", x => x.Version);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ReleaseVersion");
+        }
+    }
+}

--- a/ntbs-service/Models/ReleaseVersion.cs
+++ b/ntbs-service/Models/ReleaseVersion.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace ntbs_service.Models
+{
+    public class ReleaseVersion
+    {
+        public string Version { get; set; }
+
+        public DateTime Date { get; set; }
+    }
+}

--- a/ntbs-service/Pages/Shared/_Footer.cshtml
+++ b/ntbs-service/Pages/Shared/_Footer.cshtml
@@ -1,31 +1,38 @@
+@using ntbs_service.Services
+@inject IVersionService VersionService
+
 <footer class="govuk-footer footer" role="contentinfo">
     <div class="govuk-width-container">
         <div class="govuk-footer__meta footer-body-and-copyright">
             <div class="govuk-footer__meta-item govuk-footer__meta-item--grow footer-body no-print">
                 <h2 class="govuk-visually-hidden">Support links</h2>
-                <ul class="govuk-footer__inline-list footer-link-list">
-                    <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link footer-link" href="https://www.england.nhs.uk/tuberculosis-strategy-for-england-2015-2020/" target="_blank" rel="noopener noreferrer">
-                            TB Strategy
-                        </a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link footer-link" href="https://www.gov.uk/government/publications/tuberculosis-in-england-annual-report" target="_blank" rel="noopener noreferrer">
-                            Annual report
-                        </a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link footer-link" href="https://fingertips.phe.org.uk/profile/tb-monitoring" target="_blank" rel="noopener noreferrer">
-                            Fingertips
-                        </a>
-                    </li>
-                    <li class="govuk-footer__inline-list-item">
-                        <a class="govuk-footer__link footer-link" href="#3">
-                            Accessibility Statement
-                        </a>
-                    </li>
-                </ul>
-
+                <div class="footer-list-and-release">
+                    <ul class="govuk-footer__inline-list footer-link-list">
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link footer-link" href="https://www.england.nhs.uk/tuberculosis-strategy-for-england-2015-2020/" target="_blank" rel="noopener noreferrer">
+                                TB Strategy
+                            </a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link footer-link" href="https://www.gov.uk/government/publications/tuberculosis-in-england-annual-report" target="_blank" rel="noopener noreferrer">
+                                Annual report
+                            </a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link footer-link" href="https://fingertips.phe.org.uk/profile/tb-monitoring" target="_blank" rel="noopener noreferrer">
+                                Fingertips
+                            </a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link footer-link" href="#3">
+                                Accessibility Statement
+                            </a>
+                        </li>
+                    </ul>
+                    <p class="govuk-footer__link footer-link footer-version">
+                        Release-@VersionService.GetReleaseVersion().Version-@VersionService.GetReleaseVersion().Date.ToShortDateString()
+                    </p>
+                </div>
                 <svg role="presentation" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
                     <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
                 </svg>

--- a/ntbs-service/Services/VersionService.cs
+++ b/ntbs-service/Services/VersionService.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
+using ntbs_service.Models;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Entities.Alerts;
+using ntbs_service.Models.Enums;
+using Serilog;
+
+namespace ntbs_service.Services
+{
+    public interface IVersionService
+    {
+        ReleaseVersion GetReleaseVersion();
+
+    }
+
+    public class VersionService : IVersionService
+    {
+        private readonly NtbsContext _context;
+
+
+        public VersionService(
+            NtbsContext context)
+        {
+            _context = context;
+        }
+
+        public ReleaseVersion GetReleaseVersion()
+        {
+            return this._context.ReleaseVersion.SingleOrDefault() ?? new ReleaseVersion{Version = "unknown"};
+        }
+    }
+}

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -196,6 +196,7 @@ namespace ntbs_service
             services.AddScoped<IDataQualityRepository, DataQualityRepository>();
             services.AddScoped<IDrugResistanceProfileRepository, DrugResistanceProfileRepository>();
             services.AddScoped<IFaqRepository, FaqRepository>();
+            services.AddScoped<IVersionService, VersionService>();
 
             // Services
             services.AddScoped<INotificationService, NotificationService>();

--- a/ntbs-service/wwwroot/css/footer.scss
+++ b/ntbs-service/wwwroot/css/footer.scss
@@ -39,3 +39,13 @@
     margin-bottom: 5px;
 }
 
+.footer-list-and-release {
+  display: flex;
+  justify-content: space-between;
+}
+
+.footer-version {
+  margin: 4px auto auto auto;
+  padding: 0 10px;
+}
+


### PR DESCRIPTION
## Description
Added release version table and service. The release version and date is then displayed in the footer.
This PR is linked to these pull requests in other repos:
https://github.com/publichealthengland/ntbs-reporting/pull/29
https://github.com/publichealthengland/ntbs-data-migration/pull/98
https://github.com/publichealthengland/ntbs-specimen-matching/pull/6

I didn't want to update the DACPACs if there were changes to be made, so I'll do that after approval.

## Checklist:
- [x] Automated tests are passing locally.
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [x] EF migrations created and committed. Snapshot committed
- [x] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Specimen matching database DACPAC updated
