### PR TITLE
NTBS-NONE Change authentication cookie timeout to 12 hours

### DIFF
--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -5,7 +5,7 @@
     "AdminUserGroup": "App.Auth.NIS.NTBS.Admin",
     "NationalTeamAdGroup": "App.Auth.NIS.NTBS.NTS",
     "ServiceGroupAdPrefix": "App.Auth.NIS.NTBS.Service",
-    "MaxSessionCookieLifetimeInMinutes": 1440
+    "MaxSessionCookieLifetimeInMinutes": 720
   },
   "AdfsOptions": {
     "AdfsUrl": "https://fs-ntbs.uksouth.cloudapp.azure.com"


### PR DESCRIPTION
Based on our conversation on Monday: Timeout the authentication cookies after 12 hours, which should reduce the likelihood that users are logged out during their working days, and instead just need to log in at the start of each day.

I've tested that I can run the app (ie the JSON is not malformed) but nothing more than that, given how small the change is