### PR TITLE
NTBS-2066 Change report URLs to PowerBI app

### DIFF
--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -81,8 +81,6 @@ spec:
                 key: authority
           - name: AzureAdOptions__Enabled
             value: "true"
-          - name: ExternalLinks__ReportingOverview
-            value: "https://aptemus.sharepoint.com/:u:/r/sites/NTBS-development/SitePages/Reports_int.aspx"
           - name: MigrationConfig__TablePrefix
             value: "Int"
           - name: Sentry__Environment

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -126,6 +126,8 @@ spec:
               value: "false"
             - name: ScheduledJobsConfig__MarkImportedNotificationsAsImportedEnabled
               value: "false"
+            - name: ExternalLinks__ReportingOverview
+              value: "https://app.powerbi.com/Redirect?action=OpenApp&appId=70e1af43-d5ca-48f8-b8c3-e146fc470fb7&ctid=ee4e1499-4a35-4b2e-ad47-5f3cf9de8666"
             - name: Sentry__Environment
               value: live
             - name: KRB5_CLIENT_KTNAME

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -87,7 +87,7 @@ spec:
                 name: development-ad-sync-credentials
                 key: password
           - name: ExternalLinks__ReportingOverview
-            value: "https://aptemus.sharepoint.com/:u:/r/sites/NTBS-development/SitePages/Reports_test.aspx"
+            value: "https://app.powerbi.com/Redirect?action=OpenApp&appId=e3e5baa2-50f6-42c8-ae97-7c1bd720a204&ctid=dde2b1dd-a61c-4a89-9734-382c1f37630e"
           - name: MigrationConfig__TablePrefix
             value: "Test"
           - name: Sentry__Environment

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -81,8 +81,6 @@ spec:
                 key: authority
           - name: AzureAdOptions__Enabled
             value: "true"
-          - name: ExternalLinks__ReportingOverview
-            value: "https://aptemus.sharepoint.com/:u:/r/sites/NTBS-development/SitePages/Reports_uat.aspx"
           - name: MigrationConfig__TablePrefix
             value: "Uat"
           - name: Sentry__Environment


### PR DESCRIPTION
Just a trivial config change: change `Reports/` URLs to PowerBI apps for Azure test and PHE Live, and remove URLs for the other two Azure environments (the other two PHE environments didn't have report URLs before this change).