### PR TITLE
NTBS-2299 No alerts on closed notifications

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -143,9 +143,12 @@ namespace ntbs_service_unit_tests.DataMigration
             Assert.Null(notification.SocialRiskFactors.RiskFactorHomelessness.InPastFiveYears);
             Assert.Null(notification.SocialRiskFactors.RiskFactorHomelessness.MoreThanFiveYearsAgo);
             Assert.Equal(Status.Yes, notification.SocialRiskFactors.RiskFactorImprisonment.Status);
-            Assert.Equal(false, notification.SocialRiskFactors.RiskFactorImprisonment.IsCurrent);
-            Assert.Equal(true, notification.SocialRiskFactors.RiskFactorImprisonment.InPastFiveYears);
-            Assert.Equal(false, notification.SocialRiskFactors.RiskFactorImprisonment.MoreThanFiveYearsAgo);
+            Assert.False(notification.SocialRiskFactors.RiskFactorImprisonment.IsCurrent);
+            Assert.True(notification.SocialRiskFactors.RiskFactorImprisonment.InPastFiveYears);
+            Assert.False(notification.SocialRiskFactors.RiskFactorImprisonment.MoreThanFiveYearsAgo);
+
+            Assert.False(notification.ShouldBeClosed());
+            Assert.Equal(NotificationStatus.Notified, notification.NotificationStatus);
 
             Assert.Empty(validationErrors);
         }
@@ -252,8 +255,10 @@ namespace ntbs_service_unit_tests.DataMigration
                 .Single();
 
             // Assert
-            Assert.Equal(1, notification.TreatmentEvents.Count);
-            Assert.Equal(true, notification.ClinicalDetails.IsPostMortem);
+            Assert.Single(notification.TreatmentEvents);
+            Assert.True(notification.ClinicalDetails.IsPostMortem);
+            Assert.True(notification.ShouldBeClosed());
+            Assert.Equal(NotificationStatus.Closed, notification.NotificationStatus);
             // For post mortem cases we *only* want to import the single death event so outcomes reporting is correct
             Assert.Collection(notification.TreatmentEvents,
                 te => Assert.Equal(TreatmentOutcomeType.Died, te.TreatmentOutcome.TreatmentOutcomeType));

