### PR TITLE
Wait until URL has changed for transfer UI tests

### DIFF
--- a/ntbs-ui-tests/Steps/AssertSteps.cs
+++ b/ntbs-ui-tests/Steps/AssertSteps.cs
@@ -6,8 +6,10 @@ using ntbs_service.Models.Validations;
 using ntbs_ui_tests.Helpers;
 using ntbs_ui_tests.Hooks;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
 using TechTalk.SpecFlow;
 using Xunit;
+using ExpectedConditions = SeleniumExtras.WaitHelpers.ExpectedConditions;
 
 namespace ntbs_ui_tests.Steps
 {
@@ -48,9 +50,15 @@ namespace ntbs_ui_tests.Steps
         [Then(@"I should see the Notification")]
         public void ThenIShouldSeeTheNotification()
         {
-            var urlRegex = new Regex(@".*/Notifications/(\d+)/?(#.+)?$");
-            var match = urlRegex.Match(Browser.Url);
-            Assert.True(match.Success, $"Url I am on instead: {Browser.Url}");
+            const string notificationUrlRegex = @".*/Notifications/(\d+)/?(#.+)?$";
+            try
+            {
+                var wait = new WebDriverWait(Browser, Settings.ImplicitWait);
+                wait.Until(ExpectedConditions.UrlMatches(notificationUrlRegex));
+            }
+            catch (WebDriverTimeoutException) {
+                Assert.Matches(notificationUrlRegex, Browser.Url);
+            }
         }
 
         #endregion
@@ -88,7 +96,7 @@ namespace ntbs_ui_tests.Steps
             var warningElement = HtmlElementHelper.FindElementById(Browser, warningId);
             Assert.Contains(warningMessage, warningElement.Text);
         }
-        
+
         #endregion
 
         #region Transfer pages
@@ -106,7 +114,7 @@ namespace ntbs_ui_tests.Steps
             var transferInformationElements = Browser.FindElements(By.ClassName("transfer-request-information"));
             Assert.Contains(transferInformationElements, t => t.Text.Contains(title) && t.Text.Contains(value));
         }
-        
+
         #endregion
 
         #region Notification overview
@@ -202,7 +210,7 @@ namespace ntbs_ui_tests.Steps
             Assert.DoesNotContain(notificationId, TestContext.AddedNotificationIds);
             TestContext.AddedNotificationIds.Add(notificationId);
         }
-        
+
         #endregion
 
         private int GetNotificationIdAndAssertMatchFromUrl()

--- a/ntbs-ui-tests/ntbs-ui-tests.csproj
+++ b/ntbs-ui-tests/ntbs-ui-tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="17.0.5" />
+    <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.6" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.6" />


### PR DESCRIPTION
## Description
Spotted this whilst debugging the package updates

Use a `WebDriverWait` to wait for a URL to change after pressing a `POST` button in the Transfer Notification UI tests, instead of failing if the `POST` doesn't redirect quickly enough.

## Checklist:
- [x] Automated tests are passing locally, including UI tests
- [x] UI tests pass on GitHub ([success](https://github.com/publichealthengland/ntbs_Beta/runs/2726409757))