### PR TITLE
NTBS-2238 Get cluster match changes from specimen DB

### DIFF
--- a/ntbs-service/DataAccess/NotificationClusterRepository.cs
+++ b/ntbs-service/DataAccess/NotificationClusterRepository.cs
@@ -16,11 +16,11 @@ namespace ntbs_service.DataAccess
 
     public class NotificationClusterRepository : INotificationClusterRepository
     {
-        private readonly string _reportingDbConnectionString;
+        private readonly string _specimenMatchingConnectionString;
 
         public NotificationClusterRepository(IConfiguration configuration)
         {
-            _reportingDbConnectionString = configuration.GetConnectionString(Constants.DbConnectionStringReporting);
+            _specimenMatchingConnectionString = configuration.GetConnectionString(Constants.DbConnectionStringSpecimenMatching);
         }
 
         public async Task<IEnumerable<NotificationClusterValue>> GetNotificationClusterValues()
@@ -31,7 +31,7 @@ namespace ntbs_service.DataAccess
                     ,[{nameof(NotificationClusterValue.ClusterId)}]
                 FROM [dbo].[vwNotificationClusterMatch]";
 
-            using (var connection = new SqlConnection(_reportingDbConnectionString))
+            using (var connection = new SqlConnection(_specimenMatchingConnectionString))
             {
                 connection.Open();
                 return await connection.QueryAsync<NotificationClusterValue>(query);
@@ -47,7 +47,7 @@ namespace ntbs_service.DataAccess
                 FROM [dbo].[NotificationClusterMatch]
                 WHERE [{nameof(NotificationClusterValue.NotificationId)}] = @etsNotificationId";
 
-            using (var connection = new SqlConnection(_reportingDbConnectionString))
+            using (var connection = new SqlConnection(_specimenMatchingConnectionString))
             {
                 connection.Open();
                 return await connection.QuerySingleOrDefaultAsync<NotificationClusterValue>(query, new { etsNotificationId });
@@ -56,7 +56,7 @@ namespace ntbs_service.DataAccess
 
         public async Task SetNotificationClusterValue(int etsNotificationId, int ntbsNotificationId)
         {
-            using (var connection = new SqlConnection(_reportingDbConnectionString))
+            using (var connection = new SqlConnection(_specimenMatchingConnectionString))
             {
                 connection.Open();
                 await connection.ExecuteAsync(

--- a/ntbs-service/Jobs/DataQualityAlertsJob.cs
+++ b/ntbs-service/Jobs/DataQualityAlertsJob.cs
@@ -45,11 +45,6 @@ namespace ntbs_service.Jobs
             _dataQualityRepository.GetNotificationsEligibleForDqClinicalDatesAlertsAsync
         );
 
-        private async Task CreateClusterAlertsInBulkAsync() => await CreateAlertsInBulkAsync<DataQualityClusterAlert>(
-            _dataQualityRepository.GetNotificationsEligibleForDqClusterAlertsCountAsync,
-            _dataQualityRepository.GetNotificationsEligibleForDqClusterAlertsAsync
-        );
-
         private async Task CreateDotVotAlertsInBulkAsync() => await CreateAlertsInBulkAsync<DataQualityDotVotAlert>(
             _dataQualityRepository.GetNotificationsEligibleForDqDotVotAlertsCountAsync,
             _dataQualityRepository.GetNotificationsEligibleForDqDotVotAlertsAsync
@@ -105,7 +100,6 @@ namespace ntbs_service.Jobs
             await CreateDraftAlertsInBulkAsync();
             await CreateBirthCountryAlertsInBulkAsync();
             await CreateClinicalDatesAlertsInBulkAsync();
-            await CreateClusterAlertsInBulkAsync();
             await CreateDotVotAlertsInBulkAsync();
             await CreateTreatmentOutcome12MonthAlertsInBulkAsync();
             await CreateTreatmentOutcome24MonthAlertsInBulkAsync();

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -411,6 +411,20 @@ namespace ntbs_service.Services
                 }
 
                 notification.ClusterId = clusterValue.ClusterId;
+
+                // Create or dismiss data quality alert based on this change to the cluster ID
+                if (DataQualityClusterAlert.NotificationQualifies(notification))
+                {
+                    await _alertService.AddUniqueAlertAsync(new DataQualityClusterAlert
+                    {
+                        NotificationId = notification.NotificationId,
+                        CreationDate = DateTime.Now
+                    });
+                }
+                else
+                {
+                    await _alertService.AutoDismissAlertAsync<DataQualityClusterAlert>(notification);
+                }
             }
 
             await _notificationRepository.SaveChangesAsync(


### PR DESCRIPTION
## Description
* The cluster matches are being moved into the specimen matching DB, not reporting, so get the changes from there. This is being moved here: publichealthengland/ntbs-specimen-matching#15.
* Change how the Cluster Data Quality alert is generated: don't generate it using the `DataQualityAlerts` job, instead create or dismiss the alert when changes to the cluster ID are being applied by the `NotificationClusterUpdate` job.
* Amend the `NotificationService` tests to cover this create or dismiss behaviour.

## Checklist:
- [x] Automated tests are passing locally.