### PR TITLE
NTBS-2241 Migrate DRP and species

### DIFF
--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -40,6 +40,8 @@ namespace ntbs_service.DataMigration
         private readonly ISpecimenService _specimenService;
         private readonly IImportValidator _importValidator;
         private readonly IClusterImportService _clusterImportService;
+        private readonly ICultureAndResistanceService _cultureAndResistanceService;
+        private readonly IDrugResistanceProfileService _drugResistanceProfileService;
         private readonly ICaseManagerImportService _caseManagerImportService;
 
         public NotificationImportService(INotificationMapper notificationMapper,
@@ -52,6 +54,8 @@ namespace ntbs_service.DataMigration
                              ISpecimenService specimenService,
                              IImportValidator importValidator,
                              IClusterImportService clusterImportService,
+                             ICultureAndResistanceService cultureAndResistanceService,
+                             IDrugResistanceProfileService drugResistanceProfileService,
                              ICaseManagerImportService caseManagerImportService)
         {
             sentryHub.ConfigureScope(s =>
@@ -68,6 +72,8 @@ namespace ntbs_service.DataMigration
             _specimenService = specimenService;
             _importValidator = importValidator;
             _clusterImportService = clusterImportService;
+            _cultureAndResistanceService = cultureAndResistanceService;
+            _drugResistanceProfileService = drugResistanceProfileService;
             _caseManagerImportService = caseManagerImportService;
         }
 
@@ -185,6 +191,8 @@ namespace ntbs_service.DataMigration
                 await _migratedNotificationsMarker.MarkNotificationsAsImportedAsync(savedNotifications);
                 importResult.NtbsIds = savedNotifications.ToDictionary(x => x.LegacyId, x => x.NotificationId);
                 await ImportReferenceLabResultsAsync(context, requestId, savedNotifications, importResult);
+                await _cultureAndResistanceService.MigrateNotificationCultureResistanceSummary(savedNotifications);
+                await _drugResistanceProfileService.UpdateDrugResistanceProfiles(savedNotifications);
                 await _clusterImportService.UpdateClusterInformation(savedNotifications);
 
                 var newIdsString = string.Join(" ,", savedNotifications.Select(x => x.NotificationId));

--- a/ntbs-service/Jobs/DrugResistanceProfileUpdateJob.cs
+++ b/ntbs-service/Jobs/DrugResistanceProfileUpdateJob.cs
@@ -9,9 +9,9 @@ namespace ntbs_service.Jobs
     {
         private const int MaxNumberOfUpdatesPerRun = 2000;
 
-        private readonly IDrugResistanceProfilesService _service;
+        private readonly IDrugResistanceProfileService _service;
 
-        public DrugResistanceProfileUpdateJob(IDrugResistanceProfilesService service)
+        public DrugResistanceProfileUpdateJob(IDrugResistanceProfileService service)
         {
             _service = service;
         }

--- a/ntbs-service/Services/DrugResistanceProfileService.cs
+++ b/ntbs-service/Services/DrugResistanceProfileService.cs
@@ -12,6 +12,7 @@ namespace ntbs_service.Services
     public interface IDrugResistanceProfileService
     {
         Task<int> UpdateDrugResistanceProfiles(int maxNumberOfUpdates);
+        Task UpdateDrugResistanceProfiles(List<Notification> notifications);
     }
 
     public class DrugResistanceProfileService : IDrugResistanceProfileService
@@ -49,6 +50,18 @@ namespace ntbs_service.Services
             return totalNumberOfProfilesInNeedOfUpdate > maxNumberOfUpdates
                 ? totalNumberOfProfilesInNeedOfUpdate - maxNumberOfUpdates
                 : 0;
+        }
+
+        public async Task UpdateDrugResistanceProfiles(List<Notification> notifications)
+        {
+            var drugResistanceProfiles = await _drugResistanceProfileRepository.GetDrugResistanceProfilesAsync();
+
+            var notificationIds = notifications.Select(n => n.NotificationId);
+            var profilesToUpdateOnThisRun = drugResistanceProfiles
+                .Where(keyValuePair => notificationIds.Contains(keyValuePair.Key))
+                .ToDictionary(keyValuePair => keyValuePair.Key, keyValuePair => keyValuePair.Value);
+
+            await UpdateDrugResistanceProfiles(profilesToUpdateOnThisRun);
         }
 
         private async Task UpdateDrugResistanceProfiles(Dictionary<int, DrugResistanceProfile> updatedDrugResistanceProfiles)
@@ -137,6 +150,11 @@ namespace ntbs_service.Services
         public Task<int> UpdateDrugResistanceProfiles(int maxNumberOfUpdates)
         {
             return Task.FromResult(0);
+        }
+
+        public Task UpdateDrugResistanceProfiles(List<Notification> notifications)
+        {
+            return Task.CompletedTask;
         }
     }
 

