### PR TITLE
NTBS-2298 Phase banners per environment

### DIFF
--- a/ntbs-service/Constants.cs
+++ b/ntbs-service/Constants.cs
@@ -17,6 +17,7 @@
         public const string DbConnectionStringSpecimenMatching = "specimenMatching";
         public const string ExternalLinks = "ExternalLinks";
         public const string EnvironmentDescription = "EnvironmentDescription";
+        public const string EnvironmentName = "EnvironmentDescription:EnvironmentName";
 
         public const int SqlServerDefaultCommandTimeOut = 600;
     }

--- a/ntbs-service/Constants.cs
+++ b/ntbs-service/Constants.cs
@@ -16,6 +16,7 @@
         public const string DbConnectionStringMigration = "migration";
         public const string DbConnectionStringSpecimenMatching = "specimenMatching";
         public const string ExternalLinks = "ExternalLinks";
+        public const string EnvironmentDescription = "EnvironmentDescription";
 
         public const int SqlServerDefaultCommandTimeOut = 600;
     }

--- a/ntbs-service/Pages/Health.cshtml
+++ b/ntbs-service/Pages/Health.cshtml
@@ -24,6 +24,11 @@
     </div>
 
     <div>
+        <h2>Environment</h2>
+        Environment: @Model.EnvironmentName
+    </div>
+
+    <div>
         <h2>Optional modules</h2>
         <div>Audit: @(Model.AuditEnabled ? Tick : Cross)</div>
         <div>Cluster matching: @(Model.ClusterMatchingEnabled ? Tick : Cross)</div>

--- a/ntbs-service/Pages/Health.cshtml.cs
+++ b/ntbs-service/Pages/Health.cshtml.cs
@@ -12,6 +12,8 @@ namespace ntbs_service.Pages
         {
             Release = configuration.GetValue<string>(Constants.Release);
 
+            EnvironmentName = configuration.GetValue<string>(Constants.EnvironmentName);
+
             AuditEnabled = configuration.GetValue<bool>(Constants.AuditEnabledConfigValue);
 
             // Note the value negation, since we're turning mocked => enabled
@@ -30,6 +32,7 @@ namespace ntbs_service.Pages
         }
 
         public string Release { get; }
+        public string EnvironmentName { get; }
         public bool AuditEnabled { get; }
         public bool ClusterMatchingEnabled { get; }
         public bool ReferenceLabResultsEnabled { get; }

--- a/ntbs-service/Pages/Shared/_Header.cshtml
+++ b/ntbs-service/Pages/Shared/_Header.cshtml
@@ -6,23 +6,18 @@
 @inject ntbs.IUserService UserService
 @inject ntbs.IReportingLinksService ReportingLinksService
 
+@using Microsoft.Extensions.Configuration
+@using ntbs_service.Properties
+@inject IConfiguration Configuration
+
 @{
     var breadcrumbs = ViewData["Breadcrumbs"];
+
+    var environmentDescription = new EnvironmentDescription();
+    Configuration.GetSection(Constants.EnvironmentDescription).Bind(environmentDescription);
 }
 
 <header role="banner" data-module="govuk-header">
-    <div class="govuk-phase-banner">
-        <div class="govuk-width-container">
-            <p class="govuk-phase-banner__content ">
-                <strong class="govuk-tag govuk-phase-banner__content__tag">
-                    beta
-                </strong>
-                <span class="govuk-phase-banner__text">
-                    This service is not yet live - your <a class="govuk-link" href="mailto:ntbs@phe.gov.uk?subject=NTBS%20UAT%20Feedback">feedback</a> will help us to improve it. Please do not enter live data.
-                </span>
-            </p>
-        </div>
-    </div>
     <div class="header-title-and-logo-background">
         <div class="govuk-header__container govuk-width-container no-border">
             <button type="button" role="button" class="govuk-header__menu-button govuk-js-header-toggle header-expand-menu-button" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
@@ -37,6 +32,24 @@
             </div>
         </div>
     </div>
+
+    @if (!environmentDescription.ContainsLiveData)
+    {
+        <div class="govuk-phase-banner live-data-warning-banner">
+            <div class="govuk-width-container">
+                <p class="govuk-phase-banner__content ">
+                    <strong class="govuk-tag govuk-phase-banner__content__tag">
+                        @environmentDescription.DisplayName
+                    </strong>
+                    <span class="govuk-phase-banner__text">
+                        The data on this site is synthetic and is for @environmentDescription.DisplayName purposes only.
+                        Please do not enter real patient data.
+                    </span>
+                </p>
+            </div>
+        </div>
+    }
+
     <div id="header-nav" class="header-navigation-background">
         <div class="govuk-header__container govuk-width-container no-border">
             <nav>
