### PR TITLE
NTBS-2274 test NotificationImportService

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/NotificationImportServiceTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationImportServiceTest.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using Hangfire.Server;
+using Moq;
+using ntbs_service.DataAccess;
+using ntbs_service.DataMigration;
+using ntbs_service.Models.Entities;
+using ntbs_service.Services;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataMigration
+{
+    public class NotificationImportServiceTest
+    {
+        private readonly INotificationImportService _notificationImportService;
+
+        private readonly Mock<INotificationMapper> _notificationMapper = new Mock<INotificationMapper>();
+        private readonly Mock<INotificationRepository> _notificationRepository = new Mock<INotificationRepository>();
+        private readonly Mock<IImportLogger> _logger = new Mock<IImportLogger>();
+        private readonly Mock<Sentry.IHub> _sentryHub = new Mock<Sentry.IHub>();
+        private readonly Mock<IMigrationRepository> _migrationRepository = new Mock<IMigrationRepository>();
+        private readonly Mock<ISpecimenImportService> _specimenImportService = new Mock<ISpecimenImportService>();
+        private readonly Mock<IImportValidator> _importValidator = new Mock<IImportValidator>();
+        private readonly Mock<IClusterImportService> _clusterImportService = new Mock<IClusterImportService>();
+
+        private readonly Mock<INotificationImportRepository> _notificationImportRepository =
+            new Mock<INotificationImportRepository>();
+
+        private readonly Mock<IMigratedNotificationsMarker> _migratedNotificationsMarker =
+            new Mock<IMigratedNotificationsMarker>();
+
+        private readonly Mock<ICultureAndResistanceService> _cultureAndResistanceService =
+            new Mock<ICultureAndResistanceService>();
+
+        private readonly Mock<IDrugResistanceProfileService> _drugResistanceProfileService =
+            new Mock<IDrugResistanceProfileService>();
+
+        private readonly Mock<ICaseManagerImportService> _caseManagerImportService =
+            new Mock<ICaseManagerImportService>();
+
+        private readonly PerformContext _performContext = null;
+        private readonly string _requestId = "request1";
+
+        public NotificationImportServiceTest()
+        {
+            _notificationImportService = new NotificationImportService(
+                _notificationMapper.Object,
+                _notificationRepository.Object,
+                _notificationImportRepository.Object,
+                _logger.Object,
+                _sentryHub.Object,
+                _migrationRepository.Object,
+                _migratedNotificationsMarker.Object,
+                _specimenImportService.Object,
+                _importValidator.Object,
+                _clusterImportService.Object,
+                _cultureAndResistanceService.Object,
+                _drugResistanceProfileService.Object,
+                _caseManagerImportService.Object);
+
+            _importValidator
+                .Setup(iv => iv.CleanAndValidateNotification(_performContext, _requestId, It.IsAny<Notification>()))
+                .Returns(Task.FromResult(new List<ValidationResult>()));
+
+            _notificationImportRepository
+                .Setup(nir => nir.AddLinkedNotificationsAsync(It.IsAny<List<Notification>>()))
+                .Returns((List<Notification> notificationList) => Task.FromResult(notificationList));
+
+            _notificationRepository.Setup(nr => nr.NotificationWithLegacyIdExistsAsync(It.IsAny<string>()))
+                .Returns(Task.FromResult(false));
+        }
+
+        [Fact]
+        public async Task ImportByDateAsync_ImportsIdsInRange()
+        {
+            // Arrange
+            var rangeStartDate = DateTime.Parse("2021-01-01");
+            var rangeEndDate = DateTime.Parse("2021-05-01");
+            var notification1 = new Notification { NotificationId = 101, ETSID = "1" };
+            var notification2 = new Notification { NotificationId = 102, ETSID = "2" };
+            var notificationList = new List<IList<Notification>> { new[] { notification1 }, new[] { notification2 } };
+
+            _notificationMapper.Setup(nm =>
+                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, rangeStartDate, rangeEndDate))
+                .Returns(Task.FromResult(notificationList.AsEnumerable()));
+
+            // Act
+            var importResults =
+                await _notificationImportService.ImportByDateAsync(_performContext, _requestId, rangeStartDate, rangeEndDate);
+
+            // Assert
+            VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
+            VerifyNotificationImportServicesAreCalled(notification2, Times.Once());
+
+            Assert.All(importResults, result => Assert.True(result.IsValid));
+            Assert.Collection(importResults,
+                result => Assert.Contains(notification1.NotificationId, result.NtbsIds.Values),
+                result => Assert.Contains(notification2.NotificationId, result.NtbsIds.Values));
+        }
+
+        [Fact]
+        public async Task ImportByLegacyIdsAsync_ImportsIdsFromList()
+        {
+            // Arrange
+            var legacyIds = new List<string> { "1", "2", "3" };
+            var notification1 = new Notification { NotificationId = 101, ETSID = "1" };
+            var notification2 = new Notification { NotificationId = 102, ETSID = "2" };
+            var notificationList = new List<IList<Notification>> { new[] { notification1 }, new[] { notification2 } };
+
+            _notificationMapper.Setup(nm =>
+                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                .Returns(Task.FromResult(notificationList.AsEnumerable()));
+
+            // Act
+            var importResults =
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+
+            // Assert
+            VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
+            VerifyNotificationImportServicesAreCalled(notification2, Times.Once());
+
+            Assert.All(importResults, result => Assert.True(result.IsValid));
+            Assert.Collection(importResults,
+                result => Assert.Contains(notification1.NotificationId, result.NtbsIds.Values),
+                result => Assert.Contains(notification2.NotificationId, result.NtbsIds.Values));
+        }
+
+        [Fact]
+        public async Task ImportByLegacyIdsAsync_ImportsNotificationGroup()
+        {
+            // Arrange
+            var legacyIds = new List<string> { "1", "2" };
+            var notification1 = new Notification { NotificationId = 101, ETSID = "1" };
+            var notification2 = new Notification { NotificationId = 102, ETSID = "2" };
+            var notificationList = new List<IList<Notification>> { new[] { notification1, notification2 } };
+
+            _notificationMapper.Setup(nm =>
+                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                .Returns(Task.FromResult(notificationList.AsEnumerable()));
+
+            // Act
+            var importResults =
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+
+            // Assert
+            VerifyInitialImportServicesAreCalled(notification1, Times.Once());
+            VerifyInitialImportServicesAreCalled(notification2, Times.Once());
+            VerifyCommittingImportServicesAreCalled(new[] { notification1, notification2 }, Times.Once());
+
+            Assert.Collection(importResults, result =>
+            {
+                Assert.True(result.IsValid);
+                Assert.Contains(notification1.NotificationId, result.NtbsIds.Values);
+                Assert.Contains(notification2.NotificationId, result.NtbsIds.Values);
+            });
+        }
+
+        [Fact]
+        public async Task ImportByLegacyIdsAsync_DoesNotImportExistingNotifications()
+        {
+            // Arrange
+            var legacyIds = new List<string> { "1", "2", "3" };
+            var notification1 = new Notification { NotificationId = 101, ETSID = "1" };
+            var existingNotification2 = new Notification { NotificationId = 102, ETSID = "2" };
+            var notificationList = new List<IList<Notification>>
+            {
+                new[] { notification1 }, new[] { existingNotification2 }
+            };
+
+            const string existingId = "2";
+
+            _notificationMapper.Setup(nm =>
+                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                .Returns(Task.FromResult(notificationList.AsEnumerable()));
+
+            _notificationRepository.Setup(nr => nr.NotificationWithLegacyIdExistsAsync(existingId))
+                .Returns(Task.FromResult(true));
+
+            // Act
+            var importResults =
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+
+            // Assert
+            VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
+            VerifyNotificationImportServicesAreCalled(existingNotification2, Times.Never());
+
+            Assert.All(importResults, result => Assert.True(result.IsValid));
+            Assert.Collection(importResults,
+                result => Assert.Contains(notification1.NotificationId, result.NtbsIds.Values));
+        }
+
+        [Fact]
+        public async Task ImportByLegacyIdsAsync_DoesNotImportInvalidNotifications()
+        {
+            // Arrange
+            var legacyIds = new List<string> { "1", "2", "3" };
+            var notification1 = new Notification { NotificationId = 101, ETSID = "1" };
+            var invalidNotification2 = new Notification { NotificationId = 103, ETSID = "3" };
+            var notificationList = new List<IList<Notification>>
+            {
+                new[] {notification1}, new[] { invalidNotification2 }
+            };
+
+            _notificationMapper.Setup(nm =>
+                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                .Returns(Task.FromResult(notificationList.AsEnumerable()));
+
+            _importValidator
+                .Setup(iv => iv.CleanAndValidateNotification(_performContext, _requestId, invalidNotification2))
+                .Returns(Task.FromResult(new List<ValidationResult> { new ValidationResult("Validator error") }));
+
+            // Act
+            var importResults =
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+
+            // Assert
+            VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
+
+            VerifyInitialImportServicesAreCalled(invalidNotification2, Times.Once());
+            VerifyCommittingImportServicesAreCalled(new[] { invalidNotification2 }, Times.Never());
+
+            Assert.Collection(importResults, result =>
+            {
+                Assert.Contains(notification1.NotificationId, result.NtbsIds.Values);
+                Assert.True(result.IsValid);
+            }, result =>
+            {
+                Assert.Empty(result.NtbsIds);
+                Assert.False(result.IsValid);
+            });
+        }
+
+        private void VerifyNotificationImportServicesAreCalled(Notification notification, Times times)
+        {
+            VerifyInitialImportServicesAreCalled(notification, times);
+            VerifyCommittingImportServicesAreCalled(new List<Notification> { notification }, times);
+        }
+
+        private void VerifyInitialImportServicesAreCalled(Notification notification, Times times)
+        {
+            _caseManagerImportService.Verify(s =>
+                s.ImportOrUpdateUserFromNotification(notification, _performContext, _requestId), times);
+            _importValidator
+                .Verify(s => s.CleanAndValidateNotification(_performContext, _requestId, notification), times);
+        }
+
+        private void VerifyCommittingImportServicesAreCalled(IList<Notification> notifications, Times times)
+        {
+            Expression<Func<List<Notification>, bool>> matchesNotificationList = l => l.SequenceEqual(notifications);
+
+            _notificationImportRepository
+                .Verify(s => s.AddLinkedNotificationsAsync(It.Is(matchesNotificationList)), times);
+            _migratedNotificationsMarker.Verify(s =>
+                s.MarkNotificationsAsImportedAsync(It.Is(matchesNotificationList)), times);
+            _specimenImportService.Verify(s => s.ImportReferenceLabResultsAsync(
+                    _performContext,
+                    _requestId,
+                    It.Is(matchesNotificationList),
+                    It.IsAny<ImportResult>()),
+                times);
+            _cultureAndResistanceService.Verify(s =>
+                s.MigrateNotificationCultureResistanceSummary(It.Is(matchesNotificationList)), times);
+            _drugResistanceProfileService.Verify(s =>
+                s.UpdateDrugResistanceProfiles(It.Is(matchesNotificationList)), times);
+            _clusterImportService.Verify(s =>
+                s.UpdateClusterInformation(It.Is(matchesNotificationList)), times);
+        }
+    }
+}

--- a/ntbs-service-unit-tests/DataMigration/SpecimenImportTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/SpecimenImportTest.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hangfire.Server;
+using Moq;
+using ntbs_service.DataMigration;
+using ntbs_service.Models.Entities;
+using ntbs_service.Services;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataMigration
+{
+    public class SpecimenImportTest
+    {
+        private readonly ISpecimenImportService _specimenImportService;
+
+        private readonly Mock<IImportLogger> _logger = new Mock<IImportLogger>();
+        private readonly Mock<ISpecimenService> _specimenService = new Mock<ISpecimenService>();
+        private readonly ImportResult _importResult = new ImportResult("John Doe");
+
+        private readonly PerformContext _performContext = null;
+        private readonly string _requestId = "request1";
+
+        public SpecimenImportTest()
+        {
+            _specimenImportService = new SpecimenImportService(_logger.Object, _specimenService.Object);
+        }
+
+        [Fact]
+        public async Task ImportReferenceLabResultsAsync_ImportsResults()
+        {
+            // Arrange
+            var notifications = new[] {
+                new Notification { NotificationId = 101, ETSID = "1" },
+                new Notification { NotificationId = 102, ETSID = "2" }
+            };
+            var specimenMatches = new[] { ("1", "Reference1"), ("2", "Reference2"), ("2", "Reference3") };
+
+            _specimenService.Setup(s =>
+                    s.GetLegacyReferenceLaboratoryMatches(
+                        It.Is<IEnumerable<string>>(l => l.SequenceEqual(new[] { "1", "2" }))))
+                .Returns(Task.FromResult(specimenMatches.AsEnumerable()));
+
+            _specimenService.Setup(s =>
+                    s.MatchSpecimenAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(Task.FromResult(true));
+
+            // Act
+            await _specimenImportService.ImportReferenceLabResultsAsync(_performContext, _requestId, notifications,
+                _importResult);
+
+            // Assert
+            Assert.Empty(_importResult.ValidationErrors);
+            _specimenService.Verify(
+                s => s.MatchSpecimenAsync(101, "Reference1", AuditService.AuditUserSystem, true), Times.Once);
+            _specimenService.Verify(
+                s => s.MatchSpecimenAsync(102, "Reference2", AuditService.AuditUserSystem, true), Times.Once);
+            _specimenService.Verify(
+                s => s.MatchSpecimenAsync(102, "Reference3", AuditService.AuditUserSystem, true), Times.Once);
+        }
+
+        [Fact]
+        public async Task ImportReferenceLabResultsAsync_RecordsErrors()
+        {
+            // Arrange
+            var notifications = new[] {
+                new Notification { NotificationId = 101, ETSID = "1" },
+                new Notification { NotificationId = 102, ETSID = "2" }
+            };
+            var specimenMatches = new[] { ("1", "Reference1"), ("2", "Reference2") };
+
+            _specimenService.Setup(s =>
+                    s.GetLegacyReferenceLaboratoryMatches(
+                        It.Is<IEnumerable<string>>(l => l.SequenceEqual(new[] { "1", "2" }))))
+                .Returns(Task.FromResult(specimenMatches.AsEnumerable()));
+
+            _specimenService.Setup(s =>
+                    s.MatchSpecimenAsync(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(Task.FromResult(true));
+
+            _specimenService.Setup(s =>
+                    s.MatchSpecimenAsync(102, "Reference2", It.IsAny<string>(), It.IsAny<bool>()))
+                .Returns(Task.FromResult(false));
+
+            // Act
+            await _specimenImportService.ImportReferenceLabResultsAsync(_performContext, _requestId, notifications,
+                _importResult);
+
+            // Assert
+            Assert.Collection(_importResult.ValidationErrors, errorPair => Assert.Equal("2", errorPair.Key));
+        }
+    }
+}

--- a/ntbs-service/DataMigration/SpecimenImportService.cs
+++ b/ntbs-service/DataMigration/SpecimenImportService.cs
@@ -1,0 +1,55 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Hangfire.Server;
+using ntbs_service.Models.Entities;
+using ntbs_service.Services;
+
+namespace ntbs_service.DataMigration
+{
+    public interface ISpecimenImportService
+    {
+        Task ImportReferenceLabResultsAsync(PerformContext context, string requestId, IList<Notification> notifications,
+            ImportResult importResult);
+    }
+
+    public class SpecimenImportService : ISpecimenImportService
+    {
+        private readonly IImportLogger _logger;
+        private readonly ISpecimenService _specimenService;
+
+        public SpecimenImportService(IImportLogger logger,ISpecimenService specimenService)
+        {
+            _logger = logger;
+            _specimenService = specimenService;
+        }
+
+        /// <summary>
+        /// We have to run the reference lab result matches after the notifications have been imported into the main db,
+        /// since the matches are stored externally - we need to know what the generated NTBS ids are beforehand.
+        /// </summary>
+        public async Task ImportReferenceLabResultsAsync(PerformContext context,
+            string requestId,
+            IList<Notification> notifications,
+            ImportResult importResult)
+        {
+            var legacyIds = notifications.Select(n => n.ETSID);
+            var matches = await _specimenService.GetLegacyReferenceLaboratoryMatches(legacyIds);
+            foreach (var (legacyId, referenceLaboratoryNumber) in matches)
+            {
+                var notificationId = notifications.Single(n => n.ETSID == legacyId).NotificationId;
+                var success = await _specimenService.MatchSpecimenAsync(notificationId,
+                    referenceLaboratoryNumber,
+                    AuditService.AuditUserSystem,
+                    isMigrating: true);
+                if (!success)
+                {
+                    var error = $"Failed to set the specimen match for Notification: {notificationId}, reference lab number: {referenceLaboratoryNumber}. " +
+                                $"The notification is already imported, manual intervention needed!";
+                    _logger.LogError(context, requestId, error);
+                    importResult.AddNotificationError(legacyId, error);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
* Refactor the specimen importing logic out of `NotificationImportService` and into a new `SpecimenImportService`.
* Add tests for this new `SpecimenImportService`
* Add tests for `NotificationImportService`

I'm happy to refactor the `NotificationImportService` service some more if you would like, separating out the grouping step, and the specimen and cluster dependencies as we discussed, if you think it is needed.

## Checklist:
- [x] Automated tests are passing locally.