### PR TITLE
NTBS-NONE-UI-TEST-FIX: delete legacy specimens and from new imported notification table

### DIFF
--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -39,9 +39,12 @@ jobs:
           Environments__int__MigrationConnectionString: ${{ secrets.UI_TESTS_INT_MIGRATION_CONNECTION_STRING }}
           Environments__test__MigrationConnectionString: ${{ secrets.UI_TESTS_TEST_MIGRATION_CONNECTION_STRING }}
           Environments__uat__MigrationConnectionString: ${{ secrets.UI_TESTS_UAT_MIGRATION_CONNECTION_STRING }}
-          Environments__int__ImportedNotificationTableName: ${{ secrets.UI_TESTS_INT_IMPORTED_NOTIFICATION_TABLE_NAME }}
-          Environments__test__ImportedNotificationTableName: ${{ secrets.UI_TESTS_TEST_IMPORTED_NOTIFICATION_TABLE_NAME }}
-          Environments__uat__ImportedNotificationTableName: ${{ secrets.UI_TESTS_UAT_IMPORTED_NOTIFICATION_TABLE_NAME }}
+          Environments__int__ImportedNotificationNtbsEnvironment: ${{ secrets.UI_TESTS_INT_IMPORTED_NOTIFICATION_NTBS_ENVIRONMENT }}
+          Environments__test__ImportedNotificationNtbsEnvironment: ${{ secrets.UI_TESTS_TEST_IMPORTED_NOTIFICATION_NTBS_ENVIRONMENT }}
+          Environments__uat__ImportedNotificationNtbsEnvironment: ${{ secrets.UI_TESTS_UAT_IMPORTED_NOTIFICATION_NTBS_ENVIRONMENT }}
+          Environments__int__SpecimenConnectionString: ${{ secrets.UI_TESTS_INT_SPECIMEN_CONNECTION_STRING }}
+          Environments__test__SpecimenConnectionString: ${{ secrets.UI_TESTS_TEST_SPECIMEN_CONNECTION_STRING }}
+          Environments__uat__SpecimenConnectionString: ${{ secrets.UI_TESTS_UAT_SPECIMEN_CONNECTION_STRING }}
         run: |
           sudo selenium-standalone install --drivers.chrome.version=89.0.4389.23
           selenium-standalone start --drivers.chrome.version=89.0.4389.23 > /dev/null 2>&1 &

--- a/ntbs-ui-tests/Features/ImportLegacyNotification.feature
+++ b/ntbs-ui-tests/Features/ImportLegacyNotification.feature
@@ -20,5 +20,5 @@ Feature: Import legacy notification
     And I can see the value Angola for element with id 'banner-country-of-birth'
     And I can see the value 963 657 7830 for element with id 'banner-nhs-number'
     And I can see the value Male for element with id 'banner-sex'
-    And I can see the value No result for element with id 'banner-drug-resistance'
+    And I can see the value Sensitive to first line for element with id 'banner-drug-resistance'
     And I can see the value Complete for element with id 'banner-treatment-outcome'

--- a/ntbs-ui-tests/Hooks/DriverSetup.cs
+++ b/ntbs-ui-tests/Hooks/DriverSetup.cs
@@ -1,4 +1,5 @@
 ﻿using System.Data.SqlClient;
+using System.Linq;
 using System.Threading.Tasks;
 using BoDi;
 using Dapper;
@@ -73,6 +74,13 @@ namespace ntbs_ui_tests.Hooks
 
         private async Task CleanUpMigratedNotification()
         {
+            using (var connection = new SqlConnection(settings.EnvironmentConfig.SpecimenConnectionString))
+            {
+                connection.Open();
+                var deleteSpecimens = "DELETE FROM NotificationSpecimenMatch WHERE ReferenceLaboratoryNumber IN ('M.7148378', 'M.9420326')";
+                await connection.ExecuteAsync(deleteSpecimens);
+                connection.Close();
+            }
             using (var connection = new SqlConnection(settings.EnvironmentConfig.ConnectionString))
             {
                 connection.Open();
@@ -83,7 +91,9 @@ namespace ntbs_ui_tests.Hooks
             using (var connection = new SqlConnection(settings.EnvironmentConfig.MigrationConnectionString))
             {
                 connection.Open();
-                var deleteImportedNotification = $"DELETE FROM {settings.EnvironmentConfig.ImportedNotificationTableName} WHERE LegacyId = '189045'";
+                var deleteImportedNotification =
+                    "DELETE FROM ImportedNotifications WHERE LegacyId = '189045'" +
+                    $"AND NtbsEnvironment LIKE '{settings.EnvironmentConfig.ImportedNotificationNtbsEnvironment}'";
                 await connection.ExecuteAsync(deleteImportedNotification);
             }
         }

--- a/ntbs-ui-tests/Hooks/TestConfig.cs
+++ b/ntbs-ui-tests/Hooks/TestConfig.cs
@@ -34,8 +34,9 @@ namespace ntbs_ui_tests.Hooks
     {
         public string ConnectionString { get; set; }
         public string MigrationConnectionString { get; set; }
-        public string ImportedNotificationTableName { get; set; }
+        public string SpecimenConnectionString { get; set; }
         public string RootUri { get; set; }
+        public string ImportedNotificationNtbsEnvironment { get; set; }
     }
 
     public class UserConfig

--- a/ntbs-ui-tests/testSettings.json
+++ b/ntbs-ui-tests/testSettings.json
@@ -14,7 +14,8 @@
       "RootUri": "https://localhost:5001",
       "ConnectionString": "data source=localhost;initial catalog=ntbsDev;trusted_connection=true;MultipleActiveResultSets=true;",
       "MigrationConnectionString": "data source=localhost;initial catalog=ntbs_migration;trusted_connection=true;MultipleActiveResultSets=true",
-      "ImportedNotificationTableName": "DevImportedNotifications"
+      "SpecimenConnectionString": "data source=localhost;initial catalog=specimen-matching;trusted_connection=true;MultipleActiveResultSets=true",
+      "ImportedNotificationNtbsEnvironment": "Dev"
     },
     "int": {
       "RootUri": "https://ntbs-int.e32846b1ddf0432eb63f.northeurope.aksapp.io"


### PR DESCRIPTION
## Description
Now delete only the record from the imported notifications table with the correct environment. 
Unmatch any specimens that are connected to the imported notification.

## Checklist:
- [x] Automated tests are passing locally.
