### PR TITLE
NTBS-2369 Fix bug in mark imported notifications job

### DIFF
--- a/ntbs-service/DataMigration/NotificationImportHelper.cs
+++ b/ntbs-service/DataMigration/NotificationImportHelper.cs
@@ -83,6 +83,7 @@ namespace ntbs_service.DataMigration
 	            WHERE NOT EXISTS (
                     SELECT 1 FROM ImportedNotifications
                     WHERE ImportedNotifications.LegacyId = ntbsNotifications.LegacyId
+                    AND ImportedNotifications.NtbsEnvironment = '{_ntbsEnvironment}'
                 )
         ";
 


### PR DESCRIPTION
Insert imported notification entry when same notification has already been imported in another environment

Tested this locally by hacking around with my local db
