### PR TITLE
NTBS-2322 log migration events to db

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
+++ b/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
@@ -15,6 +15,7 @@ namespace ntbs_service_unit_tests.DataMigration
 {
     public class CaseManagerImportServiceTests : IDisposable
     {
+        private const int BATCH_ID = 56789;
         private const string NOTIFICATION_ID = "11111";
         private const string CASE_MANAGER_USERNAME_1 = "TestUser@nhs.net";
         private const string CASE_MANAGER_USERNAME_2 = "MartinUser@nhs.net";
@@ -35,7 +36,9 @@ namespace ntbs_service_unit_tests.DataMigration
             SetupMockMigrationRepo();
             IUserRepository userRepository = new UserRepository(_context);
             IReferenceDataRepository referenceDataRepository = new ReferenceDataRepository(_context);
-            var importLogger = new ImportLogger();
+            Mock<INotificationImportRepository> mockNotificationImportRepository = new Mock<INotificationImportRepository>();
+
+            var importLogger = new ImportLogger(mockNotificationImportRepository.Object);
             _caseManagerImportService = new CaseManagerImportService(userRepository, referenceDataRepository,
                 _migrationRepositoryMock.Object, importLogger);
         }
@@ -54,7 +57,7 @@ namespace ntbs_service_unit_tests.DataMigration
             await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS00TEST", HOSPITAL_GUID_1);
 
             // Act
-            await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, null, "test-request-1");
+            await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, null, BATCH_ID);
 
             // Assert
             var addedUser = _context.User.SingleOrDefault();
@@ -75,7 +78,7 @@ namespace ntbs_service_unit_tests.DataMigration
             await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS11FAKE", HOSPITAL_GUID_1);
 
             // Act
-            await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, null, "test-request-1");
+            await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, null, BATCH_ID);
 
             // Assert
             var addedUser = _context.User.SingleOrDefault();
@@ -97,7 +100,7 @@ namespace ntbs_service_unit_tests.DataMigration
             await GivenUserExistsInNtbsWithName("Jon", "Jonston");
 
             // Act
-            await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, null, "test-request-1");
+            await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, null, BATCH_ID);
 
             // Assert
             var updatedUser = _context.User.Single();

--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
@@ -21,11 +21,13 @@ namespace ntbs_service_unit_tests.DataMigration
         private readonly IImportValidator _importValidator;
         private readonly Mock<IReferenceDataRepository> _referenceDataRepositoryMock =
             new Mock<IReferenceDataRepository>();
+        private readonly Mock<IImportLogger> _importLoggerMock = new Mock<IImportLogger>();
+
+        private const int RunId = 12345;
 
         public ImportValidatorTest()
         {
-            var importLogger = new ImportLogger();
-            _importValidator = new ImportValidator(importLogger, _referenceDataRepositoryMock.Object);
+            _importValidator = new ImportValidator(_importLoggerMock.Object, _referenceDataRepositoryMock.Object);
         }
 
         [Fact]
@@ -54,7 +56,7 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             // Act
-            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, notification);
 
             // Assert
             var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
@@ -99,7 +101,7 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             // Act
-            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, notification);
 
             // Assert
             var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
@@ -132,7 +134,7 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             // Act
-            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, notification);
 
             // Assert
             var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
@@ -157,7 +159,7 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             // Act
-            var validationResults = await _importValidator.CleanAndValidateNotification(null, "test-request-V", notification);
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, notification);
 
             // Assert
             var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();

--- a/ntbs-service-unit-tests/DataMigration/NotificationImportServiceTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationImportServiceTest.cs
@@ -42,7 +42,7 @@ namespace ntbs_service_unit_tests.DataMigration
             new Mock<ICaseManagerImportService>();
 
         private readonly PerformContext _performContext = null;
-        private readonly string _requestId = "request1";
+        private readonly int _runId = 12345;
 
         public NotificationImportServiceTest()
         {
@@ -61,7 +61,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 _caseManagerImportService.Object);
 
             _importValidator
-                .Setup(iv => iv.CleanAndValidateNotification(_performContext, _requestId, It.IsAny<Notification>()))
+                .Setup(iv => iv.CleanAndValidateNotification(_performContext, _runId, It.IsAny<Notification>()))
                 .Returns(Task.FromResult(new List<ValidationResult>()));
 
             _notificationImportRepository
@@ -83,12 +83,12 @@ namespace ntbs_service_unit_tests.DataMigration
             var notificationList = new List<IList<Notification>> { new[] { notification1 }, new[] { notification2 } };
 
             _notificationMapper.Setup(nm =>
-                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, rangeStartDate, rangeEndDate))
+                    nm.GetNotificationsGroupedByPatient(_performContext, _runId, rangeStartDate, rangeEndDate))
                 .Returns(Task.FromResult(notificationList.AsEnumerable()));
 
             // Act
             var importResults =
-                await _notificationImportService.ImportByDateAsync(_performContext, _requestId, rangeStartDate, rangeEndDate);
+                await _notificationImportService.ImportByDateAsync(_performContext, _runId, rangeStartDate, rangeEndDate);
 
             // Assert
             VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
@@ -110,12 +110,12 @@ namespace ntbs_service_unit_tests.DataMigration
             var notificationList = new List<IList<Notification>> { new[] { notification1 }, new[] { notification2 } };
 
             _notificationMapper.Setup(nm =>
-                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                    nm.GetNotificationsGroupedByPatient(_performContext, _runId, legacyIds))
                 .Returns(Task.FromResult(notificationList.AsEnumerable()));
 
             // Act
             var importResults =
-                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _runId, legacyIds);
 
             // Assert
             VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
@@ -137,12 +137,12 @@ namespace ntbs_service_unit_tests.DataMigration
             var notificationList = new List<IList<Notification>> { new[] { notification1, notification2 } };
 
             _notificationMapper.Setup(nm =>
-                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                    nm.GetNotificationsGroupedByPatient(_performContext, _runId, legacyIds))
                 .Returns(Task.FromResult(notificationList.AsEnumerable()));
 
             // Act
             var importResults =
-                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _runId, legacyIds);
 
             // Assert
             VerifyInitialImportServicesAreCalled(notification1, Times.Once());
@@ -172,7 +172,7 @@ namespace ntbs_service_unit_tests.DataMigration
             const string existingId = "2";
 
             _notificationMapper.Setup(nm =>
-                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                    nm.GetNotificationsGroupedByPatient(_performContext, _runId, legacyIds))
                 .Returns(Task.FromResult(notificationList.AsEnumerable()));
 
             _notificationRepository.Setup(nr => nr.NotificationWithLegacyIdExistsAsync(existingId))
@@ -180,7 +180,7 @@ namespace ntbs_service_unit_tests.DataMigration
 
             // Act
             var importResults =
-                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _runId, legacyIds);
 
             // Assert
             VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
@@ -204,16 +204,16 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             _notificationMapper.Setup(nm =>
-                    nm.GetNotificationsGroupedByPatient(_performContext, _requestId, legacyIds))
+                    nm.GetNotificationsGroupedByPatient(_performContext, _runId, legacyIds))
                 .Returns(Task.FromResult(notificationList.AsEnumerable()));
 
             _importValidator
-                .Setup(iv => iv.CleanAndValidateNotification(_performContext, _requestId, invalidNotification2))
+                .Setup(iv => iv.CleanAndValidateNotification(_performContext, _runId, invalidNotification2))
                 .Returns(Task.FromResult(new List<ValidationResult> { new ValidationResult("Validator error") }));
 
             // Act
             var importResults =
-                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _requestId, legacyIds);
+                await _notificationImportService.ImportByLegacyIdsAsync(_performContext, _runId, legacyIds);
 
             // Assert
             VerifyNotificationImportServicesAreCalled(notification1, Times.Once());
@@ -241,9 +241,9 @@ namespace ntbs_service_unit_tests.DataMigration
         private void VerifyInitialImportServicesAreCalled(Notification notification, Times times)
         {
             _caseManagerImportService.Verify(s =>
-                s.ImportOrUpdateUserFromNotification(notification, _performContext, _requestId), times);
+                s.ImportOrUpdateUserFromNotification(notification, _performContext, _runId), times);
             _importValidator
-                .Verify(s => s.CleanAndValidateNotification(_performContext, _requestId, notification), times);
+                .Verify(s => s.CleanAndValidateNotification(_performContext, _runId, notification), times);
         }
 
         private void VerifyCommittingImportServicesAreCalled(IList<Notification> notifications, Times times)
