### PR TITLE
NTBS-2218 Update CSS colour variables

### DIFF
--- a/ntbs-service/Pages/Shared/_Header.cshtml
+++ b/ntbs-service/Pages/Shared/_Header.cshtml
@@ -28,7 +28,7 @@
 
             <div class="govuk-header__logo header-logo-container header-logo">
                 <span class="govuk-header__logotype">
-                    <img src="~/Images/PHE_3268_DIGI_AW-100px.png" class="header-phe-logo" alt="Public Health England logo"/>
+                    <img src="~/Images/PHE_3268_DIGI_AW-100px.png" alt="Public Health England logo"/>
                 </span>
             </div>
             <div class=" govuk-header__link--service-name header-title">

--- a/ntbs-service/wwwroot/css/_colors.scss
+++ b/ntbs-service/wwwroot/css/_colors.scss
@@ -1,14 +1,34 @@
 $phe-red: #822433;
-$phe-red-focus: #610925;
-$dull-red: #D8D8D87f;
-$secondary-button: #425563;
-$secondary-button-focus: #384854;
-$button-drop-shadow: #003317;
+$phe-red-dull: #610925;
+$phe-navy: #002776;
+
 $grey: #999999;
 $lighter-grey: #CCCCCC;
 $shaded-background-color: #F0F4F5;
 
-$phe-navy: #002776;
+$primary-button: $phe-red;
+$primary-button-focus: $phe-red-dull;
+$secondary-button: #425563;
+$secondary-button-focus: #384854;
+$button-drop-shadow: #003317;
+$warning-button: #d4351c;
+$warning-button-focus: #aa2a16;
+
+$manage-notification-circle: $phe-red;
+$manage-notification-expander-background: #ececec;
+$inset-text-border: $phe-red;
+
+$success-green: #00a551;
+$specimen-card-border: $phe-navy;
+
+$page-border: #e5e5e5;
+$header-navigation-background: $phe-red;
+$header-submenu-background: #f9f9f9;
+$breadcrumb-trail-background: #DDDACF;
+$kpi-card: $phe-red;
+
+$button-link-hover: #ffcd60;
+$button-link-focus: $color_nhsuk-warm-yellow;
 
 $banner-header--draft: #dcc2c6;
 $banner-border--draft: #8c3a47;

--- a/ntbs-service/wwwroot/css/_colors.scss
+++ b/ntbs-service/wwwroot/css/_colors.scss
@@ -38,3 +38,10 @@ $banner-header--denotified: #787878;
 $banner-border--denotified: black;
 $banner-header--legacy: #ffdbbc;
 $banner-border--legacy: #ff9c44;
+
+// Translate CSS colours into strings that can be used in URL-encoded SVGs,
+// such as the "Manage notification" circle.
+// See: https://stackoverflow.com/a/25478589
+@function url-friendly-colour($colour) {
+    @return '%23' + str-slice('#{$colour}', 2, -1)
+}

--- a/ntbs-service/wwwroot/css/buttons.scss
+++ b/ntbs-service/wwwroot/css/buttons.scss
@@ -1,12 +1,12 @@
 @import "./colors.scss";
 
 .ntbsuk-button--primary {
-    background-color: $phe-red;
+    background-color: $primary-button;
     box-shadow: 0 4px 0 $button-drop-shadow;
     margin-bottom: 24px;
 
     &:hover {
-        background-color: $phe-red-focus;
+        background-color: $primary-button-focus;
     }
 }
 
@@ -21,10 +21,10 @@
 }
 
 .ntbsuk-button--warning {
-    background-color: #d4351c;
+    background-color: $warning-button;
     box-shadow: 0 4px 0 $button-drop-shadow;
 
     &:hover {
-        background-color: #aa2a16;
+        background-color: $warning-button-focus;
     }
 }

