### PR TITLE
NTBS-2099: Anonymise notification data in migration logs

### DIFF
--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -177,7 +177,8 @@ namespace ntbs_service.DataMigration
                 return validationsResults;
             }
 
-            var message = $"Case manager assigned to notification is not present in NTBS database";
+            // As we have imported the case manager in a previous step we don't expect to see this message
+            var message = "Case manager assigned to notification is not present in NTBS database";
             validationsResults.Add(new ValidationResult(message, new[] { nameof(details.CaseManagerUsername) }));
 
             return validationsResults;

--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -177,7 +177,7 @@ namespace ntbs_service.DataMigration
                 return validationsResults;
             }
 
-            var message = $"Case manager {details.CaseManagerUsername} is not present in NTBS database";
+            var message = $"Case manager assigned to notification is not present in NTBS database";
             validationsResults.Add(new ValidationResult(message, new[] { nameof(details.CaseManagerUsername) }));
 
             return validationsResults;

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -131,17 +131,15 @@ namespace ntbs_service.DataMigration
 
         private async Task<ImportResult> ValidateAndImportNotificationGroupAsync(PerformContext context, string requestId, List<Notification> notifications)
         {
-            var patientFullName = notifications.First().PatientDetails.FullName;
-            var patientInitials = $"{notifications.First().PatientDetails.GivenName[0]}.{notifications.First().PatientDetails.FamilyName[0]}.";
-            var importResult = new ImportResult(patientFullName);
+            var importResult = new ImportResult(notifications.First().PatientDetails.FullName);
 
-            _logger.LogInformation(context, requestId, $"{notifications.Count} notifications found to import for patient with initials {patientInitials}");
+            _logger.LogInformation(context, requestId, $"{notifications.Count} notifications found to import in notification group containing legacy ID {notifications.First().LegacyId}");
 
             // Verify that no repeated NotificationIds have returned
             var ids = notifications.Select(n => n.LegacyId).ToList();
             if (ids.Distinct().Count() != ids.Count)
             {
-                var errorMessage = $"Duplicate records found ({string.Join(',', ids)}) - aborting import for patient with initials {patientInitials}";
+                var errorMessage = $"Duplicate records found ({string.Join(',', ids)}) - aborting import for notification group containing legacy ID {notifications.First().LegacyId}";
                 importResult.AddGroupError(errorMessage);
                 _logger.LogImportFailure(context, requestId, errorMessage);
                 return importResult;
@@ -176,7 +174,7 @@ namespace ntbs_service.DataMigration
 
             if (isAnyNotificationInvalid)
             {
-                _logger.LogImportFailure(context, requestId, $"Terminating importing notifications for  patient with initials {patientInitials} due to validation errors");
+                _logger.LogImportFailure(context, requestId, $"Terminating importing notification group containing legacy ID {notifications.First().LegacyId} due to validation errors");
                 return importResult;
             }
 
@@ -192,7 +190,7 @@ namespace ntbs_service.DataMigration
                 var newIdsString = string.Join(" ,", savedNotifications.Select(x => x.NotificationId));
                 _logger.LogSuccess(context, requestId, $"Imported notifications have following Ids: {newIdsString}");
 
-                _logger.LogInformation(context, requestId, $"Finished importing notification for  patient with initials {patientInitials}");
+                _logger.LogInformation(context, requestId, $"Finished importing notification group containing legacy ID {notifications.First().LegacyId}");
             }
             catch (MarkingNotificationsAsImportedFailedException e)
             {
@@ -203,7 +201,7 @@ namespace ntbs_service.DataMigration
             catch (Exception e)
             {
                 Log.Error(e, e.Message);
-                _logger.LogImportFailure(context, requestId, message: $"Failed to save notification for patient with initials {patientInitials} or mark it as imported ", e);
+                _logger.LogImportFailure(context, requestId, message: $"Failed to save notification in notification group containing legacy ID {notifications.First().LegacyId} or mark it as imported ", e);
                 importResult.AddGroupError($"{e.Message}: {e.StackTrace}");
             }
             return importResult;


### PR DESCRIPTION
## Description
When migrating in notifications we were logging sensitive information - the notification patient name and potentially the case manager username. I have removed the username from the log message and changed the patient name to initials - I thought that it may be useful to know this if for example you're checking the notification in the database.

## Checklist:
- [x] Automated tests are passing locally.