@@ -256,7 +256,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 s.MarkNotificationsAsImportedAsync(It.Is(matchesNotificationList)), times);
             _specimenImportService.Verify(s => s.ImportReferenceLabResultsAsync(
                     _performContext,
-                    _requestId,
+                    _runId,
                     It.Is(matchesNotificationList),
                     It.IsAny<ImportResult>()),
                 times);

--- a/ntbs-service-unit-tests/DataMigration/SpecimenImportTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/SpecimenImportTest.cs
@@ -19,7 +19,7 @@ namespace ntbs_service_unit_tests.DataMigration
         private readonly ImportResult _importResult = new ImportResult("John Doe");
 
         private readonly PerformContext _performContext = null;
-        private readonly string _requestId = "request1";
+        private readonly int _runId = 12345;
 
         public SpecimenImportTest()
         {
@@ -44,7 +44,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 .Returns(Task.FromResult(true));
 
             // Act
-            await _specimenImportService.ImportReferenceLabResultsAsync(_performContext, _requestId, notifications,
+            await _specimenImportService.ImportReferenceLabResultsAsync(_performContext, _runId, notifications,
                 _importResult);
 
             // Assert
@@ -76,7 +76,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 .Returns(Task.FromResult(false));
 
             // Act
-            await _specimenImportService.ImportReferenceLabResultsAsync(_performContext, _requestId, notifications,
+            await _specimenImportService.ImportReferenceLabResultsAsync(_performContext, _runId, notifications,
                 _importResult);
 
             // Assert

--- a/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
@@ -32,8 +32,9 @@ namespace ntbs_service_unit_tests.DataMigration
                 .Returns((string username) => Task.FromResult(_usernameToLegacyUserDict[username]));
             migrationRepo.Setup(repo => repo.GetLegacyUserHospitalsByUsername(It.IsAny<string>()))
                 .ReturnsAsync((string username) => new List<MigrationLegacyUserHospital>());
+            var importLogger = new Mock<IImportLogger>();
             _caseManagerImportService =
-                new CaseManagerImportService(userRepo, _referenceDataRepository, migrationRepo.Object, new ImportLogger());
+                new CaseManagerImportService(userRepo, _referenceDataRepository, migrationRepo.Object, importLogger.Object);
             _treatmentEventMapper = new TreatmentEventMapper(_caseManagerImportService, _referenceDataRepository);
         }
 
@@ -55,7 +56,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 HospitalId = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7B"),
                 TreatmentEventType = "TransferIn"
             };
-            
+
             // Act
             var mappedEvent = await _treatmentEventMapper.AsTransferEvent(migrationTransferEvent);
 
@@ -82,7 +83,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 TreatmentOutcomeId = 2,
                 Note = "The patient had a specific outcome"
             };
-            
+
             // Act
             var mappedEvent = await _treatmentEventMapper.AsOutcomeEvent(migrationTransferEvent);
 
@@ -109,7 +110,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 TreatmentOutcomeId = 2,
                 Note = "The patient had a specific outcome"
             };
-            
+
             // Act
             var mappedEvent = await _treatmentEventMapper.AsOutcomeEvent(migrationTransferEvent);
 
@@ -121,7 +122,7 @@ namespace ntbs_service_unit_tests.DataMigration
             Assert.Null(mappedEvent.TbServiceCode);
             Assert.Null(mappedEvent.CaseManagerId);
         }
-        
+
         private void GivenLegacyUserWithName(string username, string givenName, string familyName)
         {
             _usernameToLegacyUserDict.Add(

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -65,6 +65,9 @@ namespace ntbs_service.DataAccess
         public virtual DbSet<MBovisOccupationExposure> MBovisOccupationExposures { get; set; }
         public virtual DbSet<MBovisAnimalExposure> MBovisAnimalExposure { get; set; }
         public DbSet<NotificationAndDuplicateIds> NotificationAndDuplicateIds { get; set; }
+        public virtual DbSet<LegacyImportMigrationRun> LegacyImportMigrationRun { get; set; }
+        public virtual DbSet<LegacyImportNotificationOutcome> LegacyImportNotificationOutcome { get; set; }
+        public virtual DbSet<LegacyImportNotificationLogMessage> LegacyImportNotificationLogMessage { get; set; }
 
         public DbSet<ReleaseVersion> ReleaseVersion { get; set; }
 
@@ -118,6 +121,7 @@ namespace ntbs_service.DataAccess
             var animalTypeEnumConverter = new EnumToStringConverter<AnimalType>();
             var animalTbStatusEnumConverter = new EnumToStringConverter<AnimalTbStatus>();
             var treatmentRegimentEnumConverter = new EnumToStringConverter<TreatmentRegimen>();
+            var logMessageLevelEnumConverter = new EnumToStringConverter<LogMessageLevel>();
 
             #endregion
 
@@ -849,6 +853,40 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.SystemName)
                     .IsRequired()
                     .HasMaxLength(64);
+            });
+
+            modelBuilder.Entity<LegacyImportNotificationOutcome>(entity =>
+            {
+                entity.Property(e => e.OldNotificationId)
+                    .HasMaxLength(50)
+                    .IsRequired();
+
+                entity.HasOne<LegacyImportMigrationRun>()
+                    .WithMany(e => e.LegacyImportNotificationOutcomes)
+                    .HasForeignKey(e => e.LegacyImportMigrationRunId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                entity.HasIndex(e => e.LegacyImportMigrationRunId);
+            });
+
+            modelBuilder.Entity<LegacyImportNotificationLogMessage>(entity =>
+            {
+                entity.Property(e => e.OldNotificationId)
+                    .HasMaxLength(50)
+                    .IsRequired();
+
+                entity.Property(e => e.LogMessageLevel)
+                    .HasConversion(logMessageLevelEnumConverter)
+                    .HasMaxLength(EnumMaxLength);
+
+                entity.HasOne<LegacyImportMigrationRun>()
+                    .WithMany(e => e.LegacyImportNotificationLogMessages)
+                    .HasForeignKey(e => e.LegacyImportMigrationRunId)
+                    .OnDelete(DeleteBehavior.Cascade)
+                    .IsRequired();
+
+                entity.HasIndex(e => e.LegacyImportMigrationRunId);
             });
         }
 

--- a/ntbs-service/DataMigration/ImportLogger.cs
+++ b/ntbs-service/DataMigration/ImportLogger.cs
@@ -1,46 +1,86 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using Hangfire.Console;
 using Hangfire.Server;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Entities.Alerts;
