### PR TITLE
NTBS-2322 Notification import concurrency fix

### DIFF
--- a/EFAuditer-tests/EFAuditer-tests.csproj
+++ b/EFAuditer-tests/EFAuditer-tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/EFAuditer/EFAuditer.csproj
+++ b/EFAuditer/EFAuditer.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="17.0.4" />
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">

--- a/coming-soon/coming-soon.csproj
+++ b/coming-soon/coming-soon.csproj
@@ -52,4 +52,9 @@
     </Content>
   </ItemGroup>
 
+
+  <ItemGroup>
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/load-test-data-generation/load-test-data-generation.csproj
+++ b/load-test-data-generation/load-test-data-generation.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="33.0.2" />
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
   </ItemGroup>
 

--- a/ntbs-bulk-insert/ntbs-bulk-insert.csproj
+++ b/ntbs-bulk-insert/ntbs-bulk-insert.csproj
@@ -14,6 +14,7 @@
     <ItemGroup>
       <PackageReference Include="EFCore.BulkExtensions" Version="5.1.6" />
       <PackageReference Include="Faker.Net" Version="1.5.136" />
+      <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
       <PackageReference Include="NBuilder" Version="6.1.0" />
       <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />

--- a/ntbs-integration-tests/ntbs-integration-tests.csproj
+++ b/ntbs-integration-tests/ntbs-integration-tests.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.15.0" />
     <PackageReference Include="Audit.EntityFramework.Core" Version="17.0.4" />
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />

--- a/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/EnhancedSurveillanceAlertsServiceTest.cs
@@ -36,7 +36,7 @@ namespace ntbs_service_unit_tests.Services
         [InlineData("NonMDR", true, Status.Unknown, false, true)]
         [InlineData("NonMDR", true, Status.No, false, true)]
         [InlineData("NonMDR", true, Status.Yes, false, true)]
-        public void CreateOrDismissMdrAlert(string drugResistance,
+        public async Task CreateOrDismissMdrAlert(string drugResistance,
             bool isMdrPlanned,
             Status? mdrExposureStatus,
             bool shouldCreateAlert,
@@ -62,7 +62,7 @@ namespace ntbs_service_unit_tests.Services
             };
 
             // Act
-            EnhancedSurveillanceAlertsService.CreateOrDismissMdrAlert(notification);
+            await EnhancedSurveillanceAlertsService.CreateOrDismissMdrAlert(notification);
 
             // Assert
             var numberOfCallsToCreate = shouldCreateAlert ? Times.Once() : Times.Never();

--- a/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
+++ b/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="17.0.4" />
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Hangfire.Core" Version="1.7.22" />
     <PackageReference Include="Hangfire.SqlServer" Version="1.7.22" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.22" />
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Markdig" Version="0.24.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="5.0.5" />

--- a/ntbs-ui-tests/ntbs-ui-tests.csproj
+++ b/ntbs-ui-tests/ntbs-ui-tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="17.0.4" />
+    <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.5" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.5" />


### PR DESCRIPTION
## Description
* A few of the `async` `ImportLogger` methods were not being properly awaited in the `ImportValidator`, leading to multiple threads accessing the `NtbsContext` and thus concurrency bugs. Await them properly now.
* Add `MissingAwaitWarning` analyser; this should catch some of the issues we were having with NTBS-2322.
* Fix minor `async`/`await` issue in a unit test caught be the newly added analyser

## Checklist:
- [x] Automated tests are passing locally.