### PR TITLE
NTBS-2180: No longer show print audit in notification changes and add test

### DIFF
--- a/ntbs-service-unit-tests/Services/AuditServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AuditServiceTest.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using EFAuditer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Graph;
+using ntbs_service.Models.SeedData;
+using ntbs_service.Services;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Services
+{
+    public class AuditServiceTest : IDisposable
+    {
+        private readonly AuditDatabaseContext _context;
+        private readonly AuditService _auditService;
+
+        public AuditServiceTest()
+        {
+            _context = SetupTestContext();
+            _auditService = new AuditService(_context);
+        }
+
+        public void Dispose()
+        {
+            _context.Dispose();
+        }
+
+        [Fact]
+        public async Task CorrectlyFiltersReadAndPrintAuditLogs()
+        {
+            // Arrange
+            _context.AuditLogs.AddRange(new List<AuditLog>
+            {
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "32", EventType = AuditEventType.READ_EVENT, AuditData = "Read a book"},
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "32", EventType = AuditEventType.PRINT_EVENT, AuditData = "Printed a book"},
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "32", EventType = AuditEventType.MATCH_EVENT, AuditData = "Used matches"},
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "32", EventType = AuditEventType.UNMATCH_EVENT, AuditData = "Put down matches"}
+            });
+            _context.SaveChanges();
+            
+            // Act
+            var notificationLogs = await _auditService.GetWriteAuditsForNotification(32);
+
+            // Assert
+            Assert.Equal(2, notificationLogs.Count);
+            Assert.Empty(notificationLogs.Where(log => log.EventType == AuditEventType.PRINT_EVENT));
+            Assert.Empty(notificationLogs.Where(log => log.EventType == AuditEventType.READ_EVENT));
+            Assert.Contains("Used matches", notificationLogs.Select(log => log.AuditData));
+            Assert.Contains("Put down matches", notificationLogs.Select(log => log.AuditData));
+        }
+
+        [Fact]
+        public async Task CorrectlyFiltersRootEntityTypeAndRootId()
+        {
+            // Arrange
+            _context.AuditLogs.AddRange(new List<AuditLog>
+            {
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "33", EventType = AuditEventType.MATCH_EVENT, AuditData = "Used matches"},
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "33", EventType = AuditEventType.UNMATCH_EVENT, AuditData = "Put down matches"},
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "32", EventType = AuditEventType.MATCH_EVENT, AuditData = "Used matches"}, 
+                new AuditLog{RootEntity = RootEntities.Notification, RootId = "32", EventType = AuditEventType.UNMATCH_EVENT, AuditData = "Put down matches"},
+                new AuditLog{RootEntity = "SomethingElse", RootId = "33", EventType = AuditEventType.MATCH_EVENT, AuditData = "Used matches"}
+            });
+            _context.SaveChanges();
+            
+            // Act
+            var notificationLogs = await _auditService.GetWriteAuditsForNotification(33);
+
+            // Assert
+            Assert.Equal(2, notificationLogs.Count);
+            Assert.Empty(notificationLogs.Where(log => log.RootEntity != RootEntities.Notification));
+            Assert.Empty(notificationLogs.Where(log => log.RootId != "33"));
+        }
+
+        private AuditDatabaseContext SetupTestContext()
+        {
+            // Generating a unique database name makes sure the database is not shared between tests.
+            string dbName = Guid.NewGuid().ToString();
+            return new AuditDatabaseContext(new DbContextOptionsBuilder<AuditDatabaseContext>()
+                .UseInMemoryDatabase(dbName)
+                .Options
+            );
+        }
+    }
+}

--- a/ntbs-service/Models/SeedData/AuditEventType.cs
+++ b/ntbs-service/Models/SeedData/AuditEventType.cs
@@ -1,0 +1,10 @@
+﻿namespace ntbs_service.Models.SeedData
+{
+    public static class AuditEventType
+    {
+        public static string READ_EVENT = "Read";
+        public static string UNMATCH_EVENT = "Unmatch";
+        public static string MATCH_EVENT = "Match";
+        public static string PRINT_EVENT = "Print";
+    }
+}