+using ntbs_service.Models.Enums;
 using Serilog;
 
 namespace ntbs_service.DataMigration
 {
     public interface IImportLogger
     {
-        void LogInformation(PerformContext context, string requestId, string message);
-        void LogWarning(PerformContext context, string requestId, string message);
-        void LogSuccess(PerformContext context, string requestId, string message);
-        void LogImportFailure(PerformContext context, string requestId, string message, Exception exception = null);
-        void LogError(PerformContext context, string requestId, string message, Exception exception = null);
+        void LogInformation(PerformContext context, int runId, string message);
+
+        Task LogNotificationWarning(PerformContext context, int runId, string legacyId, string message);
+        Task LogGroupWarning(PerformContext context, int runId, IList<Notification> notificationGroup,
+            string message);
+
+        void LogSuccess(PerformContext context, int runId, string message);
+        Task LogGroupSuccess(PerformContext context, int runId, IList<Notification> notificationGroup);
+        Task LogImportGroupFailure(PerformContext context, int runId, IList<Notification> notificationGroup,
+            string message, Exception exception = null);
+
+        Task LogNotificationError(PerformContext context, int runId, string legacyId, string message);
+        Task LogGroupError(PerformContext context, int runId, IList<Notification> notificationGroup,
+            string message);
     }
 
     public class ImportLogger : IImportLogger
     {
-        public void LogInformation(PerformContext context, string requestId, string message)
+        private readonly INotificationImportRepository _notificationImportRepository;
+
+        public ImportLogger(INotificationImportRepository notificationImportRepository)
         {
-            Log.Information($"NOTIFICATION IMPORT - {requestId} - {message}");
-            context.WriteLine($"NOTIFICATION IMPORT - {requestId} - {message}");
+            _notificationImportRepository = notificationImportRepository;
+        }
+
+        public void LogInformation(PerformContext context, int runId, string message)
+        {
+            Log.Information($"NOTIFICATION IMPORT - {runId} - {message}");
+            context.WriteLine($"NOTIFICATION IMPORT - {runId} - {message}");
 
         }
-        public void LogSuccess(PerformContext context, string requestId, string message)
+        public void LogSuccess(PerformContext context, int runId, string message)
         {
-            Log.Information($"NOTIFICATION IMPORT - {requestId} - {message}");
+            Log.Information($"NOTIFICATION IMPORT - {runId} - {message}");
 
             context.SetTextColor(ConsoleTextColor.Green);
-            context.WriteLine($"NOTIFICATION IMPORT - {requestId} - {message}");
+            context.WriteLine($"NOTIFICATION IMPORT - {runId} - {message}");
             context.ResetTextColor();
         }
 
-        public void LogImportFailure(PerformContext context, string requestId, string message, Exception exception = null)
+        public async Task LogGroupSuccess(PerformContext context, int runId, IList<Notification> notificationGroup)
         {
+            await SaveNotificationGroupOutcome(runId, notificationGroup, message: null, successfullyMigrated: true);
+
+            var importMappings =
+                string.Join(", ", notificationGroup.Select(n => $"({n.NotificationId}, {n.LegacyId})"));
+            var message = $"Imported notifications, in form (NtbsId, LegacyId) - {importMappings}";
+            LogSuccess(context, runId, message);
+
+            LogInformation(context, runId,
+                $"Finished importing notification group containing legacy ID {notificationGroup.First().LegacyId}");
+        }
+
+        public async Task LogImportGroupFailure(PerformContext context, int runId, IList<Notification>
+            notificationGroup, string message, Exception exception = null)
+        {
+            var legacyIds = string.Join(", ", notificationGroup.Select(n => n.LegacyId));
+            message = $"Notification group ({legacyIds}) failed to import {message}";
+
+            await SaveNotificationGroupOutcome(runId, notificationGroup, message, successfullyMigrated: false);
+
             // Import failure is not an error-level event - since failures
             // can be result of typical issues too (e.g. validation)
-
             // The reason for failure itself can report issues at higher log levels if needed.
-            Log.Information(exception, $"NOTIFICATION IMPORT - {requestId} - {message}");
+            Log.Information(exception, $"NOTIFICATION IMPORT - {runId} - {message}");
 
             context.SetTextColor(ConsoleTextColor.Red);
-            context.WriteLine($"NOTIFICATION IMPORT - {requestId} - {message}");
+            context.WriteLine($"NOTIFICATION IMPORT - {runId} - {message}");
             if (exception != null)
             {
                 context.WriteLine(exception.Message);
@@ -48,22 +88,94 @@ namespace ntbs_service.DataMigration
             context.ResetTextColor();
         }
 
-        public void LogWarning(PerformContext context, string requestId, string message)
+        private void LogWarning(PerformContext context, int runId, string message)
         {
-            Log.Warning($"NOTIFICATION IMPORT - {requestId} - {message}");
+            Log.Warning($"NOTIFICATION IMPORT - {runId} - {message}");
 
             context.SetTextColor(ConsoleTextColor.Yellow);
-            context.WriteLine($"NOTIFICATION IMPORT - {requestId} - {message}");
+            context.WriteLine($"NOTIFICATION IMPORT - {runId} - {message}");
             context.ResetTextColor();
         }
 
-        public void LogError(PerformContext context, string requestId, string message, Exception exception = null)
+        public async Task LogNotificationWarning(PerformContext context, int runId, string legacyId, string message)
         {
-            Log.Error($"NOTIFICATION IMPORT - {requestId} - {message}");
+            await SaveNotificationMessage(runId, legacyId, message, LogMessageLevel.Warning);
+
+            LogWarning(context, runId, $"Legacy notification {legacyId} {message}");
+        }
+
+        public async Task LogGroupWarning(PerformContext context, int runId, IList<Notification> notificationGroup,
+            string message)
+        {
+            await SaveNotificationGroupMessage(runId, notificationGroup, message, LogMessageLevel.Error);
+
+            LogWarning(context, runId, message);
+        }
+
+        private void LogError(PerformContext context, int runId, string message, Exception exception = null)
+        {
+            Log.Error($"NOTIFICATION IMPORT - {runId} - {message}");
 
             context.SetTextColor(ConsoleTextColor.DarkRed);
-            context.WriteLine($"NOTIFICATION IMPORT - {requestId} - {message}");
+            context.WriteLine($"NOTIFICATION IMPORT - {runId} - {message}");
             context.ResetTextColor();
+        }
+
+        public async Task LogNotificationError(PerformContext context, int runId, string legacyId, string message)
+        {
+            await SaveNotificationMessage(runId, legacyId, message, LogMessageLevel.Error);
+
+            LogError(context, runId, $"Legacy notification {legacyId} {message}");
+        }
+
+        public async Task LogGroupError(PerformContext context, int runId, IList<Notification> notificationGroup,
+            string message)
+        {
+            await SaveNotificationGroupMessage(runId, notificationGroup, message, LogMessageLevel.Error);
+
+            LogError(context, runId, message);
+        }
+
+        private async Task SaveNotificationMessage(int runId, string legacyId, string message,
+            LogMessageLevel messageLevel)
+        {
+            var dbMessage = new LegacyImportNotificationLogMessage
+            {
+                LegacyImportMigrationRunId = runId,
+                OldNotificationId = legacyId,
+                Message = message,
+                LogMessageLevel = messageLevel
+            };
+            await _notificationImportRepository.AddLegacyImportNotificationLogMessage(dbMessage);
+        }
+
+        private async Task SaveNotificationGroupMessage(int runId, IEnumerable<Notification> notificationGroup,
+            string message, LogMessageLevel messageLevel)
+        {
+            var messages = notificationGroup
+                .Select(n => new LegacyImportNotificationLogMessage
+                {
+                    LegacyImportMigrationRunId = runId,
+                    OldNotificationId = n.LegacyId,
+                    Message = message,
+                    LogMessageLevel = messageLevel
+                });
+            await _notificationImportRepository.AddLegacyImportNotificationLogMessageRange(messages);
+        }
+
+        private async Task SaveNotificationGroupOutcome(int runId, IEnumerable<Notification> notificationGroup,
+            string message, bool successfullyMigrated)
+        {
+            var outcomes = notificationGroup
+                .Select(n => new LegacyImportNotificationOutcome
+                {
+                    LegacyImportMigrationRunId = runId,
+                    OldNotificationId = n.LegacyId,
+                    NtbsId = n.NotificationId,
+                    SuccessfullyMigrated = successfullyMigrated,
+                    Notes = message
+                });
+            await _notificationImportRepository.AddLegacyImportNotificationOutcomeRange(outcomes);
         }
     }
 }

--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -14,7 +14,7 @@ namespace ntbs_service.DataMigration
     public interface IImportValidator
     {
         Task<List<ValidationResult>> CleanAndValidateNotification(PerformContext context,
-            string requestId,
+            int runId,
             Notification notification);
     }
 
@@ -30,11 +30,11 @@ namespace ntbs_service.DataMigration
         }
 
         public async Task<List<ValidationResult>> CleanAndValidateNotification(PerformContext context,
-            string requestId,
+            int runId,
             Notification notification)
         {
-            CleanData(notification, context, requestId);
-            return (await GetValidationErrors(context, requestId, notification)).ToList();
+            CleanData(notification, context, runId);
+            return (await GetValidationErrors(context, runId, notification)).ToList();
         }
 
         /// <summary>
