### PR TITLE
NTBS-2316 Make select list values consistent

### DIFF
--- a/ntbs-service/Models/OptionValue.cs
+++ b/ntbs-service/Models/OptionValue.cs
@@ -1,9 +1,21 @@
-﻿namespace ntbs_service.Models
+﻿using System;
+using ntbs_service.Helpers;
+
+namespace ntbs_service.Models
 {
     public class OptionValue
     {
         public string Value { get; set; }
         public string Text { get; set; }
         public string Group { get; set; }
+
+        public static OptionValue FromEnum(Enum e)
+        {
+            return new OptionValue
+            {
+                Value = (Convert.ToInt32(e)).ToString(),
+                Text = e.GetDisplayName()
+            };
+        }
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -177,7 +177,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
                     }),
                     Results = ((Result[])Enum.GetValues(typeof(Result)))
                         .Where(result => result.IsValidForTestType(value))
-                        .Select(result => new OptionValue { Value = result.ToString(), Text = result.GetDisplayName() })
+                        .Select(result => OptionValue.FromEnum(result))
                 });
         }
     }

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -239,11 +239,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
                 {
                     SubTypes = filteredTreatmentOutcomes
                         .Where(n => n.TreatmentOutcomeSubType != null)
-                        .Select(n => new OptionValue
-                        {
-                            Value = ((int?)n.TreatmentOutcomeSubType).ToString(),
-                            Text = n.TreatmentOutcomeSubType?.GetDisplayName()
-                        })
+                        .Select(n => OptionValue.FromEnum(n.TreatmentOutcomeSubType))
                 });
         }
     }


### PR DESCRIPTION
## Description
Fix a bug where the manual test result, result value would be lost from the edit page, because the select list used was not of the format that the Vue Filtered-Dropdown component was being told by the page. This led to the Vue component messing up the select box's options, and it getting set to the first value by default. This error was not present when JS was off.

The approach used by treatment event outcome subtype was correct; text as the enum name and the value as the enum integer. Extract out this calculation to `OptionValue.FromEnum`, and call it from both places.

## Checklist:
- [x] Automated tests are passing locally.