### PR TITLE
NTBS-2098: Use staging environment for azure environments to enable detailed sentry logs

### DIFF
--- a/ntbs-service/appsettings.Staging.json
+++ b/ntbs-service/appsettings.Staging.json
@@ -7,8 +7,8 @@
     "Dsn": "https://b3c915cf2d2e4c769073f587052bd39b@sentry.io/2703466",
     "IncludeRequestPayload": true,
     "SendDefaultPii": true,
-    "AttachStackTrace": false,
-    "Debug": false,
+    "AttachStackTrace": true,
+    "Debug": true,
     "DiagnosticsLevel": "Error"
   }
 }

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -19,6 +19,8 @@ spec:
         ports:
         - containerPort: 8080
         env:
+          - name: ASPNETCORE_ENVIRONMENT
+            value: "Staging"
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -19,6 +19,8 @@ spec:
         ports:
         - containerPort: 8080
         env:
+          - name: ASPNETCORE_ENVIRONMENT
+            value: "Staging"
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -19,6 +19,8 @@ spec:
         ports:
         - containerPort: 8080
         env:
+          - name: ASPNETCORE_ENVIRONMENT
+            value: "Staging"
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Description
I have disabled attaching stack trace (which does not affect stack traces sent with exceptions - these are always sent) and debug (in the documentation it says that it is generally advised that this is off in production). I have also created a new version of app settings for "staging" environments - which we will use for our azure environments. This has the old production settings, sending everything to sentry that it can so we can have all the available information during development of any issues. 

## Checklist:
- [x] Automated tests are passing locally.