@@ -45,16 +45,16 @@ namespace ntbs_service.DataMigration
         /// </summary>
         private void CleanData(Notification notification,
             PerformContext context,
-            string requestId)
+            int runId)
         {
             var missingDateResults = notification.TestData.ManualTestResults
                 .Where(result => !result.TestDate.HasValue)
                 .ToList();
             missingDateResults.ForEach(result =>
             {
-                var missingDateMessage =
-                    $"Notification {notification.LegacyId} had test results without a date set. The notification will be imported without this test record.";
-                _logger.LogWarning(context, requestId, missingDateMessage);
+                var missingDateMessage = "had test results without a date set. " +
+                                         "The notification will be imported without this test record.";
+                _logger.LogNotificationWarning(context, runId, notification.LegacyId, missingDateMessage);
                 notification.TestData.ManualTestResults.Remove(result);
             });
 
@@ -63,9 +63,9 @@ namespace ntbs_service.DataMigration
                 .ToList();
             dateInFutureResults.ForEach(result =>
             {
-                var dateInFutureMessage =
-                    $"Notification {notification.LegacyId} had test results with date set in future. The notification will be imported without this test record.";
-                _logger.LogWarning(context, requestId, dateInFutureMessage);
+                var dateInFutureMessage = "had test results with date set in future. " +
+                                          "The notification will be imported without this test record.";
+                _logger.LogNotificationWarning(context, runId, notification.LegacyId, dateInFutureMessage);
                 notification.TestData.ManualTestResults.Remove(result);
             });
 
@@ -74,9 +74,9 @@ namespace ntbs_service.DataMigration
                 .ToList();
             missingResults.ForEach(result =>
             {
-                var missingResultMessage =
-                    $"Notification {notification.LegacyId} had test results without a result recorded. The notification will be imported without this test record.";
-                _logger.LogWarning(context, requestId, missingResultMessage);
+                var missingResultMessage = "had test results without a result recorded. " +
+                                           "The notification will be imported without this test record.";
+                _logger.LogNotificationWarning(context, runId, notification.LegacyId, missingResultMessage);
                 notification.TestData.ManualTestResults.Remove(result);
             });
 
@@ -88,15 +88,15 @@ namespace ntbs_service.DataMigration
 
             if (ValidateObject(notification.ContactTracing).Any())
             {
-                var message =
-                    $"Notification {notification.LegacyId} invalid contact tracing figures. The notification will be imported without contact tracing data.";
-                _logger.LogWarning(context, requestId, message);
+                var message = "invalid contact tracing figures. " +
+                              "The notification will be imported without contact tracing data.";
+                _logger.LogNotificationWarning(context, runId, notification.LegacyId, message);
                 notification.ContactTracing = new ContactTracing();
             }
         }
 
         private async Task<IEnumerable<ValidationResult>> GetValidationErrors(PerformContext context,
-            string requestId, Notification notification)
+            int runId, Notification notification)
         {
             var singletonModels = new List<ModelBase>
             {
@@ -130,7 +130,7 @@ namespace ntbs_service.DataMigration
             NotificationHelper.SetShouldValidateFull(notification);
             void SetValidationContext(ModelBase model) => model.SetValidationContext(notification);
             singletonModels.ForEach(SetValidationContext);
-            // patient details has special treatment due to the await-ed results below 
+            // patient details has special treatment due to the await-ed results below
             notification.PatientDetails.SetValidationContext(notification);
             modelCollections.ForEach(collection => collection.ForEach(SetValidationContext));
 
@@ -139,7 +139,7 @@ namespace ntbs_service.DataMigration
             validationsResults.AddRange(ValidateObject(notification));
             singletonModels.Select(ValidateObject)
                 .ForEach(results => validationsResults.AddRange(results));
-            await VerifyCaseManager(context, requestId, notification.HospitalDetails);
+            await VerifyCaseManager(context, runId, notification);
             validationsResults.AddRange(
                 modelCollections.SelectMany(collection => collection.SelectMany(ValidateObject)));
 
@@ -157,17 +157,19 @@ namespace ntbs_service.DataMigration
         }
 
         private async Task VerifyCaseManager(PerformContext context,
-            string requestId, HospitalDetails details)
+            int runId, Notification notification)
         {
-            if (!details.CaseManagerId.HasValue)
+            if (!notification.HospitalDetails.CaseManagerId.HasValue)
             {
                 return;
             }
-            
-            var possibleCaseManager = await _referenceDataRepository.GetUserByIdAsync(details.CaseManagerId.Value);
+
+            var possibleCaseManager =
+                await _referenceDataRepository.GetUserByIdAsync(notification.HospitalDetails.CaseManagerId.Value);
             if (possibleCaseManager != null && !possibleCaseManager.IsCaseManager)
             {
-                _logger.LogWarning(context, requestId, "User set as case manager for notification is not a case manager.");
+                await _logger.LogNotificationWarning(context, runId, notification.LegacyId,
+                    "User set as case manager for notification is not a case manager.");
             }
         }
     }

--- a/ntbs-service/DataMigration/NotificationImportRepository.cs
+++ b/ntbs-service/DataMigration/NotificationImportRepository.cs
@@ -1,8 +1,11 @@
+using System;
+using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using EFAuditer;
 using ntbs_service.DataAccess;
 using ntbs_service.Models.Entities;
+using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
 using ntbs_service.Services;
 
@@ -12,15 +15,26 @@ namespace ntbs_service.DataMigration
     {
         Task<List<Notification>> AddLinkedNotificationsAsync(List<Notification> notifications);
         void AddSystemUserToAudits();
+
+        Task<LegacyImportMigrationRun> CreateLegacyImportMigrationRun(IList<string> legacyIds,
+            string fileName = null, string description = null);
+        Task<LegacyImportMigrationRun> CreateLegacyImportMigrationRun(DateTime rangeStartDate,
+            DateTime rangeEndDate, string description = null);
+
+        Task AddLegacyImportNotificationLogMessage(LegacyImportNotificationLogMessage message);
+        Task AddLegacyImportNotificationLogMessageRange(IEnumerable<LegacyImportNotificationLogMessage> messages);
+        Task AddLegacyImportNotificationOutcomeRange(IEnumerable<LegacyImportNotificationOutcome> outcomes);
     }
 
     public class NotificationImportRepository : INotificationImportRepository
     {
         private readonly NtbsContext _context;
+        private readonly IConfiguration _configuration;
 
-        public NotificationImportRepository(NtbsContext context)
+        public NotificationImportRepository(NtbsContext context, IConfiguration configuration)
         {
             _context = context;
+            _configuration = configuration;
         }
 
         public void AddSystemUserToAudits()
@@ -33,14 +47,68 @@ namespace ntbs_service.DataMigration
             if (notifications.Count > 1)
             {
                 var group = new NotificationGroup();
-                _context.NotificationGroup.Add(group);
+                await _context.NotificationGroup.AddAsync(group);
                 notifications.ForEach(n => n.Group = group);
             }
 
-            _context.Notification.AddRange(notifications);
+            await _context.Notification.AddRangeAsync(notifications);
             _context.AddAuditCustomField(CustomFields.AuditDetails, NotificationAuditType.Imported);
             await _context.SaveChangesAsync();
             return notifications;
         }
+
+        public async Task<LegacyImportMigrationRun> CreateLegacyImportMigrationRun(IList<string> legacyIds,
+            string fileName = null, string description = null)
+        {
+            var legacyIdsString = legacyIds == null ? null : string.Join(", ", legacyIds);
+
+            var run = CreateBasicLegacyImportMigrationRun(description);
+            run.LegacyIdList = legacyIdsString;
+            run.FileName = fileName;
+
+            await _context.LegacyImportMigrationRun.AddAsync(run);
+            await _context.SaveChangesAsync();
+            return run;
+        }
+
+        public async Task<LegacyImportMigrationRun> CreateLegacyImportMigrationRun(DateTime rangeStartDate,
+            DateTime rangeEndDate, string description = null)
+        {
+            var run = CreateBasicLegacyImportMigrationRun(description);
+            run.RangeStartDate = rangeStartDate;
+            run.RangeEndDate = rangeEndDate;
+
+            await _context.LegacyImportMigrationRun.AddAsync(run);
+            await _context.SaveChangesAsync();
+            return run;
+        }
+
+        public async Task AddLegacyImportNotificationLogMessage(LegacyImportNotificationLogMessage message)
+        {
+            await _context.LegacyImportNotificationLogMessage.AddAsync(message);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task AddLegacyImportNotificationLogMessageRange(
+            IEnumerable<LegacyImportNotificationLogMessage> messages)
+        {
+            await _context.LegacyImportNotificationLogMessage.AddRangeAsync(messages);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task AddLegacyImportNotificationOutcomeRange(
+            IEnumerable<LegacyImportNotificationOutcome> outcomes)
+        {
+            await _context.LegacyImportNotificationOutcome.AddRangeAsync(outcomes);
+            await _context.SaveChangesAsync();
+        }
+
+        private LegacyImportMigrationRun CreateBasicLegacyImportMigrationRun(string description) =>
+            new LegacyImportMigrationRun
+            {
+                AppRelease = _configuration.GetValue<string>(Constants.Release),
+                StartTime = DateTime.Now,
+                Description = description
+            };
     }
 }

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -16,24 +16,25 @@ namespace ntbs_service.DataMigration
     public interface INotificationImportService
     {
         [ExpirationTimeTwoWeeks]
-        Task<IList<ImportResult>> ImportByLegacyIdsAsync(PerformContext context, string requestId, List<string> legacyIds);
+        Task<IList<ImportResult>> ImportByLegacyIdsAsync(PerformContext context, int runId, List<string> legacyIds);
 
         [ExpirationTimeTwoWeeks]
-        Task<IList<ImportResult>> BulkImportByLegacyIdsAsync(PerformContext context, string requestId, List<string> legacyIds);
+        Task<IList<ImportResult>> BulkImportByLegacyIdsAsync(PerformContext context, int runId, List<string> legacyIds);
 
         /// <summary>
         /// Import notifications (and their linked ones) with notification dates in range [rangeStartDate, rangeEndDate)
         /// </summary>
         /// <param name="context"></param>
-        /// <param name="requestId"></param>
+        /// <param name="runId"></param>
         /// <param name="rangeStartDate"></param>
         /// <param name="rangeEndDate"></param>
         /// <returns></returns>
         [ExpirationTimeTwoWeeks]
-        Task<IList<ImportResult>> ImportByDateAsync(PerformContext context, string requestId, DateTime rangeStartDate, DateTime rangeEndDate);
+        Task<IList<ImportResult>> ImportByDateAsync(PerformContext context, int runId, DateTime rangeStartDate, DateTime
+            rangeEndDate);
 
         [ExpirationTimeTwoWeeks]
-        Task<IList<ImportResult>> BulkImportByDateAsync(PerformContext context, string requestId, DateTime rangeStartDate, DateTime rangeEndDate);
+        Task<IList<ImportResult>> BulkImportByDateAsync(PerformContext context, int runId, DateTime rangeStartDate, DateTime rangeEndDate);
     }
 
     public class NotificationImportService : INotificationImportService