@@ -70,13 +83,13 @@
                             </a>
                         }
                     </li>
-                    
+
                     <navigation-with-submenu inline-template>
                         <li class="nav-with-submenu-header govuk-header__navigation-item header-navigation-link">
                             <a v-on:click="toggleMenu" href="/Help/Menu" class="govuk-header__link header-navigation-list-item nav-with-submenu-header-link">
                                 Help <i class="arrow down"></i>
                             </a>
-                            <ul ref="navigation-submenu" v-if="showMenu" class="nav-submenu-list" >
+                            <ul ref="navigation-submenu" v-if="showMenu" class="nav-submenu-list">
                                 <li class="header-navigation-link nav-submenu-list-item">
                                     <a class="govuk-header__link header-navigation-list-item" href="/Help">
                                         FAQ
@@ -90,7 +103,7 @@
                             </ul>
                         </li>
                     </navigation-with-submenu>
-                    
+
                     @if ((await AuthorizationService.AuthorizeAsync(User, "AdminOnly")).Succeeded)
                     {
                         <li class="govuk-header__navigation-item header-navigation-link">
@@ -99,13 +112,13 @@
                             </a>
                         </li>
                     }
-                    
+
                     <navigation-with-submenu inline-template>
                         <li class="nav-with-submenu-header govuk-header__navigation-item header-navigation-link">
                             <a v-on:click="toggleMenu" href="/ContactDetails/Menu" class="govuk-header__link header-navigation-list-item nav-with-submenu-header-link">
                                 @UserService.GetUserDisplayName(@User) <i class="arrow down"></i>
                             </a>
-                            <ul ref="navigation-submenu" v-if="showMenu" class="nav-submenu-list" >
+                            <ul ref="navigation-submenu" v-if="showMenu" class="nav-submenu-list">
                                 <li class="header-navigation-link nav-submenu-list-item">
                                     <a class="govuk-header__link header-navigation-list-item" href="/ContactDetails">
                                         Edit personal details
@@ -119,13 +132,13 @@
                             </ul>
                         </li>
                     </navigation-with-submenu>
-                    
+
                 </ul>
             </nav>
 
         </div>
     </div>
     <div class="breadcrumb-trail">
-        <partial name="_Breadcrumbs" model=@breadcrumbs/>  
+        <partial name="_Breadcrumbs" model=@breadcrumbs />
     </div>
 </header>

--- a/ntbs-service/Properties/EnvironmentDescription.cs
+++ b/ntbs-service/Properties/EnvironmentDescription.cs
@@ -4,5 +4,6 @@
     {
         public bool ContainsLiveData { get; set; } = false;
         public string DisplayName { get; set; } = "Unknown environment";
+        public string EnvironmentName { get; set; }
     }
 }

--- a/ntbs-service/Properties/EnvironmentDescription.cs
+++ b/ntbs-service/Properties/EnvironmentDescription.cs
@@ -1,0 +1,8 @@
+﻿namespace ntbs_service.Properties
+{
+    public class EnvironmentDescription
+    {
+        public bool ContainsLiveData { get; set; } = false;
+        public string DisplayName { get; set; } = "Unknown environment";
+    }
+}

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -39,6 +39,11 @@
   "ExternalLinks": {
     "ReportingOverview": ""
   },
+  "EnvironmentDescription": {
+    "ContainsLiveData": false,
+    "DisplayName": "development",
+    "EnvironmentName":  "local-dev"
+  },
   "MigrationConfig": {
     "TablePrefix": "Dev"
   },

--- a/ntbs-service/appsettings.Staging.json
+++ b/ntbs-service/appsettings.Staging.json
@@ -10,5 +10,9 @@
     "AttachStackTrace": true,
     "Debug": true,
     "DiagnosticsLevel": "Error"
+  },
+  "EnvironmentDescription": {
+    "ContainsLiveData": false,
+    "DisplayName": "development"
   }
 }

--- a/ntbs-service/deployments/dev.yml
+++ b/ntbs-service/deployments/dev.yml
@@ -89,6 +89,12 @@ spec:
               value: "true"
             - name: Hangfire__WorkerCount
               value: "3"
+            - name: EnvironmentDescription__ContainsLiveData
+              value: "false"
+            - name: EnvironmentDescription__DisplayName
+              value: "development"
+            - name: EnvironmentDescription__EnvironmentName
+              value: "phe-dev"
       imagePullSecrets:
         - name: registery-password
         - name: default-dockercfg-bs7wj

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -85,6 +85,8 @@ spec:
             value: "Int"
           - name: Sentry__Environment
             value: "int"
