### PR TITLE
NTBS-NONE Fix a specimen import result bug

### DIFF
--- a/ntbs-service/DataMigration/Models/ImportResult.cs
+++ b/ntbs-service/DataMigration/Models/ImportResult.cs
@@ -8,7 +8,7 @@ namespace ntbs_service.DataMigration
     {
         public string PatientName { get; set; }
         public Dictionary<string, List<string>> ValidationErrors { get; set; } = new Dictionary<string, List<string>>();
-        public bool IsValid => ValidationErrors.Values.All(x => x == null);
+        public bool IsValid => ValidationErrors.Values.All(errorList => !errorList.Any());
         public Dictionary<string, int> NtbsIds { get; set; } = new Dictionary<string, int>();
 
         public ImportResult(string patientName)
@@ -31,7 +31,7 @@ namespace ntbs_service.DataMigration
 
         public void AddValidNotification(string legacyId)
         {
-            ValidationErrors.Add(legacyId, null);
+            ValidationErrors.Add(legacyId, new List<string>());
         }
 
         public void AddNotificationError(string legacyId, string error)


### PR DESCRIPTION
## Description
When failing to import a specimen, this is noted in the `ImportResult` object. However, because that object will have recently been marked as successful, previously denoted by a `null` error list for that notification, then adding this error to the null list will cause a `NullPointerException`. Instead, we now encode success as an empty list of errors, instead of a `null` list of errors, so this list can be added to after the notification has been imported to track warnings.

## Checklist:
- [x] Automated tests are passing locally.