@@ -81,58 +82,71 @@ namespace ntbs_service.DataMigration
             _caseManagerImportService = caseManagerImportService;
         }
 
-        public async Task<IList<ImportResult>> ImportByDateAsync(PerformContext context, string requestId, DateTime rangeStartDate, DateTime rangeEndDate)
+        public async Task<IList<ImportResult>> ImportByDateAsync(PerformContext context, int runId,
+            DateTime rangeStartDate, DateTime rangeEndDate)
         {
-            _logger.LogInformation(context, requestId, "Request to import by Date started");
-            _logger.LogInformation(context, requestId, $"Importing notifications in range from {rangeStartDate.Date} to {rangeEndDate.Date}");
+            _logger.LogInformation(context, runId, "Request to import by Date started");
+            _logger.LogInformation(context, runId,
+                $"Importing notifications in range from {rangeStartDate.Date} to {rangeEndDate.Date}");
 
-            var notificationsGroupsToImport = await _notificationMapper.GetNotificationsGroupedByPatient(context, requestId, rangeStartDate, rangeEndDate);
+            var notificationsGroupsToImport =
+                await _notificationMapper.GetNotificationsGroupedByPatient(context, runId, rangeStartDate,
+                    rangeEndDate);
 
-            var importResults = await ImportNotificationGroupsAsync(context, requestId, notificationsGroupsToImport);
+            var importResults = await ImportNotificationGroupsAsync(context, runId, notificationsGroupsToImport);
 
-            _logger.LogInformation(context, requestId, "Request to import by Date finished");
+            _logger.LogInformation(context, runId, "Request to import by Date finished");
+
             return importResults;
         }
 
-        public async Task<IList<ImportResult>> BulkImportByDateAsync(PerformContext context, string requestId, DateTime rangeStartDate, DateTime rangeEndDate)
+        public async Task<IList<ImportResult>> BulkImportByDateAsync(PerformContext context, int runId,
+            DateTime rangeStartDate, DateTime rangeEndDate)
         {
             _notificationImportRepository.AddSystemUserToAudits();
-            return await ImportByDateAsync(context, requestId, rangeStartDate, rangeEndDate);
+            return await ImportByDateAsync(context, runId, rangeStartDate, rangeEndDate);
         }
 
-        public async Task<IList<ImportResult>> ImportByLegacyIdsAsync(PerformContext context, string requestId, List<string> legacyIds)
+        public async Task<IList<ImportResult>> ImportByLegacyIdsAsync(PerformContext context, int runId,
+            List<string> legacyIds)
         {
-            _logger.LogInformation(context, requestId, "Request to import by Id started");
+            _logger.LogInformation(context, runId, $"Request to import by Id started for batch group");
 
-            var notificationsGroupsToImport = await _notificationMapper.GetNotificationsGroupedByPatient(context, requestId, legacyIds);
+            var notificationsGroupsToImport =
+                await _notificationMapper.GetNotificationsGroupedByPatient(context, runId, legacyIds);
 
-            var importResults = await ImportNotificationGroupsAsync(context, requestId, notificationsGroupsToImport);
+            var importResults = await ImportNotificationGroupsAsync(context, runId, notificationsGroupsToImport);
 
-            _logger.LogInformation(context, requestId, "Request to import by Id finished");
+            _logger.LogInformation(context, runId, "Request to import by Id finished");
+
             return importResults;
         }
 
-        public async Task<IList<ImportResult>> BulkImportByLegacyIdsAsync(PerformContext context, string requestId, List<string> legacyIds)
+        public async Task<IList<ImportResult>> BulkImportByLegacyIdsAsync(PerformContext context, int runId,
+            List<string> legacyIds)
         {
             _notificationImportRepository.AddSystemUserToAudits();
-            return await ImportByLegacyIdsAsync(context, requestId, legacyIds);
+            return await ImportByLegacyIdsAsync(context, runId, legacyIds);
         }
 
-        private async Task<List<ImportResult>> ImportNotificationGroupsAsync(PerformContext context, string requestId, IEnumerable<IList<Notification>> notificationsGroups)
+
+        private async Task<List<ImportResult>> ImportNotificationGroupsAsync(PerformContext context, int runId,
+            IEnumerable<IList<Notification>> notificationsGroups)
         {
             // Filter out notifications that already exist in ntbs database
             var notificationsGroupsToImport = new List<List<Notification>>();
             foreach (var notificationsGroup in notificationsGroups)
             {
                 var legacyIds = notificationsGroup.Select(x => x.LegacyId).ToList();
-                var legacyIdsToImport = await FilterOutImportedIdsAsync(context, requestId, legacyIds);
+                var legacyIdsToImport = await FilterOutImportedIdsAsync(context, runId, legacyIds);
                 if (legacyIdsToImport.Count == notificationsGroup.Count)
                 {
                     notificationsGroupsToImport.Add(notificationsGroup.ToList());
                 }
                 else if (legacyIdsToImport.Count != 0)
                 {
-                    _logger.LogError(context, requestId, "Invalid state. Some notifications already exist in NTBS database. Manual intervention needed");
+                    await _logger.LogGroupError(context, runId, notificationsGroup,
+                        "Invalid state. Some notifications already exist in NTBS database. Manual intervention needed");
                 }
                 // The last option is that ALL notifications in the group were filtered out - that's OK! It means we
                 // have already imported this group - this will show up in the import errors.
@@ -143,7 +157,7 @@ namespace ntbs_service.DataMigration
             {
                 // Validate and Import valid notifications
                 importResults = notificationsGroupsToImport
-                    .Select(notificationsGroup => ValidateAndImportNotificationGroupAsync(context, requestId, notificationsGroup))
+                    .Select(notificationsGroup => ValidateAndImportNotificationGroupAsync(context, runId, notificationsGroup))
                     .Select(t => t.Result)
                     .ToList();
             }
@@ -151,94 +165,95 @@ namespace ntbs_service.DataMigration
             return importResults;
         }
 
-        private async Task<ImportResult> ValidateAndImportNotificationGroupAsync(PerformContext context, string requestId, List<Notification> notifications)
+        private async Task<ImportResult> ValidateAndImportNotificationGroupAsync(PerformContext context, int runId,
+            List<Notification> notifications)
         {
             var importResult = new ImportResult(notifications.First().PatientDetails.FullName);
 
-            _logger.LogInformation(context, requestId, $"{notifications.Count} notifications found to import in notification group containing legacy ID {notifications.First().LegacyId}");
+            _logger.LogInformation(context, runId,
+                $"{notifications.Count} notifications found to import in notification group containing legacy ID {notifications.First().LegacyId}");
 
             // Verify that no repeated NotificationIds have returned
             var ids = notifications.Select(n => n.LegacyId).ToList();
             if (ids.Distinct().Count() != ids.Count)
             {
-                var errorMessage = $"Duplicate records found ({string.Join(',', ids)}) - aborting import for notification group containing legacy ID {notifications.First().LegacyId}";
-                importResult.AddGroupError(errorMessage);
-                _logger.LogImportFailure(context, requestId, errorMessage);
+                importResult.AddGroupError("Aborting group import due to duplicate records found");
+                await _logger.LogImportGroupFailure(context, runId, notifications, "due to duplicate records found");
                 return importResult;
             }
 
             var isAnyNotificationInvalid = false;
             foreach (var notification in notifications)
             {
-                await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, context, requestId);
+                await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, context, runId);
                 var linkedNotificationId = notification.LegacyId;
-                _logger.LogInformation(context, requestId, $"Validating notification with Id={linkedNotificationId}");
+                _logger.LogInformation(context, runId, $"Validating notification with Id={linkedNotificationId}");
 
                 var validationErrors = await _importValidator.CleanAndValidateNotification(context,
-                    requestId,
+                    runId,
                     notification);
                 if (!validationErrors.Any())
                 {
-                    _logger.LogInformation(context, requestId, "No validation errors found");
+                    _logger.LogInformation(context, runId, "No validation errors found");
                     importResult.AddValidNotification(linkedNotificationId);
                 }
                 else
                 {
                     isAnyNotificationInvalid = true;
                     importResult.AddValidationErrorsMessages(linkedNotificationId, validationErrors);
-                    _logger.LogWarning(context, requestId, $"{validationErrors.Count} validation errors found for notification with Id={linkedNotificationId}:");
+                    await _logger.LogNotificationWarning(context, runId, linkedNotificationId,
+                        $"has {validationErrors.Count} validation errors");
                     foreach (var validationError in validationErrors)
                     {
-                        _logger.LogWarning(context, requestId, validationError.ErrorMessage);
+                        await _logger.LogNotificationWarning(context, runId, linkedNotificationId, validationError.ErrorMessage);
                     }
                 }
             }
 
             if (isAnyNotificationInvalid)
             {
-                _logger.LogImportFailure(context, requestId, $"Terminating importing notification group containing legacy ID {notifications.First().LegacyId} due to validation errors");
+                await _logger.LogImportGroupFailure(context, runId, notifications, "due to validation errors");
                 return importResult;
             }
 
