### PR TITLE
NTBS-2236 Get specimen details from specimen matching DB

### DIFF
--- a/ntbs-service/Services/CultureAndResistanceService.cs
+++ b/ntbs-service/Services/CultureAndResistanceService.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.Services
 
         public CultureAndResistanceService(IConfiguration _configuration)
         {
-            connectionString = _configuration.GetConnectionString(Constants.DbConnectionStringReporting);
+            connectionString = _configuration.GetConnectionString(Constants.DbConnectionStringSpecimenMatching);
         }
 
         public async Task<CultureAndResistance> GetCultureAndResistanceDetailsAsync(int notificationId)

--- a/ntbs-service/Services/SpecimenQueryHelper.cs
+++ b/ntbs-service/Services/SpecimenQueryHelper.cs
@@ -80,7 +80,7 @@ namespace ntbs_service.Services
             string.Join(
                 ' ',
                 _selectUnmatchedSpecimensQuery,
-                "FROM [dbo].[ufnGetUnmatchedSpecimensByService] (@param)",
+                "FROM [dbo].[ufnGetUnmatchedSpecimensByTbService] (@param)",
                 _orderByUnmatchedStatement);
 
         public static string GetUnmatchedSpecimensForPhecsQuery =>

--- a/ntbs-service/Services/SpecimenService.cs
+++ b/ntbs-service/Services/SpecimenService.cs
@@ -49,7 +49,6 @@ namespace ntbs_service.Services
 
     public class SpecimenService : ISpecimenService
     {
-        private readonly string _reportingDbConnectionString;
         private readonly string _specimenMatchingDbConnectionString;
         private readonly IAuditService _auditService;
         private readonly IAlertRepository _alertRepository;
@@ -59,8 +58,8 @@ namespace ntbs_service.Services
             IAuditService auditService,
             IAlertRepository alertRepository)
         {
-            _reportingDbConnectionString = configuration.GetConnectionString(Constants.DbConnectionStringReporting);
-            _specimenMatchingDbConnectionString = configuration.GetConnectionString("specimenMatching");
+            _specimenMatchingDbConnectionString =
+                configuration.GetConnectionString(Constants.DbConnectionStringSpecimenMatching);
             _auditService = auditService;
             _alertRepository = alertRepository;
         }
@@ -68,7 +67,7 @@ namespace ntbs_service.Services
         public async Task<IEnumerable<MatchedSpecimen>> GetMatchedSpecimenDetailsForNotificationAsync(
             int notificationId)
         {
-            using (var connection = new SqlConnection(_reportingDbConnectionString))
+            using (var connection = new SqlConnection(_specimenMatchingDbConnectionString))
             {
                 connection.Open();
                 return await connection.QueryAsync<MatchedSpecimen>(
@@ -105,7 +104,7 @@ namespace ntbs_service.Services
         public async Task<IEnumerable<SpecimenMatchPairing>> GetAllSpecimenPotentialMatchesAsync()
         {
             var query = SpecimenQueryHelper.GetAllSpecimenPotentialMatchesQuery;
-            using (var connection = new SqlConnection(_reportingDbConnectionString))
+            using (var connection = new SqlConnection(_specimenMatchingDbConnectionString))
             {
                 connection.Open();
                 return await connection.QueryAsync<SpecimenMatchPairing>(query);
@@ -116,7 +115,7 @@ namespace ntbs_service.Services
             string query,
             string param = null)
         {
-            using (var connection = new SqlConnection(_reportingDbConnectionString))
+            using (var connection = new SqlConnection(_specimenMatchingDbConnectionString))
             {
                 connection.Open();
                 return await connection.QueryAsync<SpecimenBase, SpecimenPotentialMatch, UnmatchedQueryResultRow>(


### PR DESCRIPTION
## Description
Get specimen details from specimen matching DB: previously these stored procedures lived in the reporting DB, but are being moved over as part of NTBS-2236, here: publichealthengland/ntbs-specimen-matching#13. For this to be merged and deployed the changes to the specimen matching DB also need to be merged and deployed.

## Checklist:
- [x] Automated tests are passing locally.
