### PR TITLE
NTBS-2243 When using dummy auth don't require any other AD settings

### DIFF
--- a/ntbs-service/appsettings.CI.json
+++ b/ntbs-service/appsettings.CI.json
@@ -11,9 +11,6 @@
     "DevGroup": "Global.NIS.NTBS.NTS",
     "UseDummyAuth": true
   },
-  "AdfsOptions": {
-    "AdfsUrl": "https://fs-ntbs.uksouth.cloudapp.azure.com"
-  },
   "Hangfire": {
     "Enabled": false
   }

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -12,7 +12,7 @@
     "ClientSecret": "<Provided by deployment secrets>",
     "Authority": "<Provided by deployment secrets>",
     "CallbackPath": "/signin-oidc",
-    "Enabled": false
+    "Enabled": true
   },
   "AppConfig": {
     "AuditingEnabled": true,


### PR DESCRIPTION
Previously, dummy auth (which is used by the integration tests) still had some weird dependencies on the type of AD authentication being used. I've removed these so that dummy auth is truly standalone - when it is used no config for either AdfsOptions or AzureAdOptions is required.

## Checklist:
- [x] Automated tests are passing locally.