-            _logger.LogSuccess(context, requestId, $"Importing {notifications.Count} valid notifications");
+            _logger.LogSuccess(context, runId, $"Importing {notifications.Count} valid notifications");
             try
             {
                 var savedNotifications = await _notificationImportRepository.AddLinkedNotificationsAsync(notifications);
                 await _migratedNotificationsMarker.MarkNotificationsAsImportedAsync(savedNotifications);
                 importResult.NtbsIds = savedNotifications.ToDictionary(x => x.LegacyId, x => x.NotificationId);
-                await _specimenImportService.ImportReferenceLabResultsAsync(context, requestId, savedNotifications, importResult);
+                await _specimenImportService.ImportReferenceLabResultsAsync(context, runId, savedNotifications, importResult);
                 await _cultureAndResistanceService.MigrateNotificationCultureResistanceSummary(savedNotifications);
                 await _drugResistanceProfileService.UpdateDrugResistanceProfiles(savedNotifications);
                 await _clusterImportService.UpdateClusterInformation(savedNotifications);
 
-                var newIdsString = string.Join(" ,", savedNotifications.Select(x => x.NotificationId));
-                _logger.LogSuccess(context, requestId, $"Imported notifications have following Ids: {newIdsString}");
-
-                _logger.LogInformation(context, requestId, $"Finished importing notification group containing legacy ID {notifications.First().LegacyId}");
+                await _logger.LogGroupSuccess(context, runId, notifications);
             }
             catch (MarkingNotificationsAsImportedFailedException e)
             {
                 Log.Error(e, e.Message);
-                _logger.LogWarning(context, requestId, message: e.Message);
+                await _logger.LogGroupWarning(context, runId, notifications, e.Message);
                 importResult.AddGroupError($"{e.Message}: {e.StackTrace}");
             }
             catch (Exception e)
             {
                 Log.Error(e, e.Message);
-                _logger.LogImportFailure(context, requestId, message: $"Failed to save notification in notification group containing legacy ID {notifications.First().LegacyId} or mark it as imported ", e);
+                await _logger.LogImportGroupFailure(context, runId, notifications,
+                    "failed to save a notification in the group", e);
                 importResult.AddGroupError($"{e.Message}: {e.StackTrace}");
             }
             return importResult;
         }
 
-        private async Task<List<string>> FilterOutImportedIdsAsync(PerformContext context, string requestId, List<string> legacyIds)
+        private async Task<List<string>> FilterOutImportedIdsAsync(PerformContext context, int runId,
+            List<string> legacyIds)
         {
             var legacyIdsToImport = new List<string>();
             foreach (var legacyId in legacyIds)
             {
                 if (await _notificationRepository.NotificationWithLegacyIdExistsAsync(legacyId))
                 {
-                    _logger.LogWarning(context, requestId, $"Notification with Id={legacyId} already exists in NTBS database");
+                    await _logger.LogNotificationWarning(context, runId, legacyId, "already exists in NTBS database");
                 }
                 else
                 {

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -156,10 +156,11 @@ namespace ntbs_service.DataMigration
             if (notificationsGroupsToImport.Any())
             {
                 // Validate and Import valid notifications
-                importResults = notificationsGroupsToImport
-                    .Select(notificationsGroup => ValidateAndImportNotificationGroupAsync(context, runId, notificationsGroup))
-                    .Select(t => t.Result)
-                    .ToList();
+                foreach (var notificationsGroup in notificationsGroupsToImport)
+                {
+                    importResults.Add(await ValidateAndImportNotificationGroupAsync(context, runId,
+                        notificationsGroup));
+                }
             }
 
             return importResults;

--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -27,9 +27,9 @@ namespace ntbs_service.DataMigration
     public interface INotificationMapper
     {
         Task<IEnumerable<IList<Notification>>> GetNotificationsGroupedByPatient(PerformContext context,
-            string requestId, List<string> notificationId);
+            int runId, List<string> notificationId);
         Task<IEnumerable<IList<Notification>>> GetNotificationsGroupedByPatient(PerformContext context,
-            string requestId, DateTime rangeStartDate, DateTime endStartDate);
+            int runId, DateTime rangeStartDate, DateTime endStartDate);
     }
 
     public class NotificationMapper : INotificationMapper
@@ -63,28 +63,28 @@ namespace ntbs_service.DataMigration
         }
 
         public async Task<IEnumerable<IList<Notification>>> GetNotificationsGroupedByPatient(PerformContext context,
-            string requestId, DateTime rangeStartDate, DateTime endStartDate)
+            int runId, DateTime rangeStartDate, DateTime endStartDate)
         {
             var groupedIds = await _migrationRepository.GetGroupedNotificationIdsByDate(rangeStartDate, endStartDate);
 
-            return await GetGroupedResultsAsNotificationAsync(groupedIds, context, requestId);
+            return await GetGroupedResultsAsNotificationAsync(groupedIds, context, runId);
         }
 
         public async Task<IEnumerable<IList<Notification>>> GetNotificationsGroupedByPatient(PerformContext context,
-            string requestId, List<string> notificationIds)
+            int runId, List<string> notificationIds)
         {
             var groupedIds = await _migrationRepository.GetGroupedNotificationIdsById(notificationIds);
 
-            return await GetGroupedResultsAsNotificationAsync(groupedIds, context, requestId);
+            return await GetGroupedResultsAsNotificationAsync(groupedIds, context, runId);
         }
 
