### PR TITLE
NTBS-2317 Fix validation for treatment outcome notes

### DIFF
--- a/ntbs-service/Models/Entities/TreatmentEvent.cs
+++ b/ntbs-service/Models/Entities/TreatmentEvent.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.Models.Entities
         public int? TreatmentOutcomeId { get; set; }
         public virtual TreatmentOutcome TreatmentOutcome { get; set; }
 
-        [MaxLength(150)]
+        [MaxLength(1000)]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashAndNewLine,
             ErrorMessage = ValidationMessages.StringWithNumbersAndForwardSlashFormat)]


### PR DESCRIPTION
## Description
We recently expanded the treatment outcome notes width in the DB due to changes in the migration DB. Expand the width of the field in validation as well.

## Checklist:
- [x] Automated tests are passing locally.