--- a/ntbs-service-unit-tests/Models/Entities/Alerts/ClinicalDetailsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/Alerts/ClinicalDetailsTest.cs
@@ -9,26 +9,32 @@ namespace ntbs_service_unit_tests.Models.Entities.Alerts
     public class DataQualityDotVotAlertTest
     {
         [Theory]
-        [InlineData("Yes", true, false, false)]
-        [InlineData("Yes", false, true, false)]
-        [InlineData("Yes", false, false, true)]
-        [InlineData("No", true, false, true)]
-        [InlineData("No", false, true, true)]
-        [InlineData("No", false, false, false)]
-        [InlineData("Unknown", true, false, false)]
-        [InlineData(null, true, false, false)]
+        [InlineData("Yes", true, true, false, false)]
+        [InlineData("Yes", true, false, true, false)]
+        [InlineData("Yes", false, false, true, false)]
+        [InlineData("Yes", true, false, false, true)]
+        [InlineData("Yes", false, false, false, false)]
+        [InlineData("No", true, true, false, true)]
+        [InlineData("No", true, false, true, true)]
+        [InlineData("No", false, false, true, false)]
+        [InlineData("No", true, false, false, false)]
+        [InlineData("Unknown", true, true, false, false)]
+        [InlineData(null, true, true, false, false)]
         public void DotVotAlert_CorrectlyClassifiesNotification(
             string dotOfferedString,
+            bool notificationNotified,
             bool allRisks,
             bool anyRisk,
             bool notificationShouldQualify)
         {
             // Arrange
             Enum.TryParse(dotOfferedString, out Status dotOffered);
+            var notificationStatus = notificationNotified ? NotificationStatus.Notified : NotificationStatus.Closed;
             var alcoholMisuseStatus = allRisks || anyRisk ? Status.Yes : (Status?)null;
             var allStatuses = allRisks ? Status.Yes : (Status?)null;
             var notification = new Notification
             {
+                NotificationStatus = notificationStatus,
                 ClinicalDetails = new ClinicalDetails { IsDotOffered = dotOffered },
                 SocialRiskFactors = new SocialRiskFactors
                 {

--- a/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
@@ -1,4 +1,5 @@
-﻿using Moq;
+﻿using System.Threading.Tasks;
+using Moq;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
@@ -74,25 +75,30 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Theory]
-        [InlineData("M. bovis", null, null, null, null, true, false)]
-        [InlineData("M. bovis", null, null, null, Status.Yes, true, false)]
-        [InlineData("M. bovis", null, null, Status.Yes, null, true, false)]
-        [InlineData("M. bovis", null, Status.Yes, null, null, true, false)]
-        [InlineData("M. bovis", Status.Yes, null, null, null, true, false)]
-        [InlineData("M. bovis", Status.No, Status.No, Status.No, null, true, false)]
-        [InlineData("M. bovis", Status.No, Status.No, null, Status.No, true, false)]
-        [InlineData("M. bovis", Status.No, null, Status.No, Status.No, true, false)]
-        [InlineData("M. bovis", null, Status.No, Status.No, Status.No, true, false)]
-        [InlineData("M. bovis", Status.No, Status.No, Status.No, Status.No, false, true)]
-        [InlineData("M. bovis", Status.Yes, Status.No, Status.Unknown, Status.No, false, true)]
-        [InlineData("M. bovis", Status.Yes, Status.Yes, Status.Yes, Status.Yes, false, true)]
-        [InlineData("M. bovis", Status.Unknown, Status.Unknown, Status.Unknown, Status.Unknown, false, true)]
-        [InlineData("Non M. bovis", null, null, null, null, false, true)]
-        [InlineData("Non M. bovis", null, Status.No, Status.Unknown, Status.Yes, true, false)]
-        [InlineData("Non M. bovis", Status.Yes, Status.Yes, Status.Yes, Status.Yes, false, true)]
-        [InlineData("Non M. bovis", Status.No, Status.No, Status.No, Status.No, false, true)]
-        [InlineData("Non M. bovis", Status.Unknown, Status.Unknown, Status.Unknown, Status.Unknown, false, true)]
-        public void CreateOrDismissMBovisAlert(string drugSpecies,
+        [InlineData("M. bovis", false, null, null, null, null, true, false)]
+        [InlineData("M. bovis", true, null, null, null, null, false, true)]
+        [InlineData("M. bovis", false, null, null, null, Status.Yes, true, false)]
+        [InlineData("M. bovis", false, null, null, Status.Yes, null, true, false)]
+        [InlineData("M. bovis", false, null, Status.Yes, null, null, true, false)]
+        [InlineData("M. bovis", false, Status.Yes, null, null, null, true, false)]
+        [InlineData("M. bovis", false, Status.No, Status.No, Status.No, null, true, false)]
+        [InlineData("M. bovis", false, Status.No, Status.No, null, Status.No, true, false)]
+        [InlineData("M. bovis", false, Status.No, null, Status.No, Status.No, true, false)]
+        [InlineData("M. bovis", false, null, Status.No, Status.No, Status.No, true, false)]
+        [InlineData("M. bovis", true, null, Status.No, Status.No, Status.No, false, true)]
+        [InlineData("M. bovis", false, Status.No, Status.No, Status.No, Status.No, false, true)]
+        [InlineData("M. bovis", false, Status.Yes, Status.No, Status.Unknown, Status.No, false, true)]
+        [InlineData("M. bovis", false, Status.Yes, Status.Yes, Status.Yes, Status.Yes, false, true)]
+        [InlineData("M. bovis", false, Status.Unknown, Status.Unknown, Status.Unknown, Status.Unknown, false, true)]
+        [InlineData("Non M. bovis", false, null, null, null, null, false, true)]
+        [InlineData("Non M. bovis", true, null, null, null, null, false, true)]
+        [InlineData("Non M. bovis", false, null, Status.No, Status.Unknown, Status.Yes, true, false)]
+        [InlineData("Non M. bovis", true, null, Status.No, Status.Unknown, Status.Yes, false, true)]
+        [InlineData("Non M. bovis", false, Status.Yes, Status.Yes, Status.Yes, Status.Yes, false, true)]
+        [InlineData("Non M. bovis", false, Status.No, Status.No, Status.No, Status.No, false, true)]
+        [InlineData("Non M. bovis", false, Status.Unknown, Status.Unknown, Status.Unknown, Status.Unknown, false, true)]
+        public async Task CreateOrDismissMBovisAlert(string drugSpecies,
+            bool notificationClosed,
             Status? hasExposureToKnownCases,
             Status? hasUnpasteurisedMilkConsumption,
             Status? hasOccupationExposure,
@@ -104,6 +110,7 @@ namespace ntbs_service_unit_tests.Services
             var notification = new Notification
             {
                 NotificationId = 1,
+                NotificationStatus = notificationClosed ? NotificationStatus.Closed : NotificationStatus.Notified,
                 DrugResistanceProfile = new DrugResistanceProfile
                 {
                     Species = drugSpecies,
@@ -119,7 +126,7 @@ namespace ntbs_service_unit_tests.Services
             };
 
             // Act
-            EnhancedSurveillanceAlertsService.CreateOrDismissMBovisAlert(notification);
+            await EnhancedSurveillanceAlertsService.CreateOrDismissMBovisAlert(notification);
 
             // Assert
             var numberOfCallsToCreate = shouldCreateAlert ? Times.Once() : Times.Never();

--- a/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
@@ -509,6 +509,7 @@ namespace ntbs_service_unit_tests.Services
                 .Setup(r => r.GetNotificationAsync(existingNotification))
                 .Returns(Task.FromResult(new Notification
                 {
+                    NotificationStatus = NotificationStatus.Notified,
                     SocialContextVenues = new List<SocialContextVenue>(),
                     SocialContextAddresses = new List<SocialContextAddress>()
                 }));

--- a/ntbs-service-unit-tests/TestData/MigrationDatabaseMock/outcomeEvents.csv
+++ b/ntbs-service-unit-tests/TestData/MigrationDatabaseMock/outcomeEvents.csv
@@ -1,3 +1,3 @@
 OldNotificationId,EventDate,TreatmentEventType,TreatmentOutcomeId,Note,CaseManager,NtbsHospitalId
-130331,2015-09-15 00:00:00.0000000,TreatmentOutcome,1,"",,B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A
+130331,2015-09-15 00:00:00.0000000,TreatmentOutcome,16,"",,B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7A
 132465,2019-10-04 00:00:00.000,TreatmentOutcome,1,This is a dummy event for a post mortem case - this should not exist in the actual migration data.,,

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -13,6 +13,7 @@ namespace ntbs_service.DataAccess
         Task<Alert> GetOpenAlertByIdAsync(int? alertId);
         Task<T> GetAlertByNotificationIdAndTypeAsync<T>(int notificationId) where T : Alert;
         Task<T> GetOpenAlertByNotificationId<T>(int notificationId) where T : Alert;
+        Task<List<Alert>> GetAllOpenAlertsByNotificationId(int notificationId);
 
         Task<DataQualityPotentialDuplicateAlert> GetDuplicateAlertByNotificationIdAndDuplicateId(int notificationId,
             int duplicateId);
@@ -57,6 +58,13 @@ namespace ntbs_service.DataAccess
                 .Where(a => a.NotificationId == notificationId)
                 .OfType<T>()
                 .SingleOrDefaultAsync();
+        }
+
+        public async Task<List<Alert>> GetAllOpenAlertsByNotificationId(int notificationId)
+        {
+            return await GetBaseOpenAlertIQueryable()
+                .Where(a => a.NotificationId == notificationId)
+                .ToListAsync();
         }
 
         public async Task<DataQualityPotentialDuplicateAlert> GetDuplicateAlertByNotificationIdAndDuplicateId(int notificationId,

--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -298,12 +298,19 @@ AND (N1.[GroupId] <> N2.[GroupId] OR N1.[GroupId] is NULL or N2.[GroupId] is NUL
                             t.duplicate.NotificationDate <
                             DateTime.Now.AddDays(-DataQualityPotentialDuplicateAlert.MinNumberDaysNotifiedForAlert)
                         )
+                        // Check that the notifications are complete and have not been discarded (denotified or deleted)
+                        && (
+                            t.notification.NotificationStatus == NotificationStatus.Notified ||
+                            t.notification.NotificationStatus == NotificationStatus.Closed
+                        )
+                        && (
+                            t.duplicate.NotificationStatus == NotificationStatus.Notified ||
+                            t.duplicate.NotificationStatus == NotificationStatus.Closed
+                        )
                         // Check that notifications are not already linked.
                         &&
                         (
-                            t.notification.NotificationStatus == NotificationStatus.Notified &&
-                            t.duplicate.NotificationStatus == NotificationStatus.Notified &&
-                            (t.notification.GroupId != t.duplicate.GroupId || t.notification.GroupId == null)
+                            t.notification.GroupId != t.duplicate.GroupId || t.notification.GroupId == null
                         )
                     )
                 )

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -118,6 +118,7 @@ namespace ntbs_service.DataAccess
                     n => new NotificationForDrugResistanceImport
                     {
                         NotificationId = n.NotificationId,
+                        NotificationStatus = n.NotificationStatus,
                         DrugResistanceProfile = n.DrugResistanceProfile,
                         TreatmentRegimen = n.ClinicalDetails.TreatmentRegimen,
                         ExposureToKnownMdrCaseStatus = n.MDRDetails.ExposureToKnownCaseStatus,

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -300,19 +300,7 @@ namespace ntbs_service.DataAccess
                 .OrderBy(n => n.NotificationId)
                 .AsSplitQuery()
                 .ToListAsync())
-                .Where(n =>
-                {
-                    var lastTreatmentEvent = n.TreatmentEvents.OrderByDescending(t => t.EventDate)
-                        .ThenBy(t => t.TreatmentEventTypeIsOutcome).FirstOrDefault();
-                    if (lastTreatmentEvent != null)
-                    {
-                        return lastTreatmentEvent.TreatmentEventTypeIsOutcome
-                               && lastTreatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType !=
-                               TreatmentOutcomeSubType.StillOnTreatment
-                               && lastTreatmentEvent.EventDate < DateTime.Today.AddYears(-1);
-                    }
-                    return false;
-                });
+                .Where(n => n.ShouldBeClosed());
         }
 
         public async Task<NotificationGroup> GetNotificationGroupAsync(int notificationId)

--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -195,6 +195,11 @@ namespace ntbs_service.DataMigration
                     notificationMBovisOccupationExposures,
                     notificationMBovisUnpasteurisedMilkConsumption);
 
+                if (notification.ShouldBeClosed())
+                {
+                    notification.NotificationStatus = NotificationStatus.Closed;
+                }
+
                 notificationsToReturn.Add(notification);
             }
 

--- a/ntbs-service/Models/Entities/Alerts/DataQualityBirthCountryAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityBirthCountryAlert.cs
@@ -8,7 +8,8 @@ namespace ntbs_service.Models.Entities.Alerts
     public class DataQualityBirthCountryAlert : Alert
     {
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
-            n => n.PatientDetails.CountryId == Countries.UnknownId;
+            n => n.NotificationStatus == NotificationStatus.Notified
+                 && n.PatientDetails.CountryId == Countries.UnknownId;
 
         public static readonly Func<Notification, bool> NotificationQualifies =
             NotificationQualifiesExpression.Compile();

--- a/ntbs-service/Models/Entities/Alerts/DataQualityClinicalDatesAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityClinicalDatesAlert.cs
@@ -8,11 +8,12 @@ namespace ntbs_service.Models.Entities.Alerts
     public class DataQualityClinicalDatesAlert : Alert
     {
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
-            n => n.ClinicalDetails.SymptomStartDate > n.ClinicalDetails.TreatmentStartDate
-                 || n.ClinicalDetails.SymptomStartDate > n.ClinicalDetails.FirstPresentationDate
-                 || n.ClinicalDetails.FirstPresentationDate > n.ClinicalDetails.TBServicePresentationDate
-                 || n.ClinicalDetails.TBServicePresentationDate > n.ClinicalDetails.DiagnosisDate
-                 || n.ClinicalDetails.DiagnosisDate > n.ClinicalDetails.TreatmentStartDate;
+            n => n.NotificationStatus == NotificationStatus.Notified
+                 && (n.ClinicalDetails.SymptomStartDate > n.ClinicalDetails.TreatmentStartDate
+                     || n.ClinicalDetails.SymptomStartDate > n.ClinicalDetails.FirstPresentationDate
+                     || n.ClinicalDetails.FirstPresentationDate > n.ClinicalDetails.TBServicePresentationDate
+                     || n.ClinicalDetails.TBServicePresentationDate > n.ClinicalDetails.DiagnosisDate
+                     || n.ClinicalDetails.DiagnosisDate > n.ClinicalDetails.TreatmentStartDate);
 
         public static readonly Func<Notification, bool> NotificationQualifies =
             NotificationQualifiesExpression.Compile();

--- a/ntbs-service/Models/Entities/Alerts/DataQualityClusterAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityClusterAlert.cs
@@ -9,7 +9,8 @@ namespace ntbs_service.Models.Entities.Alerts
     public class DataQualityClusterAlert : Alert
     {
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
-            n => n.ClusterId != null
+            n => n.NotificationStatus == NotificationStatus.Notified
+                 && n.ClusterId != null
                  && !n.SocialContextAddresses.Any()
                  && !n.SocialContextVenues.Any();
 

--- a/ntbs-service/Models/Entities/Alerts/DataQualityDotVotAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityDotVotAlert.cs
@@ -9,29 +9,29 @@ namespace ntbs_service.Models.Entities.Alerts
     public class DataQualityDotVotAlert : Alert
     {
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
-            n =>
+            n => n.NotificationStatus == NotificationStatus.Notified
                 // record has one or more social risk factors but DOT is set to No
-                ((
-                    n.SocialRiskFactors.AlcoholMisuseStatus == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorDrugs.Status == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorHomelessness.Status == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorImprisonment.Status == Status.Yes ||
-                    n.SocialRiskFactors.MentalHealthStatus == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorSmoking.Status == Status.Yes ||
-                    n.SocialRiskFactors.AsylumSeekerStatus == Status.Yes ||
-                    n.SocialRiskFactors.ImmigrationDetaineeStatus == Status.Yes
-                ) && n.ClinicalDetails.IsDotOffered == Status.No)
-                || // OR - record has no social risk factors but DOT set to Yes
-                (!(
-                    n.SocialRiskFactors.AlcoholMisuseStatus == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorDrugs.Status == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorHomelessness.Status == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorImprisonment.Status == Status.Yes ||
-                    n.SocialRiskFactors.MentalHealthStatus == Status.Yes ||
-                    n.SocialRiskFactors.RiskFactorSmoking.Status == Status.Yes ||
-                    n.SocialRiskFactors.AsylumSeekerStatus == Status.Yes ||
-                    n.SocialRiskFactors.ImmigrationDetaineeStatus == Status.Yes
-                ) && n.ClinicalDetails.IsDotOffered == Status.Yes);
+                && (((
+                        n.SocialRiskFactors.AlcoholMisuseStatus == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorDrugs.Status == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorHomelessness.Status == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorImprisonment.Status == Status.Yes ||
+                        n.SocialRiskFactors.MentalHealthStatus == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorSmoking.Status == Status.Yes ||
+                        n.SocialRiskFactors.AsylumSeekerStatus == Status.Yes ||
+                        n.SocialRiskFactors.ImmigrationDetaineeStatus == Status.Yes
+                    ) && n.ClinicalDetails.IsDotOffered == Status.No)
+                    || // OR - record has no social risk factors but DOT set to Yes
+                    (!(
+                        n.SocialRiskFactors.AlcoholMisuseStatus == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorDrugs.Status == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorHomelessness.Status == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorImprisonment.Status == Status.Yes ||
+                        n.SocialRiskFactors.MentalHealthStatus == Status.Yes ||
+                        n.SocialRiskFactors.RiskFactorSmoking.Status == Status.Yes ||
+                        n.SocialRiskFactors.AsylumSeekerStatus == Status.Yes ||
+                        n.SocialRiskFactors.ImmigrationDetaineeStatus == Status.Yes
+                    ) && n.ClinicalDetails.IsDotOffered == Status.Yes));
 
         public static readonly Func<Notification, bool> NotificationQualifies =
             NotificationQualifiesExpression.Compile();

--- a/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome12.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome12.cs
@@ -17,7 +17,9 @@ namespace ntbs_service.Models.Entities.Alerts
             n => TreatmentOutcomesHelper.IsTreatmentOutcomeMissingAtXYears(n, 1);
 
         public static readonly Func<Notification, bool> NotificationQualifies =
-            n => NotificationInQualifyingDateRangeExpression.Compile()(n) && NotificationInRangeQualifies(n);
+            n => n.NotificationStatus == NotificationStatus.Notified
+                 && NotificationInQualifyingDateRangeExpression.Compile()(n)
+                 && NotificationInRangeQualifies(n);
 
         public override string Action => "Please provide an outcome with appropriate date";
 

--- a/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome24.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome24.cs
@@ -16,8 +16,10 @@ namespace ntbs_service.Models.Entities.Alerts
         public static readonly Func<Notification, bool> NotificationInRangeQualifies =
             n => TreatmentOutcomesHelper.IsTreatmentOutcomeMissingAtXYears(n, 2);
 
-        public static readonly Func<Notification, bool> NotificationQualifies = n =>
-            NotificationInQualifyingDateRangeExpression.Compile()(n) && NotificationInRangeQualifies(n);
+        public static readonly Func<Notification, bool> NotificationQualifies =
+            n => n.NotificationStatus == NotificationStatus.Notified
+                 && NotificationInQualifyingDateRangeExpression.Compile()(n)
+                 && NotificationInRangeQualifies(n);
 
         public override string Action => "Please provide an outcome with appropriate date";
 

--- a/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome36.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome36.cs
@@ -17,7 +17,9 @@ namespace ntbs_service.Models.Entities.Alerts
             n => TreatmentOutcomesHelper.IsTreatmentOutcomeMissingAtXYears(n, 3);
 
         public static readonly Func<Notification, bool> NotificationQualifies =
-            n => NotificationInQualifyingDateRangeExpression.Compile()(n) && NotificationInRangeQualifies(n);
+            n => n.NotificationStatus == NotificationStatus.Notified
+                 && NotificationInQualifyingDateRangeExpression.Compile()(n)
+                 && NotificationInRangeQualifies(n);
 
         public override string Action => "Please provide an outcome with appropriate date";
 

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -107,6 +107,18 @@ namespace ntbs_service.Models.Entities
             ClinicalDetails.IsPostMortem != true || (TreatmentEvents != null && TreatmentEvents.Any(x =>
                 x.TreatmentEventTypeIsOutcome && x.TreatmentOutcome.TreatmentOutcomeType == TreatmentOutcomeType.Died));
 
+        public bool ShouldBeClosed()
+        {
+            var lastTreatmentEvent = TreatmentEvents.OrderByDescending(t => t.EventDate)
+                .ThenBy(t => t.TreatmentEventTypeIsOutcome)
+                .FirstOrDefault();
+
+            return lastTreatmentEvent != null
+                && lastTreatmentEvent.TreatmentEventTypeIsOutcome
+                && lastTreatmentEvent.TreatmentOutcome?.TreatmentOutcomeSubType != TreatmentOutcomeSubType.StillOnTreatment
+                && lastTreatmentEvent.EventDate < DateTime.Today.AddYears(-1);
+        }
+
         string IOwnedEntityForAuditing.RootEntityType => RootEntities.Notification;
     }
 }

--- a/ntbs-service/Models/Enums/NotificationStatus.cs
+++ b/ntbs-service/Models/Enums/NotificationStatus.cs
@@ -17,4 +17,23 @@ namespace ntbs_service.Models.Enums
         [Display(Name = "Notification")]
         Closed
     }
+
+    public static class NotificationStatusHelper
+    {
+        public static bool IsOpen(this NotificationStatus status)
+        {
+            switch (status)
+            {
+                case NotificationStatus.Draft:
+                case NotificationStatus.Notified:
+                    return true;
+                case NotificationStatus.Deleted:
+                case NotificationStatus.Denotified:
+                case NotificationStatus.Legacy:
+                case NotificationStatus.Closed:
+                default:
+                    return false;
+            }
+        }
+    }
 }

--- a/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
+++ b/ntbs-service/Models/Projections/NotificationForDrugResistanceImport.cs
@@ -7,6 +7,7 @@ namespace ntbs_service.Models.Projections
     public interface INotificationForDrugResistanceImport
     {
         int NotificationId { get; }
+        NotificationStatus NotificationStatus { get; }
         DrugResistanceProfile DrugResistanceProfile { get; }
         bool IsMdr { get; }
         bool IsMBovis { get; }
@@ -17,6 +18,7 @@ namespace ntbs_service.Models.Projections
     public class NotificationForDrugResistanceImport : INotificationForDrugResistanceImport
     {
         public int NotificationId { get; set; }
+        public NotificationStatus NotificationStatus { get; set; }
         public DrugResistanceProfile DrugResistanceProfile { get; set; }
         public TreatmentRegimen? TreatmentRegimen { get; set; }
         public Status? ExposureToKnownMdrCaseStatus { get; set; }

--- a/ntbs-service/Services/EnhancedSurveillanceAlertsService.cs
+++ b/ntbs-service/Services/EnhancedSurveillanceAlertsService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using ntbs_service.Models.Entities.Alerts;
+using ntbs_service.Models.Enums;
 using ntbs_service.Models.Projections;
 
 namespace ntbs_service.Services
@@ -21,7 +22,8 @@ namespace ntbs_service.Services
 
         public async Task CreateOrDismissMdrAlert(INotificationForDrugResistanceImport notification)
         {
-            if (notification.IsMdr && !notification.MdrDetailsEntered)
+            if (notification.NotificationStatus != NotificationStatus.Closed &&
+                notification.IsMdr && !notification.MdrDetailsEntered)
             {
                 await CreateMdrAlert(notification);
             }
@@ -33,7 +35,8 @@ namespace ntbs_service.Services
 
         public async Task CreateOrDismissMBovisAlert(INotificationForDrugResistanceImport notification)
         {
-            if (notification.IsMBovis && !notification.IsMBovisQuestionnaireComplete)
+            if (notification.NotificationStatus != NotificationStatus.Closed &&
+                notification.IsMBovis && !notification.IsMBovisQuestionnaireComplete)
             {
                 await CreateMBovisAlert(notification);
             }


### PR DESCRIPTION
## Description
* Close old notifications during legacy import: 
    * Refactor out the logic to determine whether a notification is inactive and should be closed to the Notification model.
    * When importing a notification, set its status to be closed if it meets the inactive criteria, instead of waiting to get closed by Hangfire the following evening.
    * Amend `NotificationMapper` tests to ensure that notifications are closed or left open depending on their treatment events during import.
* Dismiss alerts if notification is closed: 
    * Don't open data quality alerts for notifications that are closed, and when a notification is being closed all of the alerts for it should also be closed.
    * The only exception to this is that the duplicate notification alert should only be closed if both notifications are closed.
    * To do this, run a new method in `AlertService` to close all alerts for a notification, from the notification closing logic.
    * Add some tests for this `AlertService` logic.

## Checklist:
- [x] Automated tests are passing locally.