### PR TITLE
NTBS-2277 Add tests for the notification creation process

### DIFF
--- a/ntbs-integration-tests/NotificationPages/CreatePageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/CreatePageTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_integration_tests.TestServices;
+using ntbs_service;
+using ntbs_service.Helpers;
+using Xunit;
+
+namespace ntbs_integration_tests.NotificationPages
+{
+    public class CreatePageTests : TestRunnerNotificationBase
+    {
+
+        public CreatePageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task GetCreate_ReturnsRedirect()
+        {
+            // Arrange
+            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+                .CreateClientWithoutRedirects())
+            {
+                // Act
+                var response = await client.GetAsync(RouteHelper.GetCreateNotificationPath());
+
+                // Assert
+                Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+            }
+        }
+
+        [Fact]
+        public async Task GetCreate_ReturnsNotification_WithDefaultDrugResistanceProfile()
+        {
+            // Arrange
+            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+                .CreateClientWithoutRedirects())
+            {
+                // Act
+                var createResponse = await client.GetAsync(RouteHelper.GetCreateNotificationPath());
+
+                // Assert
+                var editPage = await Client.GetAsync(createResponse.Headers.Location);
+                var editDocument = await GetDocumentAsync(editPage);
+
+                // TODO NTBS-2246: use a better way of selecting the drug resistance profile value, such as
+                // querying HTML id attributes.
+                var drugResistanceValue = editDocument
+                    .QuerySelectorAll("div.notification-banner-body div.bold-label")
+                    .FirstOrDefault(e => e.InnerHtml == " Drug resistance profile ")
+                    ?.NextElementSibling
+                    .InnerHtml;
+
+                Assert.Equal(" No result ", drugResistanceValue);
+            }
+        }
+    }
+}

--- a/ntbs-service/Helpers/RouteHelper.cs
+++ b/ntbs-service/Helpers/RouteHelper.cs
@@ -51,6 +51,8 @@ namespace ntbs_service.Helpers
         {
             return $"/Help?faqId={anchorId}#{anchorId}";
         }
+
+        public static string GetCreateNotificationPath() => "Notifications/Create";
     }
 
     public static class NotificationSubPaths


### PR DESCRIPTION
## Description
* Add integration tests for the redirect behaviour of the `Create` route, and check that the drug resistance profile has been set to a default value (this is done by the database, configured in `NtbsContext`, so we need an integration test for that).
* Add a unit test to check that new notifications are created in the notifying user's TB service, and has their case manager ID, so that they are able to edit their newly created notification draft.

I'm not sure if this is the best way to be doing this, especially the fairly clunky integration tests, but I thought the best way to get feedback would just be to show you what I've got so far using a PR.

## Checklist:
- [x] Automated tests are passing locally.