### PR TITLE
NTBS-2066 Report links

### DIFF
--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ClusterInformationOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ClusterInformationOverviewPartial.cshtml
@@ -1,11 +1,13 @@
+@using ntbs_service.Services
+@inject IReportingLinksService ReportingLinksService
 @model ntbs_service.Models.Entities.Notification
 
 @if (Model.ClusterId != null)
 {
     <div class="notification-overview-type-and-edit-container">
-        <h3 class="notification-details-type">@Html.DisplayNameFor(m => m.ClusterId): 
-            <a href="@($"/Reports/Cluster/{Model.ClusterId}")" class="no-print"> @Model.ClusterId </a>
-            <span class="no-screen"> @Model.ClusterId </span> 
+        <h3 class="notification-details-type">@Html.DisplayNameFor(m => m.ClusterId):
+            <a href="@(ReportingLinksService.GetClusterReport(Model.ClusterId))" class="no-print"> @Model.ClusterId </a>
+            <span class="no-screen"> @Model.ClusterId </span>
         </h3>
     </div>
 }

--- a/ntbs-service/Pages/Reports/Index.cshtml
+++ b/ntbs-service/Pages/Reports/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@page "/Reports/{ReportType?}/{Id?}"
+﻿@page "/Reports"
 @model IndexModel
 @{
     ViewData["Title"] = "Reports";
@@ -9,17 +9,16 @@
     <h1>Reports</h1>
 
     <span>
-        @if (!string.IsNullOrEmpty(Model.ReportType))
+        @if (!string.IsNullOrEmpty(Model.ReportingPageExternalUrl))
         {
-            @: Attempted to navigate to report type: <strong>@Model.ReportType </strong>
-            @if (!string.IsNullOrEmpty(Model.Id))
-            {
-                @: with Id <strong> @Model.Id </strong>
-            } 
+            @: Attempted to navigate to
+            <a class="govuk-link govuk-link--no-visited-state" href="@Model.ReportingPageExternalUrl" target="_blank" rel="noopener noreferrer">
+                reports home page.
+            </a>
         }
         else
         {
-            @: Attempted to navigate to reports home page.
+            @: The reporting service has not been configured for this app.
         }
     </span>
 </nhs-width-container>

--- a/ntbs-service/Pages/Reports/Index.cshtml.cs
+++ b/ntbs-service/Pages/Reports/Index.cshtml.cs
@@ -1,39 +1,23 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Configuration;
+using ntbs_service.Services;
 
 namespace ntbs_service.Pages.Reports
 {
-    /// <summary>
-    /// Route intended to be both a dummy location that's navigable for
-    /// when ExternalLinks__ReportingUri env variable is not set, and additional
-    /// a centralised location for logic when routing out to external reporting.
-    ///
-    /// Intended for all external links to reporting to route through here, to then be
-    /// redirected.
-    /// </summary>
     public class IndexModel : PageModel
     {
-        [BindProperty(SupportsGet = true)]
-        public string ReportType { get; set; }
+        public string ReportingPageExternalUrl { get; }
 
-        [BindProperty(SupportsGet = true)]
-        public string Id { get; set; }
-
-        public string ReportingUri { get; }
-
-
-        public IndexModel(IConfiguration configuration)
+        public IndexModel(IReportingLinksService reportingLinksService)
         {
-            ReportingUri = configuration.GetSection("ExternalLinks")?["ReportingUri"];
+            ReportingPageExternalUrl = reportingLinksService.GetReportingPageUrl();
         }
 
         public IActionResult OnGet()
         {
-            if (!string.IsNullOrEmpty(ReportingUri))
+            if (!string.IsNullOrEmpty(ReportingPageExternalUrl))
             {
-                return Redirect(ReportingUri);
-                // TODO: Add logic for routing to difference report types directly.
+                return Redirect(ReportingPageExternalUrl);
             }
 
             return Page();

--- a/ntbs-service/Pages/Shared/_ClusterInformation.cshtml
+++ b/ntbs-service/Pages/Shared/_ClusterInformation.cshtml
@@ -1,9 +1,14 @@
+@using ntbs_service.Services
+@inject IReportingLinksService ReportingLinksService
 @model ntbs_service.Models.Entities.Notification
 
-@if(Model.ClusterId != null)
+@if (Model.ClusterId != null)
 {
     <h3>Cluster Information</h3>
     <div>
-        <p><strong>@Html.DisplayNameFor(m => m.ClusterId): </strong> <a href="/Reports/Cluster/@Model.ClusterId"> @Model.ClusterId </a> </p>
+        <p>
+            <strong>@Html.DisplayNameFor(m => m.ClusterId): </strong>
+            <a href="@(ReportingLinksService.GetClusterReport(Model.ClusterId))"> @Model.ClusterId </a>
+        </p>
     </div>
 }

--- a/ntbs-service/Pages/Shared/_Header.cshtml
+++ b/ntbs-service/Pages/Shared/_Header.cshtml
@@ -4,6 +4,7 @@
 
 @using ntbs = ntbs_service.Services
 @inject ntbs.IUserService UserService
+@inject ntbs.IReportingLinksService ReportingLinksService
 
 @{
     var breadcrumbs = ViewData["Breadcrumbs"];
@@ -56,9 +57,18 @@
                         </a>
                     </li>
                     <li class="govuk-header__navigation-item header-navigation-link">
-                        <a class="govuk-header__link header-navigation-list-item" href="/Reports">
-                            Reports
-                        </a>
+                        @if (string.IsNullOrEmpty(ReportingLinksService.GetReportingPageUrl()))
+                        {
+                            <a class="govuk-header__link header-navigation-list-item" href="/Reports">
+                                Reports
+                            </a>
+                        }
+                        else
+                        {
+                            <a class="govuk-header__link header-navigation-list-item" href="@(ReportingLinksService.GetReportingPageUrl())" target="_blank" rel="noopener noreferrer">
+                                Reports
+                            </a>
+                        }
                     </li>
                     
                     <navigation-with-submenu inline-template>

--- a/ntbs-service/Properties/ExternalLinks.cs
+++ b/ntbs-service/Properties/ExternalLinks.cs
@@ -8,5 +8,6 @@
         public string AccessibilityStatement { get; set; }
         public string License { get; set; }
         public string Copyright { get; set; }
+        public string ReportingOverview { get; set; }
     }
 }

--- a/ntbs-service/Services/ReportingLinksService.cs
+++ b/ntbs-service/Services/ReportingLinksService.cs
@@ -6,6 +6,7 @@ namespace ntbs_service.Services
     public interface IReportingLinksService
     {
         string GetReportingPageUrl();
+        string GetClusterReport(string clusterId);
     }
 
     public class ReportingLinksService : IReportingLinksService
@@ -19,5 +20,11 @@ namespace ntbs_service.Services
         }
 
         public string GetReportingPageUrl() => _externalLinks.ReportingOverview;
+
+        public string GetClusterReport(string clusterId)
+        {
+            // TODO Implement this properly in NTBS-2249
+            return "";
+        }
     }
 }

