### PR TITLE
NTBS-2240 Get DRP summary changes view from specimen DB

### DIFF
--- a/ntbs-service/DataAccess/DrugResistanceProfileRepository.cs
+++ b/ntbs-service/DataAccess/DrugResistanceProfileRepository.cs
@@ -15,11 +15,12 @@ namespace ntbs_service.DataAccess
 
     public class DrugResistanceProfileRepository : IDrugResistanceProfileRepository
     {
-        private readonly string _reportingDbConnectionString;
+        private readonly string _specimenMatchingDbConnectionString;
 
         public DrugResistanceProfileRepository(IConfiguration configuration)
         {
-            _reportingDbConnectionString = configuration.GetConnectionString(Constants.DbConnectionStringReporting);
+            _specimenMatchingDbConnectionString =
+                configuration.GetConnectionString(Constants.DbConnectionStringSpecimenMatching);
         }
 
         public async Task<Dictionary<int, DrugResistanceProfile>> GetDrugResistanceProfilesAsync()
@@ -30,7 +31,7 @@ namespace ntbs_service.DataAccess
                     [New Species] AS [Species]
                 FROM [dbo].[vwChangesToDRPSpecies]";
 
-            using (var connection = new SqlConnection(_reportingDbConnectionString))
+            using (var connection = new SqlConnection(_specimenMatchingDbConnectionString))
             {
                 connection.Open();
                 return (await connection.QueryAsync(query)).ToDictionary(


### PR DESCRIPTION
## Description
Get DRP summary changes view from specimen DB: previously this view lived in the reporting DB, but is being moved over
as part of NTBS-2240, here: publichealthengland/ntbs-specimen-matching#14. For this to be merged and deployed the changes to the specimen matching DB also need to be merged and deployed.

## Checklist:
- [x] Automated tests are passing locally.