-        private async Task<IEnumerable<IList<Notification>>> GetGroupedResultsAsNotificationAsync(IEnumerable<IGrouping<string, string>> groupedIds, PerformContext context, string requestId)
+        private async Task<IEnumerable<IList<Notification>>> GetGroupedResultsAsNotificationAsync(IEnumerable<IGrouping<string, string>> groupedIds, PerformContext context, int runId)
         {
             var resultList = new List<IList<Notification>>();
             foreach (var group in groupedIds)
             {
                 var legacyIds = group.ToList();
-                _logger.LogInformation(context, requestId, $"Fetching data for legacy notifications {string.Join(", ", legacyIds)}");
+                _logger.LogInformation(context, runId, $"Fetching data for legacy notifications {string.Join(", ", legacyIds)}");
                 var legacyNotifications = _migrationRepository.GetNotificationsById(legacyIds);
                 var sitesOfDisease = _migrationRepository.GetNotificationSites(legacyIds);
                 var manualTestResults = _migrationRepository.GetManualTestResults(legacyIds);

--- a/ntbs-service/DataMigration/SpecimenImportService.cs
+++ b/ntbs-service/DataMigration/SpecimenImportService.cs
@@ -9,8 +9,8 @@ namespace ntbs_service.DataMigration
 {
     public interface ISpecimenImportService
     {
-        Task ImportReferenceLabResultsAsync(PerformContext context, string requestId, IList<Notification> notifications,
-            ImportResult importResult);
+        Task ImportReferenceLabResultsAsync(PerformContext context, int runId,
+            IList<Notification> notifications, ImportResult importResult);
     }
 
     public class SpecimenImportService : ISpecimenImportService
@@ -29,7 +29,7 @@ namespace ntbs_service.DataMigration
         /// since the matches are stored externally - we need to know what the generated NTBS ids are beforehand.
         /// </summary>
         public async Task ImportReferenceLabResultsAsync(PerformContext context,
-            string requestId,
+            int runId,
             IList<Notification> notifications,
             ImportResult importResult)
         {
@@ -44,9 +44,9 @@ namespace ntbs_service.DataMigration
                     isMigrating: true);
                 if (!success)
                 {
-                    var error = $"Failed to set the specimen match for Notification: {notificationId}, reference lab number: {referenceLaboratoryNumber}. " +
+                    var error = $"Failed to set the specimen match for reference lab number: {referenceLaboratoryNumber}. " +
                                 $"The notification is already imported, manual intervention needed!";
-                    _logger.LogError(context, requestId, error);
+                    await _logger.LogNotificationError(context, runId, legacyId, error);
                     importResult.AddNotificationError(legacyId, error);
                 }
             }

--- a/ntbs-service/Migrations/20210521094459_AddLegacyImportMigrationRunTables.Designer.cs
+++ b/ntbs-service/Migrations/20210521094459_AddLegacyImportMigrationRunTables.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210521094459_AddLegacyImportMigrationRunTables")]
+    partial class AddLegacyImportMigrationRunTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210521094459_AddLegacyImportMigrationRunTables.cs
+++ b/ntbs-service/Migrations/20210521094459_AddLegacyImportMigrationRunTables.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class AddLegacyImportMigrationRunTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LegacyImportMigrationRun",
+                columns: table => new
+                {
+                    LegacyImportMigrationRunId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    StartTime = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    AppRelease = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    FileName = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    LegacyIdList = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    RangeStartDate = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    RangeEndDate = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LegacyImportMigrationRun", x => x.LegacyImportMigrationRunId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LegacyImportNotificationLogMessage",
+                columns: table => new
+                {
+                    LegacyImportNotificationLogMessageId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    LegacyImportMigrationRunId = table.Column<int>(type: "int", nullable: false),
+                    OldNotificationId = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    LogMessageLevel = table.Column<string>(type: "nvarchar(30)", maxLength: 30, nullable: false),
+                    Message = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LegacyImportNotificationLogMessage", x => x.LegacyImportNotificationLogMessageId);
+                    table.ForeignKey(
+                        name: "FK_LegacyImportNotificationLogMessage_LegacyImportMigrationRun_LegacyImportMigrationRunId",
+                        column: x => x.LegacyImportMigrationRunId,
+                        principalTable: "LegacyImportMigrationRun",
+                        principalColumn: "LegacyImportMigrationRunId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LegacyImportNotificationOutcome",
+                columns: table => new
+                {
+                    LegacyImportNotificationOutcomeId = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    LegacyImportMigrationRunId = table.Column<int>(type: "int", nullable: false),
+                    OldNotificationId = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                    NtbsId = table.Column<int>(type: "int", nullable: true),
+                    SuccessfullyMigrated = table.Column<bool>(type: "bit", nullable: true),
+                    Notes = table.Column<string>(type: "nvarchar(max)", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LegacyImportNotificationOutcome", x => x.LegacyImportNotificationOutcomeId);
+                    table.ForeignKey(
+                        name: "FK_LegacyImportNotificationOutcome_LegacyImportMigrationRun_LegacyImportMigrationRunId",
+                        column: x => x.LegacyImportMigrationRunId,
+                        principalTable: "LegacyImportMigrationRun",
+                        principalColumn: "LegacyImportMigrationRunId",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LegacyImportNotificationLogMessage_LegacyImportMigrationRunId",
+                table: "LegacyImportNotificationLogMessage",
+                column: "LegacyImportMigrationRunId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LegacyImportNotificationOutcome_LegacyImportMigrationRunId",
+                table: "LegacyImportNotificationOutcome",
+                column: "LegacyImportMigrationRunId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LegacyImportNotificationLogMessage");
+
+            migrationBuilder.DropTable(
+                name: "LegacyImportNotificationOutcome");
+
+            migrationBuilder.DropTable(
+                name: "LegacyImportMigrationRun");
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/Alerts/LegacyImportNotificationOutcome.cs
+++ b/ntbs-service/Models/Entities/Alerts/LegacyImportNotificationOutcome.cs
@@ -1,0 +1,12 @@
+﻿namespace ntbs_service.Models.Entities.Alerts
+{
+    public class LegacyImportNotificationOutcome
+    {
+        public int LegacyImportNotificationOutcomeId { get; set; }
+        public int LegacyImportMigrationRunId { get; set; }
+        public string OldNotificationId { get; set; }
+        public int? NtbsId { get; set; }
+        public bool? SuccessfullyMigrated { get; set; }
+        public string Notes { get; set; }
+    }
+}

--- a/ntbs-service/Models/Entities/LegacyImportMigrationRun.cs
+++ b/ntbs-service/Models/Entities/LegacyImportMigrationRun.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using ntbs_service.Models.Entities.Alerts;
+
+namespace ntbs_service.Models.Entities
+{
+    public class LegacyImportMigrationRun
+    {
+        public int LegacyImportMigrationRunId { get; set; }
+        public DateTime StartTime { get; set; }
+        public string AppRelease { get; set; }
+        public string FileName { get; set; }
+        public string Description { get; set; }
+        public string LegacyIdList { get; set; }
+        public DateTime? RangeStartDate { get; set; }
+        public DateTime? RangeEndDate { get; set; }
+
+        public virtual ICollection<LegacyImportNotificationOutcome> LegacyImportNotificationOutcomes { get; set; }
+        public virtual ICollection<LegacyImportNotificationLogMessage> LegacyImportNotificationLogMessages { get; set; }
+    }
+}

--- a/ntbs-service/Models/Entities/LegacyImportNotificationLogMessage.cs
+++ b/ntbs-service/Models/Entities/LegacyImportNotificationLogMessage.cs
@@ -1,0 +1,13 @@
+﻿using ntbs_service.Models.Enums;
+
+namespace ntbs_service.Models.Entities
+{
+    public class LegacyImportNotificationLogMessage
+    {
+        public int LegacyImportNotificationLogMessageId { get; set; }
+        public int LegacyImportMigrationRunId { get; set; }
+        public string OldNotificationId { get; set; }
+        public LogMessageLevel LogMessageLevel { get; set; }
+        public string Message { get; set; }
+    }
+}

--- a/ntbs-service/Models/Enums/LogMessageLevel.cs
+++ b/ntbs-service/Models/Enums/LogMessageLevel.cs
@@ -1,0 +1,8 @@
+﻿namespace ntbs_service.Models.Enums
+{
+    public enum LogMessageLevel
+    {
+        Warning,
+        Error
+    }
+}

--- a/ntbs-service/Pages/Admin/Migration.cshtml
+++ b/ntbs-service/Pages/Admin/Migration.cshtml
@@ -14,15 +14,17 @@
         @if (Model.Triggered)
         {
             <nhs-inset-text>
-                Job triggered successfully - see the
-                <a href="/Hangfire">Hangfire dashboard</a>
-                to track the created jobs
+                Job triggered successfully with migration run ID @Model.RunId.
+                See the <a href="/Hangfire">Hangfire dashboard</a>
+                to track the created jobs.
             </nhs-inset-text>
         }
 
-        <label nhs-label-type="Standard" asp-for="NotificationIds">Notification Ids</label>
-        <nhs-hint nhs-hint-type="Standard">Enter ids here, or upload a of ids with a single id per line</nhs-hint>
-        <input nhs-input-type="Standard" asp-for="NotificationIds">
+        <label nhs-label-type="Standard" asp-for="NotificationIds">Notification IDs</label>
+        <nhs-hint nhs-hint-type="Standard" id="notificationIds-hint">
+            Enter IDs here, or upload a of ids with a single ID per line
+        </nhs-hint>
+        <input nhs-input-type="Standard" asp-for="NotificationIds" aria-describedby="notificationIds-hint">
         <br/>
 
         <div>
@@ -111,7 +113,14 @@
                 </nhs-form-group>
             </date-input>
         </nhs-fieldset>
+        <br/>
 
+        <label nhs-label-type="Standard" asp-for="Description">Description</label>
+        <nhs-hint nhs-hint-type="Standard" id="description-hint">A description of this import run</nhs-hint>
+        <textarea nhs-textarea-type="Standard" asp-for="Description" rows="5" aria-describedby="description-hint">
+        </textarea>
+
+        <br/>
         <div>
             <button nhs-button-type="Standard" type="submit" value="Import" classes="ntbsuk-button--primary submit-search-button" id="search-button">
                 Import

--- a/ntbs-service/Pages/Admin/Migration.cshtml.cs
+++ b/ntbs-service/Pages/Admin/Migration.cshtml.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Hangfire;
-using Hangfire.Server;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -22,10 +21,13 @@ namespace ntbs_service.Pages.Admin
     public class MigrationModel : PageModel
     {
         private readonly MigrationConfig _config;
+        private readonly INotificationImportRepository _notificationImportRepository;
 
-        public MigrationModel(IOptions<MigrationConfig> config)
+        public MigrationModel(IOptions<MigrationConfig> config,
+            INotificationImportRepository notificationImportRepository)
         {
             _config = config.Value;
+            _notificationImportRepository = notificationImportRepository;
             ValidationService = new ValidationService(this);
         }
 
@@ -44,10 +46,13 @@ namespace ntbs_service.Pages.Admin
         [Display(Name = "End Notification Date")]
         public PartialDate NotificationDateRangeEnd { get; set; }
 
+        [BindProperty]
+        public string Description { get; set; }
+
         public bool Triggered { get; private set; }
         public ValidationService ValidationService { get; }
 
-        private string RequestId => HttpContext.TraceIdentifier;
+        public int RunId { get; private set; }
 
 
         public IActionResult OnGetAsync()
@@ -64,7 +69,7 @@ namespace ntbs_service.Pages.Admin
 
             if (NotificationIds != null)
             {
-                TriggerImportFromIdsField();
+                await TriggerImportFromIdsField();
             }
             else if (UploadedFile != null)
             {
@@ -72,7 +77,7 @@ namespace ntbs_service.Pages.Admin
             }
             else if (NotificationDateRangeStart != null)
             {
-                TriggerImportFromDateRange();
+                await TriggerImportFromDateRange();
             }
 
             Triggered = true;
@@ -80,28 +85,37 @@ namespace ntbs_service.Pages.Admin
             return Page();
         }
 
-        private void TriggerImportFromIdsField()
+        private async Task TriggerImportFromIdsField()
         {
             var legacyIds = NotificationIds.Split(',').Select(id => id.Trim()).ToList();
+            var migrationRun =
+                await _notificationImportRepository.CreateLegacyImportMigrationRun(legacyIds, description: Description);
+            RunId = migrationRun.LegacyImportMigrationRunId;
+
             foreach (var idBatch in SplitList(legacyIds))
             {
                 BackgroundJob.Enqueue<INotificationImportService>(x =>
-                    x.BulkImportByLegacyIdsAsync(null, RequestId, idBatch));
+                    x.BulkImportByLegacyIdsAsync(null, RunId, idBatch));
             }
         }
 
         private async Task TriggerImportFromIdsFile()
         {
             var notificationIds = await GetIdListFromFile(UploadedFile);
+            var migrationRun = await _notificationImportRepository.CreateLegacyImportMigrationRun(
+                notificationIds,
+                UploadedFile.FileName,
+                Description);
+            RunId = migrationRun.LegacyImportMigrationRunId;
 
             foreach (var idBatch in SplitList(notificationIds))
             {
                 BackgroundJob.Enqueue<INotificationImportService>(x =>
-                    x.BulkImportByLegacyIdsAsync(null, RequestId, idBatch));
+                    x.BulkImportByLegacyIdsAsync(null, RunId, idBatch));
             }
         }
 
-        private void TriggerImportFromDateRange()
+        private async Task TriggerImportFromDateRange()
         {
             NotificationDateRangeStart.TryConvertToDateTimeRange(out var notificationDateRangeStart, out _);
             NotificationDateRangeEnd.TryConvertToDateTimeRange(out var notificationDateRangeEnd, out _);
@@ -110,9 +124,15 @@ namespace ntbs_service.Pages.Admin
                 throw new ArgumentException("Could not parse the start date");
             }
 
+            var rangeStart = notificationDateRangeStart.Value;
+
             var rangeEnd = notificationDateRangeEnd ?? DateTime.Now.AddDays(1);
 
-            for (var batchStart = (DateTime)notificationDateRangeStart;
+            var migrationRun =
+                await _notificationImportRepository.CreateLegacyImportMigrationRun(rangeStart, rangeEnd, Description);
+            RunId = migrationRun.LegacyImportMigrationRunId;
+
+            for (var batchStart = rangeStart;
                 batchStart < rangeEnd;
                 batchStart = batchStart.AddDays(_config.DateRangeJobIntervalInDays))
             {
@@ -124,7 +144,7 @@ namespace ntbs_service.Pages.Admin
                 }
 
                 BackgroundJob.Enqueue<INotificationImportService>(x =>
-                    x.BulkImportByDateAsync(null, RequestId, start, end));
+                    x.BulkImportByDateAsync(null, RunId, start, end));
             }
         }
 

--- a/ntbs-service/Pages/LegacyNotifications/Index.cshtml
+++ b/ntbs-service/Pages/LegacyNotifications/Index.cshtml
@@ -9,7 +9,7 @@
 }
 
 <nhs-width-container container-width="Standard">
-    
+
     @if (Model.LegacyImportResult == null)
     {
         <div class="ondemand-migration-description-container">
@@ -37,9 +37,12 @@
                 }
             }
         </nhs-error-summary>
-        
+
         <p class="legacy-notification-instructions">What next?</p>
-        <span>Please contact ntbs@phe.gov.uk quoting Legacy notification: @Model.LegacyNotificationId and reference ID: @Model.RequestId </span>
+        <span>
+            Please contact ntbs@phe.gov.uk quoting Legacy notification: @Model.LegacyNotificationId and migration run
+            reference ID: @Model.RunId
+        </span>
     }