--- a/ntbs-service/Services/ReportingLinksService.cs
+++ b/ntbs-service/Services/ReportingLinksService.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.Extensions.Configuration;
+using ntbs_service.Properties;
+
+namespace ntbs_service.Services
+{
+    public interface IReportingLinksService
+    {
+        string GetReportingPageUrl();
+    }
+
+    public class ReportingLinksService : IReportingLinksService
+    {
+        private readonly ExternalLinks _externalLinks;
+
+        public ReportingLinksService(IConfiguration configuration)
+        {
+            _externalLinks = new ExternalLinks();
+            configuration.GetSection(Constants.ExternalLinks).Bind(_externalLinks);
+        }
+
+        public string GetReportingPageUrl() => _externalLinks.ReportingOverview;
+    }
+}

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -223,6 +223,7 @@ namespace ntbs_service
             services.AddScoped<IClusterImportService, ClusterImportService>();
             services.AddScoped<ICaseManagerImportService, CaseManagerImportService>();
             services.AddScoped<IAdUserService, AdUserService>();
+            services.AddScoped<IReportingLinksService, ReportingLinksService>();
 
             AddAuditService(services, auditDbConnectionString);
             AddReferenceLabResultServices(services);

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -37,7 +37,7 @@
     "reporting": "data source=localhost;initial catalog=reporting;trusted_connection=true;MultipleActiveResultSets=true"
   },
   "ExternalLinks": {
-    "ReportingUri": ""
+    "ReportingOverview": ""
   },
   "MigrationConfig": {
     "TablePrefix": "Dev"

--- a/ntbs-service/deployments/dev.yml
+++ b/ntbs-service/deployments/dev.yml
@@ -73,7 +73,7 @@ spec:
                 secretKeyRef:
                   name: dev-http-basic-auth-credentials
                   key: password
-            - name: ExternalLinks__ReportingUri
+            - name: ExternalLinks__ReportingOverview
               value: ""
             - name: MigrationConfig__TablePrefix
               value: "PheDev"

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -82,7 +82,7 @@ spec:
           - name: AzureAdOptions__Enabled
             value: "true"
           - name: ExternalLinks__ReportingOverview
-            value: ""
+            value: "https://aptemus.sharepoint.com/:u:/r/sites/NTBS-development/SitePages/Reports_int.aspx"
           - name: MigrationConfig__TablePrefix
             value: "Int"
           - name: Sentry__Environment

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -81,7 +81,7 @@ spec:
                 key: authority
           - name: AzureAdOptions__Enabled
             value: "true"
-          - name: ExternalLinks__ReportingUri
+          - name: ExternalLinks__ReportingOverview
             value: ""
           - name: MigrationConfig__TablePrefix
             value: "Int"

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -96,7 +96,7 @@ spec:
                 secretKeyRef:
                   name: live-connection-strings
                   key: reporting
-            - name: ExternalLinks__ReportingUri
+            - name: ExternalLinks__ReportingOverview
               value: ""
             - name: HttpBasicAuth__Enabled
               value: "false"

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -86,7 +86,7 @@ spec:
               secretKeyRef:
                 name: development-ad-sync-credentials
                 key: password
-          - name: ExternalLinks__ReportingUri
+          - name: ExternalLinks__ReportingOverview
             value: ""
           - name: MigrationConfig__TablePrefix
             value: "Test"

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -87,7 +87,7 @@ spec:
                 name: development-ad-sync-credentials
                 key: password
           - name: ExternalLinks__ReportingOverview
-            value: ""
+            value: "https://aptemus.sharepoint.com/:u:/r/sites/NTBS-development/SitePages/Reports_test.aspx"
           - name: MigrationConfig__TablePrefix
             value: "Test"
           - name: Sentry__Environment

--- a/ntbs-service/deployments/uat-phe.yml
+++ b/ntbs-service/deployments/uat-phe.yml
@@ -94,7 +94,7 @@ spec:
                 secretKeyRef:
                   name: uat-connection-strings
                   key: reporting
-            - name: ExternalLinks__ReportingUri
+            - name: ExternalLinks__ReportingOverview
               value: ""
             - name: HttpBasicAuth__Enabled
               value: "false"
@@ -117,7 +117,7 @@ spec:
             - name: LdapSettings__Password
               value: "" # intentionally empty so the app's service account gets used for authentication
             - name: LdapSettings__BaseDomain
-              value: "DC=phe,DC=gov,DC=uk"              
+              value: "DC=phe,DC=gov,DC=uk"
             - name: MigrationConfig__TablePrefix
               value: "UatPheMigration"
             - name: ScheduledJobsConfig__UserSyncEnabled

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -82,7 +82,7 @@ spec:
           - name: AzureAdOptions__Enabled
             value: "true"
           - name: ExternalLinks__ReportingOverview
-            value: ""
+            value: "https://aptemus.sharepoint.com/:u:/r/sites/NTBS-development/SitePages/Reports_uat.aspx"
           - name: MigrationConfig__TablePrefix
             value: "Uat"
           - name: Sentry__Environment

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -81,7 +81,7 @@ spec:
                 key: authority
           - name: AzureAdOptions__Enabled
             value: "true"
-          - name: ExternalLinks__ReportingUri
+          - name: ExternalLinks__ReportingOverview
             value: ""
           - name: MigrationConfig__TablePrefix
             value: "Uat"


### PR DESCRIPTION
## Description
* Link to a Sharepoint site to give the various report links in a way that is easy to maintain. The `/Reports` route redirects you to the Sharepoint site, and the `Reports` link in the navbar opens the Sharepoint site in a new tab.
* Add Sharepoint sites for the three Azure environments

The Sharepoint site has a few accessibility errors raised by WAVE but they don't look too serious and they are well out of our ability to control. Some screenshots: 

### Reports not configured (currently shown on local dev copies, and PHE environments)
![reports-not-configured](https://user-images.githubusercontent.com/3650110/116114515-562acd80-a6b1-11eb-8a73-8544a31552f5.png)

### Reports Sharepoint site
![reports-sharepoint-site](https://user-images.githubusercontent.com/3650110/116114511-54f9a080-a6b1-11eb-9c38-e5929ba36073.png)

## Checklist:
- [x] Automated tests are passing locally.