### PR TITLE
NTBS-2279 Use specimen matching DB for specimen migration

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -488,11 +488,6 @@ namespace ntbs_service_unit_tests.DataMigration
                 throw new NotImplementedException();
             }
 
-            public Task<IEnumerable<(string LegacyId, string ReferenceLaboratoryNumber)>> GetReferenceLaboratoryMatches(IEnumerable<string> legacyIds)
-            {
-                throw new NotImplementedException();
-            }
-
             public Task<MigrationLegacyUser> GetLegacyUserByUsername(string username)
             {
                 return Task.FromResult(CvsUserRecords(username));

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -35,7 +35,6 @@ namespace ntbs_service.DataMigration
         private readonly INotificationRepository _notificationRepository;
         private readonly INotificationImportRepository _notificationImportRepository;
         private readonly IImportLogger _logger;
-        private readonly IMigrationRepository _migrationRepository;
         private readonly IMigratedNotificationsMarker _migratedNotificationsMarker;
         private readonly ISpecimenService _specimenService;
         private readonly IImportValidator _importValidator;
@@ -67,7 +66,6 @@ namespace ntbs_service.DataMigration
             _notificationRepository = notificationRepository;
             _notificationImportRepository = notificationImportRepository;
             _logger = logger;
-            _migrationRepository = migrationRepository;
             _migratedNotificationsMarker = migratedNotificationsMarker;
             _specimenService = specimenService;
             _importValidator = importValidator;
@@ -225,7 +223,7 @@ namespace ntbs_service.DataMigration
             ImportResult importResult)
         {
             var legacyIds = notifications.Select(n => n.ETSID);
-            var matches = await _migrationRepository.GetReferenceLaboratoryMatches(legacyIds);
+            var matches = await _specimenService.GetLegacyReferenceLaboratoryMatches(legacyIds);
             foreach (var (legacyId, referenceLaboratoryNumber) in matches)
             {
                 var notificationId = notifications.Single(n => n.ETSID == legacyId).NotificationId;

--- a/ntbs-service/Services/MockSpecimenService.cs
+++ b/ntbs-service/Services/MockSpecimenService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -154,6 +154,13 @@ namespace ntbs_service.Services
         public Task<IEnumerable<SpecimenMatchPairing>> GetAllSpecimenPotentialMatchesAsync()
         {
             return Task.FromResult((IEnumerable<SpecimenMatchPairing>)new List<SpecimenMatchPairing>());
+        }
+
+        public Task<IEnumerable<(string LegacyId, string ReferenceLaboratoryNumber)>>
+            GetLegacyReferenceLaboratoryMatches(IEnumerable<string> legacyIds)
+        {
+            return Task.FromResult(
+                new List<(string LegacyId, string ReferenceLaboratoryNumber)>().AsEnumerable());
         }
 
         public Task<bool> UnmatchSpecimenAsync(int notificationId, string labReferenceNumber, string userName)

--- a/ntbs-service/Services/SpecimenQueryHelper.cs
+++ b/ntbs-service/Services/SpecimenQueryHelper.cs
@@ -90,6 +90,12 @@ namespace ntbs_service.Services
                 "FROM [dbo].[ufnGetUnmatchedSpecimensByPhec] (@param)",
                 _orderByUnmatchedStatement);
 
+        public static readonly string LegacyReferenceLaboratoryMatchesQuery = @"
+            SELECT [LegacyId], [ReferenceLaboratoryNumber]
+            FROM [dbo].[EtsSpecimenMatch]
+            WHERE LegacyId IN @Ids
+        ";
+
         public static string FormatEnumerableParams(IEnumerable<string> enumerable) =>
             enumerable != null ? string.Join(',', enumerable) : string.Empty;
     }


### PR DESCRIPTION
## Description
When migrating specimen matches from ETS to NTBS, use the list of ETS specimen matches stored in the specimen matching DB, rather than the one stored in the migration DB, which is being removed as part of this ticket NTBS-2279.

## Checklist:
- [x] Automated tests are passing locally.