### PR TITLE
NTBS-2375: Use source from merged notifications for legacy banner source

### DIFF
--- a/ntbs-service/Services/LegacySearchService.cs
+++ b/ntbs-service/Services/LegacySearchService.cs
@@ -136,7 +136,7 @@ namespace ntbs_service.Services
                 NotificationStatus = NotificationStatus.Legacy,
                 NotificationStatusString = "Legacy",
                 NotificationDate = (result.NotificationDate as DateTime?).ConvertToString(),
-                Source = result.Source,
+                Source = result.PrimarySource,
                 Sex = Sexes.Single(s => s.SexId == result.NtbsSexId).Label,
                 SortByDate = result.NotificationDate,
                 Name = result.FamilyName.ToUpper() + ", " + result.GivenName,


### PR DESCRIPTION
## Description
Me and Nancy have no idea why we were using the Source column from the Address table, and there's no mention of why in the original ticket NTBS-263. (I'm guessing it was overlooked as the field is called Source, which is also the name we map to in the banner).

The issue came about as some legacy notification don't have corresponding addresses (about 995 of them).

## Checklist:
- [x] Automated tests are passing locally.
