### PR TITLE
NTBS-1987 Modify treatment period grouping criteria

### DIFF
--- a/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
+++ b/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
@@ -94,6 +94,78 @@ namespace ntbs_service_unit_tests.Helpers
         }
 
         [Fact]
+        public void GroupEpisodesIntoPeriods_GroupsTransfers()
+        {
+            // Arrange
+            List<TreatmentEvent> testTransferEvents = new List<TreatmentEvent>
+            {
+                // Episode 1
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2010, 1, 1), TreatmentEventType = TreatmentEventType.TreatmentStart
+                },
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2011, 1, 1),
+                    TreatmentEventType = TreatmentEventType.TreatmentOutcome,
+                    TreatmentOutcome = new TreatmentOutcome {TreatmentOutcomeType = TreatmentOutcomeType.TreatmentStopped}
+                },
+                // Transfer
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2012, 1, 1), TreatmentEventType = TreatmentEventType.TransferOut
+                },
+                // Episode 2
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2013, 1, 1), TreatmentEventType = TreatmentEventType.TransferIn
+                },
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2014, 1, 1), TreatmentEventType = TreatmentEventType.TreatmentRestart
+                },
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2015, 1, 1),
+                    TreatmentEventType = TreatmentEventType.TransferOut
+                },
+                // Episode 3
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2016, 1, 1),
+                    TreatmentEventType = TreatmentEventType.TransferIn
+                },
+                new TreatmentEvent
+                {
+                    EventDate = new DateTime(2017, 1, 1),
+                    TreatmentEventType = TreatmentEventType.TreatmentOutcome,
+                    TreatmentOutcome = new TreatmentOutcome {TreatmentOutcomeType = TreatmentOutcomeType.Completed}
+                },
+            };
+
+            // Act
+            var periods = testTransferEvents.GroupEpisodesIntoPeriods();
+
+            // Assert
+            Assert.Equal(4, periods.Count);
+            var expectedPeriod0 = TreatmentPeriod.CreateTreatmentPeriod(1, testTransferEvents[0]);
+            expectedPeriod0.TreatmentEvents.Add(testTransferEvents[1]);
+
+            var expectedPeriod1 = TreatmentPeriod.CreateTransferPeriod(testTransferEvents[2]);
+
+            var expectedPeriod2 = TreatmentPeriod.CreateTreatmentPeriod(2, testTransferEvents[3]);
+            expectedPeriod2.TreatmentEvents.AddRange(new[] { testTransferEvents[4], testTransferEvents[5] });
+
+            var expectedPeriod3 = TreatmentPeriod.CreateTreatmentPeriod(3, testTransferEvents[6]);
+            expectedPeriod3.TreatmentEvents.Add(testTransferEvents[7]);
+
+            AssertTreatmentPeriodMatchesExpected(expectedPeriod0, periods[0]);
+            AssertTreatmentPeriodMatchesExpected(expectedPeriod1, periods[1]);
+            AssertTreatmentPeriodMatchesExpected(expectedPeriod2, periods[2]);
+            AssertTreatmentPeriodMatchesExpected(expectedPeriod3, periods[3]);
+        }
+
+        [Fact]
         public void GetMostRecentTreatmentEvent_ReturnsLastTreatmentEvent()
         {
             // Act
@@ -147,9 +219,7 @@ namespace ntbs_service_unit_tests.Helpers
             // Assert
             Assert.Collection(periods,
                 period => Assert.Collection(period.TreatmentEvents,
-                    ev => Assert.Equal(TreatmentEventType.TreatmentStart, ev.TreatmentEventType)
-                ),
-                period => Assert.Collection(period.TreatmentEvents,
+                    ev => Assert.Equal(TreatmentEventType.TreatmentStart, ev.TreatmentEventType),
                     ev => Assert.Equal(TreatmentEventType.TransferOut, ev.TreatmentEventType)
                 ),
                 period => Assert.Collection(period.TreatmentEvents,

--- a/ntbs-service/Helpers/EpisodesExtensionMethods.cs
+++ b/ntbs-service/Helpers/EpisodesExtensionMethods.cs
@@ -29,16 +29,20 @@ namespace ntbs_service.Helpers
 
             foreach (var treatmentEvent in treatmentEvents.OrderForEpisodes())
             {
-                // If a transfer out event, make a new period just for this event
-                if (treatmentEvent.TreatmentEventType == TreatmentEventType.TransferOut)
-                {
-                    treatmentPeriods.Add(TreatmentPeriod.CreateTransferPeriod(treatmentEvent));
-                }
                 // If at the start of a new treatment period, make it and add the event
-                else if (currentTreatmentPeriod == null)
+                if (currentTreatmentPeriod == null)
                 {
-                    currentTreatmentPeriod = TreatmentPeriod.CreateTreatmentPeriod(periodNumber, treatmentEvent);
-                    periodNumber++;
+                    // If a transfer out event, make a special period just for this event
+                    if (treatmentEvent.TreatmentEventType == TreatmentEventType.TransferOut)
+                    {
+                        currentTreatmentPeriod = TreatmentPeriod.CreateTransferPeriod(treatmentEvent);
+                    }
+                    else
+                    {
+                        currentTreatmentPeriod = TreatmentPeriod.CreateTreatmentPeriod(periodNumber, treatmentEvent);
+                        periodNumber++;
+                    }
+
                     treatmentPeriods.Add(currentTreatmentPeriod);
                 }
                 // Otherwise append this event to the existing period


### PR DESCRIPTION
## Description
Change the way treatment events are grouped into periods: only produce a special "Transfer" period if transfer occurs when the previous period has finished. Otherwise, fold the transfer into the existing period.

Update the unit tests to reflect these changes.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Passes acceptance criteria and QA testing examples locally