### PR TITLE
NTBS-2242 Add default DrugResistanceProfile values

### DIFF
--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -65,7 +65,7 @@ namespace ntbs_service.DataAccess
         public virtual DbSet<MBovisOccupationExposure> MBovisOccupationExposures { get; set; }
         public virtual DbSet<MBovisAnimalExposure> MBovisAnimalExposure { get; set; }
         public DbSet<NotificationAndDuplicateIds> NotificationAndDuplicateIds { get; set; }
-        
+
         public DbSet<ReleaseVersion> ReleaseVersion { get; set; }
 
         public virtual void SetValues<TEntityClass>(TEntityClass entity, TEntityClass values)
@@ -559,7 +559,7 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.Notes).HasMaxLength(500);
 
                 entity.HasIndex(e => e.Username).IsUnique();
-                
+
                 entity.HasKey(e => e.Id);
             });
 
@@ -653,6 +653,12 @@ namespace ntbs_service.DataAccess
 
             modelBuilder.Entity<DrugResistanceProfile>(entity =>
             {
+                entity.Property(e => e.Species)
+                    .HasMaxLength(30)
+                    .HasDefaultValue("No result");
+                entity.Property(e => e.DrugResistanceProfileString)
+                    .HasMaxLength(30)
+                    .HasDefaultValue("No result");
                 entity.ToTable("DrugResistanceProfile").HasKey(e => e.NotificationId);
             });
 

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -654,9 +654,11 @@ namespace ntbs_service.DataAccess
             modelBuilder.Entity<DrugResistanceProfile>(entity =>
             {
                 entity.Property(e => e.Species)
+                    .IsRequired()
                     .HasMaxLength(30)
                     .HasDefaultValue("No result");
                 entity.Property(e => e.DrugResistanceProfileString)
+                    .IsRequired()
                     .HasMaxLength(30)
                     .HasDefaultValue("No result");
                 entity.ToTable("DrugResistanceProfile").HasKey(e => e.NotificationId);

--- a/ntbs-service/Migrations/20210429162156_DefaultDrugResistanceProfile.Designer.cs
+++ b/ntbs-service/Migrations/20210429162156_DefaultDrugResistanceProfile.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210429162156_DefaultDrugResistanceProfile")]
+    partial class DefaultDrugResistanceProfile
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210429162156_DefaultDrugResistanceProfile.cs
+++ b/ntbs-service/Migrations/20210429162156_DefaultDrugResistanceProfile.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class DefaultDrugResistanceProfile : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Species",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: true,
+                defaultValue: "No result",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DrugResistanceProfileString",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: true,
+                defaultValue: "No result",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Species",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(max)",
+                nullable: true,
+                defaultValue: null,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(30)",
+                oldMaxLength: 30,
+                oldNullable: true,
+                oldDefaultValue: "No result");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DrugResistanceProfileString",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(max)",
+                nullable: true,
+                defaultValue: null,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(30)",
+                oldMaxLength: 30,
+                oldNullable: true,
+                oldDefaultValue: "No result");
+        }
+    }
+}

--- a/ntbs-service/Migrations/20210430121906_DrugResistanceProfileNotNull.Designer.cs
+++ b/ntbs-service/Migrations/20210430121906_DrugResistanceProfileNotNull.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210430121906_DrugResistanceProfileNotNull")]
+    partial class DrugResistanceProfileNotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210430121906_DrugResistanceProfileNotNull.cs
+++ b/ntbs-service/Migrations/20210430121906_DrugResistanceProfileNotNull.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class DrugResistanceProfileNotNull : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                @"UPDATE DrugResistanceProfile
+                  SET Species = COALESCE(Species, 'No result'),
+                      DrugResistanceProfileString = COALESCE(DrugResistanceProfileString, 'No result');");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Species",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: false,
+                defaultValue: "No result",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(30)",
+                oldMaxLength: 30,
+                oldNullable: true,
+                oldDefaultValue: "No result");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DrugResistanceProfileString",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: false,
+                defaultValue: "No result",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(30)",
+                oldMaxLength: 30,
+                oldNullable: true,
+                oldDefaultValue: "No result");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Species",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: true,
+                defaultValue: "No result",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(30)",
+                oldMaxLength: 30,
+                oldDefaultValue: "No result");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "DrugResistanceProfileString",
+                table: "DrugResistanceProfile",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: true,
+                defaultValue: "No result",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(30)",
+                oldMaxLength: 30,
+                oldDefaultValue: "No result");
+        }
+    }
+}


### PR DESCRIPTION
## Description
Use a default value constraint (via EF's HasDefaultValue(...)) to add
the default value "No result" for species and DRPs of a new draft
notification.

Also reduce the length of these two fields to match the maximum length in its source table: specimen-matching's `NotificationCultureAndResistanceSummary`.


## Checklist:
- [x] Automated tests are passing locally.
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [x] EF migrations created and committed. Snapshot committed
- [x] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Specimen matching database DACPAC updated
- [x] Reporting database ingestion considered (uspGenerateReusableNotification)