--- a/ntbs-service/Services/AuditService.cs
+++ b/ntbs-service/Services/AuditService.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EFAuditer;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Enums;
+using ntbs_service.Models.SeedData;
 
 namespace ntbs_service.Services
 {
@@ -27,12 +28,8 @@ namespace ntbs_service.Services
     {
         public const string AuditUserSystem = "SYSTEM";
         private readonly AuditDatabaseContext _auditContext;
-
-        private const string READ_EVENT = "Read";
-        private const string UNMATCH_EVENT = "Unmatch";
-        private const string MATCH_EVENT = "Match";
-        private const string SPECIMEN_ENTITY_TYPE = "Specimen";
-        private const string PRINT_EVENT = "Print";
+        
+        public static string SPECIMEN_ENTITY_TYPE = "Specimen";
 
         public AuditService(AuditDatabaseContext auditContext)
         {
@@ -47,7 +44,7 @@ namespace ntbs_service.Services
                 notificationIdString,
                 RootEntities.Notification,
                 auditDetails.ToString(),
-                READ_EVENT,
+                AuditEventType.READ_EVENT,
                 userName,
                 RootEntities.Notification,
                 notificationIdString);
@@ -62,7 +59,7 @@ namespace ntbs_service.Services
                 labReferenceNumber,
                 SPECIMEN_ENTITY_TYPE,
                 auditType.ToString(),
-                UNMATCH_EVENT,
+                AuditEventType.UNMATCH_EVENT,
                 userName,
                 RootEntities.Notification,
                 notificationId.ToString());
@@ -77,19 +74,10 @@ namespace ntbs_service.Services
                 labReferenceNumber,
                 SPECIMEN_ENTITY_TYPE,
                 auditType.ToString(),
-                MATCH_EVENT,
+                AuditEventType.MATCH_EVENT,
                 userName,
                 RootEntities.Notification,
                 notificationId.ToString());
-        }
-
-        public async Task<IList<AuditLog>> GetWriteAuditsForNotification(int notificationId)
-        {
-            return await _auditContext.AuditLogs
-                .Where(log => log.EventType != READ_EVENT && log.EventType != PRINT_EVENT)
-                .Where(log => log.RootEntity == RootEntities.Notification)
-                .Where(log => log.RootId == notificationId.ToString())
-                .ToListAsync();
         }
 
         public async Task AuditPrint(int notificationId, string userName)
@@ -98,10 +86,19 @@ namespace ntbs_service.Services
                 notificationId.ToString(),
                 RootEntities.Notification,
                 null,
-                PRINT_EVENT,
+                AuditEventType.PRINT_EVENT,
                 userName,
                 RootEntities.Notification,
                 notificationId.ToString());
+        }
+
+        public async Task<IList<AuditLog>> GetWriteAuditsForNotification(int notificationId)
+        {
+            return await _auditContext.AuditLogs
+                .Where(log => log.EventType != AuditEventType.READ_EVENT && log.EventType != AuditEventType.PRINT_EVENT)
+                .Where(log => log.RootEntity == RootEntities.Notification)
+                .Where(log => log.RootId == notificationId.ToString())
+                .ToListAsync();
         }
     }
 }

--- a/ntbs-service/Services/AuditService.cs
+++ b/ntbs-service/Services/AuditService.cs
@@ -86,7 +86,7 @@ namespace ntbs_service.Services
         public async Task<IList<AuditLog>> GetWriteAuditsForNotification(int notificationId)
         {
             return await _auditContext.AuditLogs
-                .Where(log => log.EventType != READ_EVENT)
+                .Where(log => log.EventType != READ_EVENT && log.EventType != PRINT_EVENT)
                 .Where(log => log.RootEntity == RootEntities.Notification)
                 .Where(log => log.RootId == notificationId.ToString())
                 .ToListAsync();


### PR DESCRIPTION
## Description
Filter out print events from notification changes section of notification. Also added a test which tests that they are filtered out.

## Checklist:
- [x] Automated tests are passing locally.
