### PR TITLE
NTBS-NONE Add a missing service dependency

### DIFF
--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -220,6 +220,7 @@ namespace ntbs_service
             services.AddScoped<IEnhancedSurveillanceAlertsService, EnhancedSurveillanceAlertsService>();
             services.AddScoped<IUserSearchService, UserSearchService>();
             services.AddScoped<IClusterImportService, ClusterImportService>();
+            services.AddScoped<ISpecimenImportService, SpecimenImportService>();
             services.AddScoped<ICaseManagerImportService, CaseManagerImportService>();
             services.AddScoped<IAdUserService, AdUserService>();
             services.AddScoped<IReportingLinksService, ReportingLinksService>();


### PR DESCRIPTION
## Description
Add in a missing dependency to the `Startup.cs` file, used in legacy notification migration