### PR TITLE
NTBS-2276 Setup load-test and training environments

### DIFF
--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -86,7 +86,7 @@ spec:
           - name: Sentry__Environment
             value: "int"
       imagePullSecrets:
-      - name: registery-password
+      - name: registry-password
 ---
 apiVersion: v1
 kind: Service

--- a/ntbs-service/deployments/load-test.yml
+++ b/ntbs-service/deployments/load-test.yml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ntbs-test
+  name: ntbs-load-test
 spec:
   selector:
     matchLabels:
-      app: ntbs-test
-  replicas: 1
+      app: ntbs-load-test
+  replicas: 2
   template:
     metadata:
       labels:
-        app: ntbs-test
+        app: ntbs-load-test
     spec:
       containers:
-      - name: ntbs-test
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service:test"
+      - name: ntbs-load-test
+        image: "ntbscontainerregistry.azurecr.io/ntbs-service:load-test"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -24,37 +24,37 @@ spec:
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: load-test-connection-strings
                 key: appDb
           - name: ConnectionStrings__ntbsMigratorContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: load-test-connection-strings
                 key: appDbMigrator
           - name: ConnectionStrings__keysContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: load-test-connection-strings
                 key: appDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: load-test-connection-strings
                 key: auditDb
           - name: ConnectionStrings__reporting
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: load-test-connection-strings
                 key: reportingDb
           - name: ConnectionStrings__specimenMatching
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: load-test-connection-strings
                 key: specimenMatchingDb
           - name: ConnectionStrings__migration
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: load-test-connection-strings
                 key: migrationDb
           - name: AdOptions__BaseUserGroup
             value: "Global.NIS.NTBS"
@@ -64,68 +64,46 @@ spec:
             value: "Global.NIS.NTBS.NTS"
           - name: AdOptions__ServiceGroupAdPrefix
             value: "Global.NIS.NTBS.Service"
-          - name: AzureAdOptions__ClientId
-            valueFrom:
-              secretKeyRef:
-                name: test-azuread-options
-                key: clientId
-          - name: AzureAdOptions__ClientSecret
-            valueFrom:
-              secretKeyRef:
-                name: test-azuread-options
-                key: clientSecret
-          - name: AzureAdOptions__Authority
-            valueFrom:
-              secretKeyRef:
-                name: test-azuread-options
-                key: authority
-          - name: AzureAdOptions__Enabled
+          - name: AdOptions__UseDummyAuth
             value: "true"
-          - name: LdapSettings__Password
-            valueFrom:
-              secretKeyRef:
-                name: development-ad-sync-credentials
-                key: password
-          - name: ExternalLinks__ReportingOverview
-            value: "https://app.powerbi.com/Redirect?action=OpenApp&appId=e3e5baa2-50f6-42c8-ae97-7c1bd720a204&ctid=dde2b1dd-a61c-4a89-9734-382c1f37630e"
-          - name: ExternalLinks__ClusterReport
-            value: "https://app.powerbi.com/groups/me/apps/e3e5baa2-50f6-42c8-ae97-7c1bd720a204/reports/c6fdd4ef-211f-4ae5-90e3-243fb341a3b4/ReportSection?ctid=dde2b1dd-a61c-4a89-9734-382c1f37630e&filter=Cluster%2FClusterId%20eq '<CLUSTER_ID>'"
           - name: MigrationConfig__TablePrefix
-            value: "Test"
+            value: "LoadTest"
           - name: Sentry__Environment
-            value: "test"
+            value: "load-test"
+          - name: ScheduledJobsConfig__UserSyncEnabled
+            value: "false"
       imagePullSecrets:
       - name: registry-password
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ntbs-test
+  name: ntbs-load-test
 spec:
   type: LoadBalancer
   ports:
     - port: 80
       targetPort: 8080
   selector:
-    app: ntbs-test
+    app: ntbs-load-test
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: ntbs-test
+  name: ntbs-load-test
   annotations:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
 spec:
   tls:
     - hosts:
-      - ntbs-test.e32846b1ddf0432eb63f.northeurope.aksapp.io
-      secretName: phe-ntbs-test-tls
+      - ntbs-load-test.e32846b1ddf0432eb63f.northeurope.aksapp.io
+      secretName: phe-ntbs-load-test-tls
   rules:
-  - host: ntbs-test.e32846b1ddf0432eb63f.northeurope.aksapp.io
+  - host: ntbs-load-test.e32846b1ddf0432eb63f.northeurope.aksapp.io
     http:
       paths:
       - backend:
-          serviceName: ntbs-test
+          serviceName: ntbs-load-test
           servicePort: 80
         path: /

--- a/ntbs-service/deployments/training.yml
+++ b/ntbs-service/deployments/training.yml
@@ -1,20 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: ntbs-test
+  name: ntbs-training
 spec:
   selector:
     matchLabels:
-      app: ntbs-test
-  replicas: 1
+      app: ntbs-training
+  replicas: 2
   template:
     metadata:
       labels:
-        app: ntbs-test
+        app: ntbs-training
     spec:
       containers:
