### PR TITLE
NTBS-2347 Use Graph Client pagination during UserSync

### DIFF
--- a/ntbs-service/Services/AdDirectoryService.cs
+++ b/ntbs-service/Services/AdDirectoryService.cs
@@ -22,7 +22,7 @@ namespace ntbs_service.Services
         ///     - user is an NTBS user object populated with data found in the external directory
         ///     - tbServicesMatchingGroups are TbService objects that correspond to user's memberships as case manager
         /// </returns>
-        IEnumerable<(User user, List<TBService> tbServicesMatchingGroups)> LookupUsers(IList<TBService> tbServices);
+        IList<(User user, IList<TBService> tbServicesMatchingGroups)> LookupUsers(IList<TBService> tbServices);
     }
 
     public class AdDirectoryService : IAdDirectoryService
@@ -66,7 +66,7 @@ namespace ntbs_service.Services
             _connection?.Dispose();
         }
 
-        public IEnumerable<(User user, List<TBService> tbServicesMatchingGroups)> LookupUsers(
+        public IList<(User user, IList<TBService> tbServicesMatchingGroups)> LookupUsers(
             IList<TBService> tbServices)
         {
             return GetAllDirectoryEntries()
@@ -86,7 +86,7 @@ namespace ntbs_service.Services
                 false,
                 new LdapSearchConstraints { ReferralFollowing = true });
 
-            // We don't want to use LdapSearchResults directly as Enumerable, since it can throw on `Next` 
+            // We don't want to use LdapSearchResults directly as Enumerable, since it can throw on `Next`
             while (searchResults.HasMore())
             {
                 var nextResult = searchResults.Next();
@@ -128,7 +128,7 @@ namespace ntbs_service.Services
                 : $"CN={baseUserGroup},CN=Users,{_settings.BaseDomain}";
         }
 
-        private static (User user, List<TBService> tbServicesMatchingGroups) BuildUser(
+        private static (User user, IList<TBService> tbServicesMatchingGroups) BuildUser(
             LdapEntry searchResult, IList<TBService> tbServices)
         {
             // TODO NTBS-1672 consider storing user guid as the key
@@ -154,7 +154,7 @@ namespace ntbs_service.Services
 
         // Example of the distinguished name format:
         // "CN=Global.NIS.NTBS.Service_Nottingham,CN=Users,DC=ntbs,DC=phe,DC=com"
-        // We are interested in the group names, e.g. Global.NIS.NTBS.Service_Nottingham 
+        // We are interested in the group names, e.g. Global.NIS.NTBS.Service_Nottingham
         private static readonly Regex DistinguishedNameRegex = new Regex("(CN=)(Global.NIS.NTBS[^,]+)(,.*)");
 
         private static List<string> GetAdGroups(IEnumerator distinguishedNames)

--- a/ntbs-service/Services/AdImportService.cs
+++ b/ntbs-service/Services/AdImportService.cs
@@ -30,7 +30,7 @@ namespace ntbs_service.Services
             var tbServices = await _referenceDataRepository.GetAllTbServicesAsync();
             using (var adDirectoryService = _adDirectoryServiceFactory.Create())
             {
-                var usersInAd = adDirectoryService.LookupUsers(tbServices).ToList();
+                var usersInAd = adDirectoryService.LookupUsers(tbServices);
                 await _adUserService.AddAndUpdateUsers(usersInAd);
             }
         }

--- a/ntbs-service/Services/AdUserService.cs
+++ b/ntbs-service/Services/AdUserService.cs
@@ -10,25 +10,25 @@ namespace ntbs_service.Services
 {
     public interface IAdUserService
     {
-        Task AddAndUpdateUsers(List<(User user, List<TBService>)> usersInAd);
+        Task AddAndUpdateUsers(IList<(User user, IList<TBService>)> usersInAd);
     }
     public class AdUserService : IAdUserService
     {
         private readonly IUserRepository _userRepository;
-        
+
         public AdUserService(IUserRepository userRepository)
         {
             _userRepository = userRepository;
         }
 
-        public async Task AddAndUpdateUsers(List<(User user, List<TBService>)> usersInAd)
+        public async Task AddAndUpdateUsers(IList<(User user, IList<TBService>)> usersInAd)
         {
             foreach (var (user, tbServicesMatchingGroups) in usersInAd)
             {
                 Log.Information($"Updating user {user.Username}");
                 await _userRepository.AddOrUpdateUser(user, tbServicesMatchingGroups);
             }
-                
+
             var ntbsUsersNotInAd = this._userRepository.GetUserQueryable()
                 .Where(user => !usersInAd.Select(u => u.user.Username)
                     .Contains(user.Username)).ToList();

--- a/ntbs-service/Services/AzureAdDirectoryService.cs
+++ b/ntbs-service/Services/AzureAdDirectoryService.cs
@@ -7,10 +7,11 @@ using Microsoft.Graph;
 using ntbs_service.Helpers;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Properties;
+using Serilog;
 
 namespace ntbs_service.Services
 {
-    public interface IAzureAdDirectoryService : IDisposable
+    public interface IAzureAdDirectoryService
     {
         /// <summary>
         /// Returns NTBS users found in Azure Active Directory directory
@@ -20,7 +21,8 @@ namespace ntbs_service.Services
         ///     - user is an NTBS user object populated with data found in Azure Active Directory
         ///     - tbServicesMatchingGroups are TbService objects that correspond to user's memberships as case manager
         /// </returns>
-        Task<IEnumerable<(Models.Entities.User user, List<TBService> tbServicesMatchingGroups)>> LookupUsers(IList<TBService> tbServices);
+        Task<IList<(Models.Entities.User user, IList<TBService> tbServicesMatchingGroups)>>
+            LookupUsers(IList<TBService> tbServices);
 
         Task<IList<Claim>> BuildRoleClaimsForUser(string userPrincipalName);
     }
@@ -38,25 +40,24 @@ namespace ntbs_service.Services
             _adOptions = adOptions;
         }
 
-        public void Dispose()
+        public async Task<IList<(Models.Entities.User user, IList<TBService> tbServicesMatchingGroups)>>
+            LookupUsers(IList<TBService> tbServices)
         {
-
-        }
-
-        public async Task<IEnumerable<(Models.Entities.User user, List<TBService> tbServicesMatchingGroups)>> LookupUsers(IList<TBService> tbServices)
-        {
-            IList<(Models.Entities.User user, List<TBService> tbServicesMatchingGroups)> userWithTbServiceGroups = new List<(Models.Entities.User user, List<TBService> tbServicesMatchingGroups)>();
+            var userWithTbServiceGroups =
+                new List<(Models.Entities.User user, IList<TBService> tbServicesMatchingGroups)>();
             var graphUsers = await GetAllDirectoryEntries();
 
-            // ensure that users are unique
-            graphUsers = graphUsers.GroupBy(u => u.UserPrincipalName).Select(u => u.FirstOrDefault());
+            // Ensure that users are unique
+            var uniqueUsers = graphUsers
+                .GroupBy(user => user.UserPrincipalName)
+                .Select(grouping => grouping.First());
 
-            foreach (var user in graphUsers)
+            var newUsers = await Task.WhenAll(uniqueUsers.Select(async user =>
             {
                 var groupNames = await BuildGroups(user);
-                var buildUserResult = BuildUser(user, tbServices, groupNames);
-                userWithTbServiceGroups.Add(buildUserResult);
-            }
+                return BuildUser(user, tbServices, groupNames);
+            }));
+            userWithTbServiceGroups.AddRange(newUsers);
 
             return userWithTbServiceGroups;
         }
@@ -65,236 +66,152 @@ namespace ntbs_service.Services
         {
             var roleClaims = new List<Claim>();
 
-            try
+            var foundUsers = await _graphServiceClient
+                .Users
+                .Request()
+                .Filter($"UserPrincipalName eq '{userPrincipalName}' or Mail eq '{userPrincipalName}'")
+                .GetAsync();
+            var foundUser = foundUsers.FirstOrDefault();
+
+            if (foundUser == null)
             {
-                var foundUsers = await _graphServiceClient.Users
-                    .Request()
-                    .Filter($"UserPrincipalName eq '{userPrincipalName}' or Mail eq '{userPrincipalName}'")
-                    .GetAsync();
-
-                var foundUser = foundUsers.FirstOrDefault();
-                if (foundUser != null)
-                {
-                    // get groups for user.
-                    var memberOfGroups = await _graphServiceClient
-                        .Users[foundUser.Id]
-                        .TransitiveMemberOf
-                        .Request()
-                        .Top(999)
-                        .GetAsync();
-
-                    foreach (var groupInfo in memberOfGroups)
-                    {
-                        var groupName = await ResolveGroupNameFromId(groupInfo.Id);
-                        // ensure we do not add any duplicate groups or blank groups
-                        if (!string.IsNullOrEmpty(groupName) && IsGroupAnNtbsGroup(groupName) && !roleClaims.Any(group => group.Value.Equals(groupName, StringComparison.CurrentCultureIgnoreCase)))
-                        {
-                            var groupNameClaim = new Claim(ClaimTypes.Role, groupName);
-                            roleClaims.Add(groupNameClaim);
-                        }
-                    }
-                }
+                return roleClaims;
             }
-            catch (Exception)
-            {
 
+            // Get groups for user
+            var groupsAndDirectoryRolesRequest = _graphServiceClient
+                .Users[foundUser.Id]
+                .TransitiveMemberOf
+                .Request();
+
+            while (groupsAndDirectoryRolesRequest != null)
+            {
+                var groupsAndDirectoryRoles = await groupsAndDirectoryRolesRequest.GetAsync();
+
+                var currentRoleClaimNames = roleClaims.Select(claim => claim.Value);
+                var newRoleClaims = groupsAndDirectoryRoles
+                    .OfType<Microsoft.Graph.Group>()
+                    .Select(group => group.DisplayName)
+                    .Where(groupName => IsGroupNameValidAndUnique(groupName, currentRoleClaimNames))
+                    .Select(groupName => new Claim(ClaimTypes.Role, groupName));
+                roleClaims.AddRange(newRoleClaims);
+
+                groupsAndDirectoryRolesRequest = groupsAndDirectoryRoles.NextPageRequest;
             }
 
             return roleClaims;
         }
 
-        private async Task<string> ResolveGroupNameFromId(string id)
+        private async Task<IList<Microsoft.Graph.User>> GetAllDirectoryEntries()
         {
-
-            if (string.IsNullOrEmpty(id))
-            {
-                throw new ArgumentNullException(nameof(id));
-            }
-
-            var groupName = "";
-
-            try
-            {
-                var result = await _graphServiceClient.Groups[id]
-                    .Request()
-                    .GetAsync();
-
-                if (result != null)
-                {
-                    groupName = result.DisplayName;
-                }
-
-
-            }
-            catch (Exception)
-            {
-                // ignore exception
-            }
-
-            return groupName;
-        }
-
-        private async Task<IEnumerable<Microsoft.Graph.User>> GetAllDirectoryEntries()
-        {
-            var listOfDirectoryEntries = new List<Microsoft.Graph.User>();
+            var directoryEntries = new List<Microsoft.Graph.User>();
 
             var baseGroups = await _graphServiceClient
-            .Groups
-            .Request()
-            .Filter($"displayName eq '{_adOptions.BaseUserGroup}'")
-            .Select("id, displayName, description")
-            .Top(1)
-            .GetAsync();
+                .Groups
+                .Request()
+                .Filter($"displayName eq '{_adOptions.BaseUserGroup}'")
+                .Select("id, displayName, description")
+                .Top(1)
+                .GetAsync();
 
             var baseGroup = baseGroups.FirstOrDefault(g => g.DisplayName == _adOptions.BaseUserGroup);
 
-            if (baseGroup != null)
+            if (baseGroup == null)
             {
-                var usersInRootGroup = await GetUsersInGroup(baseGroup.Id);
-                listOfDirectoryEntries.AddRange(usersInRootGroup);
-
-                var groupMembersRequest = _graphServiceClient.Groups[baseGroup.Id].Members.Request();
-                while (groupMembersRequest != null)
-                {
-                    var groupMembers = await groupMembersRequest.GetAsync();
-
-                    if (groupMembers != null)
-                    {
-                        // get users from root group
-                        foreach (var groupMember in groupMembers)
-                        {
-                            try
-                            {
-                                switch (groupMember.ODataType)
-                                {
-                                    case "#microsoft.graph.group":
-                                        var usersInGroup = await GetUsersInGroup(groupMember.Id);
-                                        listOfDirectoryEntries.AddRange(usersInGroup);
-                                        break;
-                                    default:
-                                        break;
-                                }
-                            }
-                            catch (Exception)
-                            {
-                                // ignore
-                            }
-                        }
-
-                        groupMembersRequest = groupMembers.NextPageRequest;
-                    }
-                    else
-                    {
-                        groupMembersRequest = null;
-                    }
-                }
+                Log.Error($"Could not find base group {_adOptions.BaseUserGroup} in Azure AD");
+                return directoryEntries;
             }
 
-            return listOfDirectoryEntries.ToArray();
+            var usersInRootGroup = await GetUsersInGroup(baseGroup.Id);
+            directoryEntries.AddRange(usersInRootGroup);
+
+            var groupMembersRequest = _graphServiceClient
+                .Groups[baseGroup.Id]
+                .Members
+                .Request();
+
+            // The request is paginated, so iterate over each page
+            while (groupMembersRequest != null)
+            {
+                var groupMembers = await groupMembersRequest.GetAsync();
+
+                var newDirectoryEntries = (await Task.WhenAll(
+                    groupMembers
+                        .OfType<Microsoft.Graph.Group>()
+                        .Select(group => GetUsersInGroup(group.Id)))
+                    ).SelectMany(entry => entry);
+                directoryEntries.AddRange(newDirectoryEntries);
+
+                groupMembersRequest = groupMembers.NextPageRequest;
+            }
+
+            return directoryEntries;
         }
 
-        private async Task<IEnumerable<Microsoft.Graph.User>> GetUsersInGroup(string groupId)
+        private async Task<IList<Microsoft.Graph.User>> GetUsersInGroup(string groupId)
         {
             var listOfUsers = new List<Microsoft.Graph.User>();
 
-            try
+            var groupMembersRequest = _graphServiceClient
+                .Groups[groupId]
+                .Members
+                .Request()
+                .Select("id, displayName");
+
+            while (groupMembersRequest != null)
             {
-                var groupMembersRequest = _graphServiceClient
-                    .Groups[groupId]
-                    .Members
+                var groupMembers = await groupMembersRequest.GetAsync();
+
+                var graphUsers = groupMembers
+                    .OfType<Microsoft.Graph.User>()
+                    .Select(user => _graphServiceClient.Users[user.Id]
                     .Request()
-                    .Select("id, displayName");
+                    .Select("accountenabled, id, displayName, givenName, surname, userPrincipalName, mail")
+                    .GetAsync());
+                listOfUsers.AddRange(await Task.WhenAll(graphUsers));
 
-                while (groupMembersRequest != null)
-                {
-                    var groupMembers = await groupMembersRequest.GetAsync();
-
-                    if (groupMembers != null)
-                    {
-                        foreach (var groupMember in groupMembers)
-                        {
-                            try
-                            {
-                                switch (groupMember.ODataType)
-                                {
-                                    case "#microsoft.graph.user":
-                                        var graphUser = await _graphServiceClient.Users[groupMember.Id]
-                                        .Request()
-                                        .Select("accountenabled, id, displayName, givenName, surname, userPrincipalName, mail")
-                                        .GetAsync();
-                                        listOfUsers.Add(graphUser);
-                                        break;
-                                    default:
-
-                                        break;
-                                }
-                            }
-                            catch (Exception)
-                            {
-                                // ignore
-                            }
-                        }
-
-                        groupMembersRequest = groupMembers.NextPageRequest;
-                    }
-                    else
-                    {
-                        groupMembersRequest = null;
-                    }
-                }
-
-            }
-            catch (Exception)
-            {
-                // ignore
+                groupMembersRequest = groupMembers.NextPageRequest;
             }
 
-            return listOfUsers.ToArray();
+            return listOfUsers;
         }
 
-        private bool IsUserExternal(Microsoft.Graph.User user)
-        {
-            return user.UserPrincipalName.Contains("#EXT#");
-        }
-
-        private bool IsGroupAnNtbsGroup(string groupName)
-        {
-            return groupName.StartsWith(_adOptions.BaseUserGroup);
-        }
-
-        private async Task<IEnumerable<string>> BuildGroups(Microsoft.Graph.User graphUser)
+        private async Task<IList<string>> BuildGroups(Microsoft.Graph.User graphUser)
         {
             var groupNames = new List<string>();
 
-            var groupIdsRequest = _graphServiceClient
+            var groupsAndDirectoryRolesRequest = _graphServiceClient
                 .Users[graphUser.Id]
                 .MemberOf
                 .Request()
                 .Select("id, displayName");
 
-            while (groupIdsRequest != null)
+            while (groupsAndDirectoryRolesRequest != null)
             {
-                var groupIds = await groupIdsRequest.GetAsync();
+                var groupsAndDirectoryRoles = await groupsAndDirectoryRolesRequest.GetAsync();
 
-                foreach (var groupInfo in groupIds)
-                {
-                    var groupName = await ResolveGroupNameFromId(groupInfo.Id);
-                    // ensure we do not add any duplicate groups or blank groups
-                    if (!string.IsNullOrEmpty(groupName) && IsGroupAnNtbsGroup(groupName) && !groupNames.Any(group => group.Equals(groupName, StringComparison.CurrentCultureIgnoreCase)))
-                    {
-                        groupNames.Add(groupName);
-                    }
-                }
+                var newGroupNames = groupsAndDirectoryRoles
+                    .OfType<Microsoft.Graph.Group>()
+                    .Select(group => group.DisplayName)
+                    .Where(groupName => IsGroupNameValidAndUnique(groupName, groupNames));
+                groupNames.AddRange(newGroupNames);
 
-                groupIdsRequest = groupIds.NextPageRequest;
+                groupsAndDirectoryRolesRequest = groupsAndDirectoryRoles.NextPageRequest;
             }
 
             return groupNames;
         }
 
-        private (Models.Entities.User user, List<TBService> tbServicesMatchingGroups) BuildUser(
+        private bool IsGroupNameValidAndUnique(string groupName, IEnumerable<string> groupNames)
+        {
+            return !string.IsNullOrEmpty(groupName)
+                   && groupName.StartsWith(_adOptions.BaseUserGroup)
+                   && !groupNames.Any(group => group.Equals(groupName, StringComparison.CurrentCultureIgnoreCase));
+        }
+
+        private (Models.Entities.User user, IList<TBService> tbServicesMatchingGroups) BuildUser(
             Microsoft.Graph.User graphUser,
-            IList<TBService> tbServices,
+            IEnumerable<TBService> tbServices,
             IEnumerable<string> groupNames)
         {
 
@@ -324,6 +241,11 @@ namespace ntbs_service.Services
             };
 
             return (user, tbServicesMatchingGroups);
+        }
+
+        private static bool IsUserExternal(Microsoft.Graph.User user)
+        {
+            return user.UserPrincipalName.Contains("#EXT#");
         }
     }
 }

--- a/ntbs-service/Services/AzureAdDirectoryServiceFactory.cs
+++ b/ntbs-service/Services/AzureAdDirectoryServiceFactory.cs
@@ -28,14 +28,13 @@ namespace ntbs_service.Services
         public IAzureAdDirectoryService Create()
         {
             var clientApplication = ConfidentialClientApplicationBuilder
-            .Create(_azureAdSettings.ClientId)
-            .WithAuthority(_azureAdSettings.Authority)
-            .WithClientSecret(_azureAdSettings.ClientSecret)
-            .Build();
+                .Create(_azureAdSettings.ClientId)
+                .WithAuthority(_azureAdSettings.Authority)
+                .WithClientSecret(_azureAdSettings.ClientSecret)
+                .Build();
 
-            var scopes = "https://graph.microsoft.com/.default";
+            const string scopes = "https://graph.microsoft.com/.default";
             var authProvider = new ClientCredentialProvider(clientApplication, scopes);
-
 
             _graphServiceClient = new GraphServiceClient(authProvider);
             return new AzureAdDirectoryService(_graphServiceClient, _adSettings);

--- a/ntbs-service/Services/AzureAdImportService.cs
+++ b/ntbs-service/Services/AzureAdImportService.cs
@@ -1,10 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using ntbs_service.DataAccess;
-using ntbs_service.Models.ReferenceEntities;
-using Serilog;
-using User = Sentry.User;
 
 namespace ntbs_service.Services
 {
@@ -26,11 +21,10 @@ namespace ntbs_service.Services
         public async Task RunCaseManagerImportAsync()
         {
             var tbServices = await _referenceDataRepository.GetAllTbServicesAsync();
-            using (var azureAdDirectoryService = _azureAdDirectoryServiceFactory.Create())
-            {
-                var usersInAd = (await azureAdDirectoryService.LookupUsers(tbServices)).ToList();
-                await _adUserService.AddAndUpdateUsers(usersInAd);
-            }
+            var azureAdDirectoryService = _azureAdDirectoryServiceFactory.Create();
+
+            var usersInAd = (await azureAdDirectoryService.LookupUsers(tbServices));
+            await _adUserService.AddAndUpdateUsers(usersInAd);
         }
     }
 }


### PR DESCRIPTION
## Description
We were having issues running `UserSync` because there were too many different groups under the BaseUserGroup. This is because the request returns the results in pages of 100 results, and there were ~250 results, so ~60% of the groups were being ignored.

By using `NextPageRequest` we can read all of the pages in sequence.

Also, tidy up some of the graph client queries, such as the base group query to use an equality check on `displayname` instead of a weird prefix and filter search.

## Checklist:
- [x] Automated tests are passing locally.