-        
+
 </nhs-width-container>


### PR DESCRIPTION
## Description
* Add tables to track the results of a legacy migration import batch. Add:
    * `LegacyImportBatchGroup`: metadata about a migration import run, which may be broken up into multiple batches.
    * `LegacyImportBatch`: metadata about the batch importing a subset of the notifications
    * `LegacyImportNotificationLogMessage`: warning and error messages for a specific notification during a batch.
    * `LegacyImportNotificationOutcome`: tracking success or failure when migrating a notification during a batch.
* Write import logs out to database:
    * Refactor `ImportLogger` to collect notification IDs, and write messages about a notification or group out to the new `LegacyImportBatch` tables.
    * Refactor services that call this logger to support this change, primarily to make sure notification IDs are passed to the logger and to change from `requestId` `string`s to `batchId` `int`s. Tweak several tests to support this as well.
    * At the start of a notification import batch, the `NotificationImportService` now creates a batch record to track it.
    * Add various methods to `NotificationImportRepository` to write all of this metadata and logs out.
    * Create `LegacyImportBatchGroup` records when triggering a migration from the front end, writing out relevant details such as the range being requested for migration and file names.
* Fix notification import concurrency bug: import notification groups sequentially in a batch, instead of in parallel where multiple threads were hitting the `NtbsContext`, which is a bad idea for EF Contexts (it should be one context per thread).

## Checklist:
- [x] Automated tests are passing locally.
- [ ] Sanity checked new EF-generated queries for performance.
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [x] EF migrations created and committed. Snapshot committed
- [x] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Specimen matching database DACPAC updated
- [x] Reporting database ingestion considered (uspGenerateReusableNotification)