-      - name: ntbs-test
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service:test"
+      - name: ntbs-training
+        image: "ntbscontainerregistry.azurecr.io/ntbs-service:training"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -24,37 +24,37 @@ spec:
           - name: ConnectionStrings__ntbsContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: training-connection-strings
                 key: appDb
           - name: ConnectionStrings__ntbsMigratorContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: training-connection-strings
                 key: appDbMigrator
           - name: ConnectionStrings__keysContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: training-connection-strings
                 key: appDb
           - name: ConnectionStrings__auditContext
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: training-connection-strings
                 key: auditDb
           - name: ConnectionStrings__reporting
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: training-connection-strings
                 key: reportingDb
           - name: ConnectionStrings__specimenMatching
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: training-connection-strings
                 key: specimenMatchingDb
           - name: ConnectionStrings__migration
             valueFrom:
               secretKeyRef:
-                name: test-connection-strings
+                name: training-connection-strings
                 key: migrationDb
           - name: AdOptions__BaseUserGroup
             value: "Global.NIS.NTBS"
@@ -67,65 +67,56 @@ spec:
           - name: AzureAdOptions__ClientId
             valueFrom:
               secretKeyRef:
-                name: test-azuread-options
+                name: uat-phe-azuread-options
                 key: clientId
           - name: AzureAdOptions__ClientSecret
             valueFrom:
               secretKeyRef:
-                name: test-azuread-options
+                name: uat-phe-azuread-options
                 key: clientSecret
           - name: AzureAdOptions__Authority
             valueFrom:
               secretKeyRef:
-                name: test-azuread-options
+                name: uat-phe-azuread-options
                 key: authority
           - name: AzureAdOptions__Enabled
             value: "true"
-          - name: LdapSettings__Password
-            valueFrom:
-              secretKeyRef:
-                name: development-ad-sync-credentials
-                key: password
-          - name: ExternalLinks__ReportingOverview
-            value: "https://app.powerbi.com/Redirect?action=OpenApp&appId=e3e5baa2-50f6-42c8-ae97-7c1bd720a204&ctid=dde2b1dd-a61c-4a89-9734-382c1f37630e"
-          - name: ExternalLinks__ClusterReport
-            value: "https://app.powerbi.com/groups/me/apps/e3e5baa2-50f6-42c8-ae97-7c1bd720a204/reports/c6fdd4ef-211f-4ae5-90e3-243fb341a3b4/ReportSection?ctid=dde2b1dd-a61c-4a89-9734-382c1f37630e&filter=Cluster%2FClusterId%20eq '<CLUSTER_ID>'"
           - name: MigrationConfig__TablePrefix
-            value: "Test"
+            value: "Training"
           - name: Sentry__Environment
-            value: "test"
+            value: "training"
       imagePullSecrets:
       - name: registry-password
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: ntbs-test
+  name: ntbs-training
 spec:
   type: LoadBalancer
   ports:
     - port: 80
       targetPort: 8080
   selector:
-    app: ntbs-test
+    app: ntbs-training
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: ntbs-test
+  name: ntbs-training
   annotations:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
 spec:
   tls:
     - hosts:
-      - ntbs-test.e32846b1ddf0432eb63f.northeurope.aksapp.io
-      secretName: phe-ntbs-test-tls
+      - ntbs-training.e32846b1ddf0432eb63f.northeurope.aksapp.io
+      secretName: phe-ntbs-training-tls
   rules:
-  - host: ntbs-test.e32846b1ddf0432eb63f.northeurope.aksapp.io
+  - host: ntbs-training.e32846b1ddf0432eb63f.northeurope.aksapp.io
     http:
       paths:
       - backend:
-          serviceName: ntbs-test
+          serviceName: ntbs-training
           servicePort: 80
         path: /

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -86,7 +86,7 @@ spec:
           - name: Sentry__Environment
             value: "uat"
       imagePullSecrets:
-      - name: registery-password
+      - name: registry-password
 ---
 apiVersion: v1
 kind: Service

--- a/ntbs-service/kubernetes/cert-manager/load-test-certificate.yaml
+++ b/ntbs-service/kubernetes/cert-manager/load-test-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ntbs-load-test
+  namespace: default
+spec:
+  dnsNames:
+    - ntbs-load-test.e32846b1ddf0432eb63f.northeurope.aksapp.io
+  secretName: phe-ntbs-load-test-tls
+  issuerRef:
+    name: load-test-cluster-issuer
+    kind: ClusterIssuer

--- a/ntbs-service/kubernetes/cert-manager/load-test-cluster-issuer.yaml
+++ b/ntbs-service/kubernetes/cert-manager/load-test-cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: load-test-cluster-issuer
+spec:
+  acme:
+    email: team-ntbs@softwire.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: phe-ntbs-load-test-tls
+    solvers:
+    - http01:
+       ingress:
+         class: addon-http-application-routing

--- a/ntbs-service/kubernetes/cert-manager/training-certificate.yaml
+++ b/ntbs-service/kubernetes/cert-manager/training-certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ntbs-training
+  namespace: default
+spec:
+  dnsNames:
+    - ntbs-training.e32846b1ddf0432eb63f.northeurope.aksapp.io
+  secretName: phe-ntbs-training-tls
+  issuerRef:
+    name: training-cluster-issuer
+    kind: ClusterIssuer

--- a/ntbs-service/kubernetes/cert-manager/training-cluster-issuer.yaml
+++ b/ntbs-service/kubernetes/cert-manager/training-cluster-issuer.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: training-cluster-issuer
+spec:
+  acme:
+    email: team-ntbs@softwire.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: phe-ntbs-training-tls
+    solvers:
+    - http01:
+       ingress:
+         class: addon-http-application-routing


### PR DESCRIPTION
Add yaml files for new environments. I have tested this by deploying these environments and they appear to be working (although the `training` environment requires PHE ICT to update the app registration in their Azure.