### PR TITLE
NTBS-2317 Expand treatment event notes

### DIFF
--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -694,7 +694,7 @@ namespace ntbs_service.DataAccess
                     .WithMany(e => e.MBovisExposureToKnownCases)
                     .HasForeignKey(e => e.NotificationId)
                     .OnDelete(DeleteBehavior.Cascade)
-                    .IsRequired(false); ;
+                    .IsRequired(false);
             });
 
             modelBuilder.Entity<MBovisUnpasteurisedMilkConsumption>(entity =>
@@ -809,6 +809,8 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.TreatmentEventType)
                     .HasConversion(treatmentEventTypeEnumConverter)
                     .HasMaxLength(EnumMaxLength);
+                entity.Property(e => e.Note)
+                    .HasMaxLength(1000);
                 entity.HasOne(e => e.CaseManager)
                     .WithMany()
                     .HasForeignKey(e => e.CaseManagerId)

--- a/ntbs-service/Migrations/20210517103719_ExpandTreatmentEventNotes.Designer.cs
+++ b/ntbs-service/Migrations/20210517103719_ExpandTreatmentEventNotes.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210517103719_ExpandTreatmentEventNotes")]
+    partial class ExpandTreatmentEventNotes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210517103719_ExpandTreatmentEventNotes.cs
+++ b/ntbs-service/Migrations/20210517103719_ExpandTreatmentEventNotes.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class ExpandTreatmentEventNotes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Note",
+                table: "TreatmentEvent",
+                type: "nvarchar(1000)",
+                maxLength: 1000,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(150)",
+                oldMaxLength: 150,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Note",
+                table: "TreatmentEvent",
+                type: "nvarchar(150)",
+                maxLength: 150,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(1000)",
+                oldMaxLength: 1000,
+                oldNullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Expand the treatment event notes field from 150 chars long to 1000. This is being made longer in migration as part of this ticket, and that change is up for review [here](https://github.com/publichealthengland/ntbs-data-migration/pull/107).

## Checklist:
- [ ] Automated tests are passing locally.
