### PR TITLE
NTBS-2264: Add treatment event mapper to registered services

### DIFF
--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -223,6 +223,7 @@ namespace ntbs_service
             services.AddScoped<ICaseManagerImportService, CaseManagerImportService>();
             services.AddScoped<IAdUserService, AdUserService>();
             services.AddScoped<IReportingLinksService, ReportingLinksService>();
+            services.AddScoped<ITreatmentEventMapper, TreatmentEventMapper>();
 
             AddAuditService(services, auditDbConnectionString);
             AddReferenceLabResultServices(services);


### PR DESCRIPTION
## Description
Forgot to register treatment event mapper in the startup. 

## Checklist:
- [ ] Automated tests are passing locally.
