### PR TITLE
NTBS-2298: correct variables for training

### DIFF
--- a/ntbs-service/deployments/training.yml
+++ b/ntbs-service/deployments/training.yml
@@ -57,13 +57,13 @@ spec:
                 name: training-connection-strings
                 key: migrationDb
           - name: AdOptions__BaseUserGroup
-            value: "Global.NIS.NTBS"
+            value: "App.Auth.NIS.NTBS"
           - name: AdOptions__AdminUserGroup
-            value: "Global.NIS.NTBS.Admin"
+            value: "App.Auth.NIS.NTBS.Admin"
           - name: AdOptions__NationalTeamAdGroup
-            value: "Global.NIS.NTBS.NTS"
+            value: "App.Auth.NIS.NTBS.NTS"
           - name: AdOptions__ServiceGroupAdPrefix
-            value: "Global.NIS.NTBS.Service"
+            value: "App.Auth.NIS.NTBS.Service"
           - name: AzureAdOptions__ClientId
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
Correcting the environment variables for the training environment. Although deployed on our Azure, it uses PHE's Azure AD for authentication, so needs the PHE names for the AD groups