--- a/ntbs-service/Services/DrugResistanceProfileService.cs
+++ b/ntbs-service/Services/DrugResistanceProfileService.cs
@@ -9,12 +9,12 @@ using ntbs_service.Models.Projections;
 
 namespace ntbs_service.Services
 {
-    public interface IDrugResistanceProfilesService
+    public interface IDrugResistanceProfileService
     {
         Task<int> UpdateDrugResistanceProfiles(int maxNumberOfUpdates);
     }
 
-    public class DrugResistanceProfileService : IDrugResistanceProfilesService
+    public class DrugResistanceProfileService : IDrugResistanceProfileService
     {
         private readonly INotificationService _notificationService;
         private readonly INotificationRepository _notificationRepository;
@@ -132,7 +132,7 @@ namespace ntbs_service.Services
         }
     }
 
-    internal class MockDrugResistanceProfilesService : IDrugResistanceProfilesService
+    internal class MockDrugResistanceProfileService : IDrugResistanceProfileService
     {
         public Task<int> UpdateDrugResistanceProfiles(int maxNumberOfUpdates)
         {

--- a/ntbs-service/Services/MockCultureAndResistanceService.cs
+++ b/ntbs-service/Services/MockCultureAndResistanceService.cs
@@ -1,3 +1,4 @@
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using ntbs_service.Models.Entities;
 
@@ -34,6 +35,11 @@ namespace ntbs_service.Services
                 });
             }
             return Task.FromResult<CultureAndResistance>(null);
+        }
+
+        public Task MigrateNotificationCultureResistanceSummary(List<Notification> notifications)
+        {
+            return Task.CompletedTask;
         }
     }
 }

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -511,12 +511,12 @@ namespace ntbs_service
             if (string.IsNullOrEmpty(Configuration.GetConnectionString(Constants.DbConnectionStringReporting)))
             {
                 services.AddScoped<IHomepageKpiService, MockHomepageKpiService>();
-                services.AddScoped<IDrugResistanceProfilesService, MockDrugResistanceProfilesService>();
+                services.AddScoped<IDrugResistanceProfileService, MockDrugResistanceProfileService>();
             }
             else
             {
                 services.AddScoped<IHomepageKpiService, HomepageKpiService>();
-                services.AddScoped<IDrugResistanceProfilesService, DrugResistanceProfileService>();
+                services.AddScoped<IDrugResistanceProfileService, DrugResistanceProfileService>();
             }
         }
 


### PR DESCRIPTION
## Description
- Make the interface of `DrugResistanceProfileService` consistent with its own name (rename from `IDrugResistanceProfilesService` to `IDrugResistanceProfileService`).
- When migrating a legacy notification, migrate its culture and drug resistance summaries. To do this:
    1. Copy the legacy notifications `NotificationCultureResistanceSummary` row in the specimen-matching DB to a new row for the new notification. This gives the reference lab summary on the Test results page. This uses a stored procedure being added here: publichealthengland/ntbs-specimen-matching#16.
    2. Run the `DrugResistanceProfile` update on the newly imported notification, copying in the DRP and species from this newly made summary record.

## Checklist:
- [x] Automated tests are passing locally.