### PR TITLE
NTBS-2225: Fix regions on service directory page

### DIFF
--- a/ntbs-service/Pages/ServiceDirectory/Index.cshtml
+++ b/ntbs-service/Pages/ServiceDirectory/Index.cshtml
@@ -34,7 +34,7 @@
 
     <h2 class="nhsuk-heading-l">Regions</h2>
 
-    <div>
+    <div class="regions-container">
         @foreach (var region in Model.AllRegions)
         {
             <nhs-grid-column grid-column-width="OneQuarter">

--- a/ntbs-service/wwwroot/css/serviceDirectory.scss
+++ b/ntbs-service/wwwroot/css/serviceDirectory.scss
@@ -1,3 +1,7 @@
 ﻿.tb-services-and-case-managers {
     width: 70%;
 }
+
+.regions-container {
+  display: inline-block;
+}

--- a/ntbs-service/wwwroot/css/serviceDirectory.scss
+++ b/ntbs-service/wwwroot/css/serviceDirectory.scss
@@ -3,5 +3,5 @@
 }
 
 .regions-container {
-  display: inline-block;
+    display: inline-block;
 }


### PR DESCRIPTION
## Description
The div that was holding the regions had a height of 0 as it was being populated just by the foreach. Giving it the display style gives it the correct height and the footer no longer overlays any regions.

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