--- a/ntbs-service/wwwroot/css/caseManager.scss
+++ b/ntbs-service/wwwroot/css/caseManager.scss
@@ -1,6 +1,8 @@
-﻿.case-manager-details-edit-container {
+﻿@import "./colors.scss";
+
+.case-manager-details-edit-container {
     display: flex;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid $lighter-grey;
     padding-top: 10px;
     width: 70%;
 }
@@ -26,11 +28,10 @@
 .case-manager-search-result-container {
     width: 70%;
     margin-bottom: 18px;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid $lighter-grey;
 
     a {
         text-decoration: none;
-        color: #005eb8;
     }
 
     .case-manager-search-result-name {
@@ -41,7 +42,7 @@
 .case-manager-results-summary {
     width: 70%;
     margin-bottom: 18px;
-    border-bottom: 1px solid #cccccc;
+    border-bottom: 1px solid $lighter-grey;
 }
 
 .case-manager-search-result-item-summary {
@@ -78,13 +79,12 @@
 // https://github.com/nhsuk/nhsuk-frontend/blob/master/packages/components/header/_header.scss
 .service-directory-search-button {
     padding-top: 4px;
-    border-bottom: 2px solid #4c6272;
-    border-top: 2px solid #4c6272;
-    border-right: 2px solid #4c6272;
+    border-bottom: 2px solid $nhsuk-form-border-color;
+    border-top: 2px solid $nhsuk-form-border-color;
+    border-right: 2px solid $nhsuk-form-border-color;
     border-left: 0;
     background-color: $color_nhsuk-grey-5;
     border-radius: 0 $nhsuk-border-radius $nhsuk-border-radius 0;
-
     display: block;
     float: right;
     font-size: inherit;
@@ -108,9 +108,9 @@
         border: 1px solid $color_nhsuk-white;
         cursor: pointer;
 
-      .nhsuk-icon__search {
-          fill: $color_nhsuk-white;
-      }
+        .nhsuk-icon__search {
+            fill: $color_nhsuk-white;
+        }
     }
 
     &:focus {

--- a/ntbs-service/wwwroot/css/flashMessage.scss
+++ b/ntbs-service/wwwroot/css/flashMessage.scss
@@ -1,10 +1,12 @@
+@import "./colors.scss";
+
 .flash-message {
   padding: 16px;
   margin-bottom: 24px;
   border: 4px solid black;
 
   &.flash-message--success {
-    border-color: #00a551;
+    border-color: $success-green;
   }
 
   .flash-message-title {

--- a/ntbs-service/wwwroot/css/header.scss
+++ b/ntbs-service/wwwroot/css/header.scss
@@ -5,17 +5,17 @@
 }
 
 .header-navigation-background {
-    background: $phe-red;
-  
+    background: $header-navigation-background;
+
     @media print {
-      display: none;
+        display: none;
     }
 }
 
 @media print {
-  .govuk-phase-banner {
-    display: none;
-  } 
+    .govuk-phase-banner {
+        display: none;
+    }
 }
 
 .header-navigation-list {
@@ -28,40 +28,40 @@
     .nav-menu-with-dropdown {
         display: inline-block;
     }
-  
+
     .nav-submenu-list {
         position: absolute;
-        background-color: #f9f9f9;
+        background-color: $header-submenu-background;
         box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
         z-index: 1;
         margin: 13px 0 -13px -10px;
-        border: 1px solid black;        
+        border: 1px solid black;
         list-style-type: none;
         padding: 0;
         overflow: hidden;
     }
-  
+
     .nav-submenu-list .nav-submenu-list-item {
         margin: 0;
         padding: 5px;
         width: 100%;
         outline: 1px solid black;
     }
-  
+
     .nav-with-submenu-header-link {
-      color: white;
+        color: white;
     }
-  
+
     .nav-with-submenu-header {
         margin-bottom: 8px;
-      
+
         @media (min-width: 768px) {
             & {
                 margin-right: 15px;
             }
         }
     }
-  
+
     .nav-submenu-list a {
         color: black;
         padding: 6px 8px;
@@ -70,8 +70,10 @@
         text-align: left;
         font-weight: 200;
     }
-  
-    .show {display: block;}
+
+    .show {
+        display: block;
+    }
 }
 
 body:not(.js-enabled) {
@@ -88,16 +90,16 @@ body:not(.js-enabled) {
 }
 
 .arrow {
-  border: solid white;
-  border-width: 0 3px 3px 0;
-  display: inline-block;
-  padding: 3px;
+    border: solid white;
+    border-width: 0 3px 3px 0;
+    display: inline-block;
+    padding: 3px;
 }
 
 .down {
-  transform: rotate(45deg);
-  -webkit-transform: rotate(45deg);
-  margin-bottom: 3px;
+    transform: rotate(45deg);
+    -webkit-transform: rotate(45deg);
+    margin-bottom: 3px;
 }
 
 .header-title {
@@ -116,12 +118,13 @@ body:not(.js-enabled) {
     margin: 0;
     width: 200px;
     box-sizing: content-box;
+
+    img {
+        height: 30px;
+        width: 200px;
+    }
 }
 
-.header-phe-logo {
-    height: 30px;
-    width: 200px;
-}
 
 .header-expand-menu-button {
     color: black;
@@ -135,7 +138,7 @@ body:not(.js-enabled) {
     .breadcrumb-trail {
         display: block;
         height: 45px;
-        background-color: #DDDACF;
+        background-color: $breadcrumb-trail-background;
         margin-top: 10px;
 
         @media print {
@@ -145,5 +148,5 @@ body:not(.js-enabled) {
 }
 
 .breadcrumb-trail-background {
-    background-color: #DDDACF;
+    background-color: $breadcrumb-trail-background;
 }

--- a/ntbs-service/wwwroot/css/home.scss
+++ b/ntbs-service/wwwroot/css/home.scss
@@ -1,3 +1,5 @@
+@import "./colors.scss";
+
 .heading {
     margin: auto 0;
 }
@@ -17,7 +19,7 @@
 }
 
 .homepage-kpi-card {
-  background-color: $phe-red;
+  background-color: $kpi-card;
   background-clip: content-box;
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }

--- a/ntbs-service/wwwroot/css/labResults.scss
+++ b/ntbs-service/wwwroot/css/labResults.scss
@@ -1,3 +1,5 @@
+@import "./colors.scss";
+
 .lab-results-radio-container {
   width: 60px;
   display: flex;
@@ -67,12 +69,12 @@
 }
 
 .nhsuk-care-card--specimen {
-  @include care-card($phe-navy, $color_nhsuk-white, 4px);
+  @include care-card($specimen-card-border, $color_nhsuk-white, 4px);
 
   .nhsuk-care-card__arrow {
     &:before,
     &:after {
-      border-color: $phe-navy;
+      border-color: $specimen-card-border;
     }
   }
 

--- a/ntbs-service/wwwroot/css/notification.scss
+++ b/ntbs-service/wwwroot/css/notification.scss
@@ -51,7 +51,7 @@
       border-color: black;
       border-style: solid;
       border-radius: 4px;
-      background-color: $dull-red;
+      background-color: $manage-notification-expander-background;
 
       &:focus .nhsuk-details__summary-text {
         box-shadow: none;
@@ -97,7 +97,7 @@
 
   border-top-width: 10px;
   border-top-style: solid;
-  
+
   @media(max-width: 35em) {
     flex-direction: column;
   }
@@ -158,7 +158,7 @@
 }
 
 .nhs-inset-text--ntbs {
-  border-color: $phe-red;
+  border-color: $inset-text-border;
   margin-top: 0;
   margin-bottom: 0;
 }

--- a/ntbs-service/wwwroot/css/notification.scss
+++ b/ntbs-service/wwwroot/css/notification.scss
@@ -62,8 +62,8 @@
       margin-left: 16px;
       color: black;
       text-decoration: none;
-      // Taken from nhs expander, but with colour swapped for phe-red
-      background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%237f0029'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+      // Taken from nhs expander, but with colour swapped for $manage-notification-circle
+      background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='#{url-friendly-colour($manage-notification-circle)}'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
     }
     .nhsuk-details__text {
       display: flex;
@@ -74,8 +74,8 @@
   }
 
   .nhsuk-expander[open] .nhsuk-details__summary-text {
-    // Taken from nhs expander, but with colour swapped for phe-red
-    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='%237f0029'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+    // Taken from nhs expander, but with colour swapped for $manage-notification-circle
+    background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='#{url-friendly-colour($manage-notification-circle)}'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
   }
 }
 

--- a/ntbs-service/wwwroot/css/notificationView.scss
+++ b/ntbs-service/wwwroot/css/notificationView.scss
@@ -1,7 +1,9 @@
+@import "./colors.scss";
+
 .notification-overview-type-and-edit-container {
   display: flex;
-  border-bottom: 1px solid #cccccc;
-  border-top: 1px solid #cccccc;
+  border-bottom: 1px solid $lighter-grey;
+  border-top: 1px solid $lighter-grey;
   padding-top: 10px;
   width: 100%;
 }
@@ -12,7 +14,7 @@
 
 .notification-edit-link {
   margin: auto 5px 14px auto;
-  
+
   @media print {
     display: none;
   }
@@ -45,16 +47,16 @@
 }
 
 .overview-alerts-container {
-  border-top: 1px #cccccc solid;
+  border-top: 1px $lighter-grey solid;
 }
 
 .overview-alert {
-  border-bottom: 1px #cccccc solid;
+  border-bottom: 1px $lighter-grey solid;
   padding: 10px 0;
 }
 
 .episode-grouping-overview-heading {
-  display: inline; 
+  display: inline;
   padding-right: 50px;
 }
 

--- a/ntbs-service/wwwroot/css/site.scss
+++ b/ntbs-service/wwwroot/css/site.scss
@@ -10,6 +10,7 @@
 @import "./reset.scss";
 // We're importing the raw scss instaed of a packaged css bundle since we're using some of the dynamic elements ourselves (colour variables, functions etc)
 @import "../../node_modules/nhsuk-frontend/packages/nhsuk.scss";
+@import "../../node_modules/govuk-frontend/govuk/settings/_colours-applied.scss";
 @import "../../node_modules/vue-accessible-modal/dist/index.css";
 @import "./_colors.scss";
 @import "./checkboxes.scss";
@@ -84,11 +85,11 @@ html {
 }
 
 .border-top {
-  border-top: 1px solid #e5e5e5;
+  border-top: 1px solid $page-border;
 }
 
 .border-bottom {
-  border-bottom: 1px solid #e5e5e5;
+  border-bottom: 1px solid $page-border;
 }
 
 .box-shadow {
@@ -123,7 +124,7 @@ body {
 .contents-list-item--current {
   font-weight: bold;
   padding-left: 10px;
-  border-left: 4px solid #1d70b8;
+  border-left: 4px solid $govuk-link-colour;
 }
 
 .text-align-right {
@@ -198,23 +199,23 @@ body {
 .button-link {
   background: none;
   border: none;
-  color: #003078;
+  color: $nhsuk-link-active-color;
   text-decoration: underline;
   cursor: pointer;
   font-size: large;
   outline: none;
 
   &:hover {
-    background-color: #ffcd60;
-    box-shadow: 0 0 0 4px #ffcd60;
-    color: #212b32;
+    background-color: $button-link-hover;
+    box-shadow: 0 0 0 4px $button-link-hover;
+    color: $nhsuk-focus-text-color;
     text-decoration: none;
   }
 
   &:focus {
-    background-color: #ffb81c;
-    box-shadow: 0 0 0 4px #ffb81c;
-    color: #212b32;
+    background-color: $button-link-focus;
+    box-shadow: 0 0 0 4px $button-link-focus;
+    color: $nhsuk-focus-text-color;
     outline: 4px solid transparent;
     outline-offset: 4px;
   }
@@ -259,7 +260,7 @@ body {
 
   /* If link should be displayed use display-link to explicitly declare behaviour. */
   a.display-link:after {
-    color: #212b32;
+    color: $nhsuk-focus-text-color;
     content: " (Link: " attr(href) ")";
     /* [1] */
     font-size: 14pt;


### PR DESCRIPTION
## Description
- Extract CSS colours out into variables: name all colours used in CSS and define them in the `_colours.scss` file.
- Use a CSS colour variable instead of hard coded colours for the manage notification plus/minus expander symbol.

This will make any rebranding done later this year more straightforward. I have left references to PHE in the `_colours.scss`, because we are using PHE brand colours. When we come to rebrand, this means it will be clear which colours are from PHE and need to be replaced, and which colours are just helpful colours that are not tied to PHE branding. This should be quite easy, because all of the references to PHE have now been contained to this single file.

## Checklist:
- [x] Colours are the same, or extremely similar to before on the site
- [x] No hard-coded colours in CSS files aside from `_colours.scss`
- [x] No reference to PHE in CSS files aside from `_colours.scss`
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))