### PR TITLE
NTBS-2199 Improve linked notification hyperlinking

### DIFF
--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -31,6 +31,7 @@ namespace ntbs_service.Pages.Notifications
             NotificationRepository = notificationRepository;
         }
         public int NumberOfLinkedNotifications { get; set; }
+        public int? LatestLinkedNotificationId { get; private set; }
 
         public Notification Notification { get; set; }
         public NotificationBannerModel NotificationBannerModel { get; set; }
@@ -74,6 +75,7 @@ namespace ntbs_service.Pages.Notifications
                     Notification.Group = notificationGroup;
                 }
                 NumberOfLinkedNotifications = Notification.Group?.Notifications.Count - 1 ?? 0;
+                LatestLinkedNotificationId = Notification.Group?.Notifications.LastOrDefault()?.NotificationId;
             }
         }
 

--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -58,9 +58,9 @@
                         </button>
                     </form>
                 }
-                else if (Model.Notification.Group?.Notifications != null && Model.NotificationId != Model.Notification.Group.Notifications.LastOrDefault()?.NotificationId)
+                else if (Model.LatestLinkedNotificationId.HasValue && Model.LatestLinkedNotificationId != Model.NotificationId)
                 {
-                    <a id='new-linked-notification-button' class="nhsuk-button ntbsuk-button--secondary" role="button" href="/Notifications/@Model.Notification.Group.Notifications.LastOrDefault()?.NotificationId/Overview">
+                    <a id='new-linked-notification-button' class="nhsuk-button ntbsuk-button--secondary" role="button" href="@RouteHelper.GetNotificationPath(Model.LatestLinkedNotificationId.Value, NotificationSubPaths.Overview)">
                         Navigate to latest linked notification
                     </a>
                 }


### PR DESCRIPTION
## Description
Use the route helper for more robust linking between the notification actions overview and the overview page.

Also, improve the way latest linked notification IDs are determined, cover a case for possible nulls and bring the data manipulation out of the view.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Linked notification links now have the correct `href` values