### PR TITLE
NTBS-2317 Loosen validation for treatment event notes

### DIFF
--- a/ntbs-service/Models/Entities/TreatmentEvent.cs
+++ b/ntbs-service/Models/Entities/TreatmentEvent.cs
@@ -35,8 +35,8 @@ namespace ntbs_service.Models.Entities
 
         [MaxLength(1000)]
         [RegularExpression(
-            ValidationRegexes.CharacterValidationWithNumbersForwardSlashAndNewLine,
-            ErrorMessage = ValidationMessages.StringWithNumbersAndForwardSlashFormat)]
+            ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
+            ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string Note { get; set; }
 
         public int NotificationId { get; set; }


### PR DESCRIPTION
## Description
Allow basic special characters like punctuation in the notes for treatment events, which are imported from the legacy systems.

## Checklist:
- [x] Automated tests are passing locally.