+          - name: EnvironmentDescription__EnvironmentName
+            value: "azure-int"
       imagePullSecrets:
       - name: registry-password
 ---

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -136,6 +136,12 @@ spec:
               value: "true"
             - name: Hangfire__WorkerCount
               value: "3"
+            - name: EnvironmentDescription__ContainsLiveData
+              value: "true"
+            - name: EnvironmentDescription__DisplayName
+              value: "live"
+            - name: EnvironmentDescription__EnvironmentName
+              value: "phe-live"
           volumeMounts:
             - mountPath: /krbtab
               name: krb-tab

--- a/ntbs-service/deployments/load-test.yml
+++ b/ntbs-service/deployments/load-test.yml
@@ -72,6 +72,8 @@ spec:
             value: "load-test"
           - name: ScheduledJobsConfig__UserSyncEnabled
             value: "false"
+          - name: EnvironmentDescription__EnvironmentName
+            value: "azure-load-test"
       imagePullSecrets:
       - name: registry-password
 ---

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -94,6 +94,8 @@ spec:
             value: "Test"
           - name: Sentry__Environment
             value: "test"
+          - name: EnvironmentDescription__EnvironmentName
+            value: "azure-test"
       imagePullSecrets:
       - name: registry-password
 ---

--- a/ntbs-service/deployments/training.yml
+++ b/ntbs-service/deployments/training.yml
@@ -85,6 +85,10 @@ spec:
             value: "Training"
           - name: Sentry__Environment
             value: "training"
+          - name: EnvironmentDescription__DisplayName
+            value: "training"
+          - name: EnvironmentDescription__EnvironmentName
+            value: "azure-training"
       imagePullSecrets:
       - name: registry-password
 ---

--- a/ntbs-service/deployments/uat-phe.yml
+++ b/ntbs-service/deployments/uat-phe.yml
@@ -132,6 +132,12 @@ spec:
               value: "true"
             - name: Hangfire__WorkerCount
               value: "3"
+            - name: EnvironmentDescription__ContainsLiveData
+              value: "false"
+            - name: EnvironmentDescription__DisplayName
+              value: "verification"
+            - name: EnvironmentDescription__EnvironmentName
+              value: "phe-uat"
           volumeMounts:
             - mountPath: /krbtab
               name: krb-tab

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -85,6 +85,8 @@ spec:
             value: "Uat"
           - name: Sentry__Environment
             value: "uat"
+          - name: EnvironmentDescription__EnvironmentName
+            value: "azure-uat"
       imagePullSecrets:
       - name: registry-password
 ---

--- a/ntbs-service/wwwroot/css/_colors.scss
+++ b/ntbs-service/wwwroot/css/_colors.scss
@@ -1,6 +1,7 @@
 $phe-red: #822433;
 $phe-red-dull: #610925;
 $phe-navy: #002776;
+$phe-yellow: #eaab00;
 
 $grey: #999999;
 $lighter-grey: #CCCCCC;
@@ -22,6 +23,7 @@ $success-green: #00a551;
 $specimen-card-border: $phe-navy;
 
 $page-border: #e5e5e5;
+$live-data-warning-background: $phe-yellow;
 $header-navigation-background: $phe-red;
 $header-submenu-background: #f9f9f9;
 $breadcrumb-trail-background: #DDDACF;

--- a/ntbs-service/wwwroot/css/header.scss
+++ b/ntbs-service/wwwroot/css/header.scss
@@ -150,3 +150,8 @@ body:not(.js-enabled) {
 .breadcrumb-trail-background {
     background-color: $breadcrumb-trail-background;
 }
+
+.live-data-warning-banner {
+    background-color: $live-data-warning-background;
+    border-bottom: none;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above, including the related JIRA ticket -->

## Description
* Describe environment in phase banner
    * Modify the phase banner so it only displays when live data should not be in the system, and have it describe the environment (eg. "Training" or "Development").
    * Adjust the phase banner styles to make it more eye-catching, and move it to below the app name in accordance with GOV.UK design system recommendations.
* Show environment name in Health page
* Add user-facing environment names to config files

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))

## Screenshots
### Training banner
![training_phase_banner](https://user-images.githubusercontent.com/3650110/117976863-24a83800-b328-11eb-8631-d7e7d423ebfc.png)
### Live banner (now removed)
![live_phase_banner](https://user-images.githubusercontent.com/3650110/117976867-2540ce80-b328-11eb-916f-c1c637bfb63e.png)