### PR TITLE
NTBS-2373 Fix manage notification expander colours

### DIFF
--- a/ntbs-service/wwwroot/css/notification.scss
+++ b/ntbs-service/wwwroot/css/notification.scss
@@ -62,8 +62,10 @@
       margin-left: 16px;
       color: black;
       text-decoration: none;
-      // Taken from nhs expander, but with colour swapped for $manage-notification-circle
-      background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='#{url-friendly-colour($manage-notification-circle)}'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+      &:before {
+        // Taken from nhs expander, but with colour swapped for $manage-notification-circle
+        background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__plus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='#{url-friendly-colour($manage-notification-circle)}'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M12 8v8M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
+      }
     }
     .nhsuk-details__text {
       display: flex;
@@ -73,7 +75,7 @@
     }
   }
 
-  .nhsuk-expander[open] .nhsuk-details__summary-text {
+  .nhsuk-expander[open] .nhsuk-details__summary-text &:before {
     // Taken from nhs expander, but with colour swapped for $manage-notification-circle
     background: url("data:image/svg+xml,%3Csvg class='nhsuk-icon nhsuk-icon__minus' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='32' aria-hidden='true'%3E%3Ccircle cx='12' cy='12' r='10' fill='#{url-friendly-colour($manage-notification-circle)}'%3E%3C/circle%3E%3Cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M8 12h8'%3E%3C/path%3E%3C/svg%3E%0A") left -2px center no-repeat;
   }


### PR DESCRIPTION
## Description
A minor bug I spotted during show and tell:

Some changes to the NHS CSS made the expander plus and minus symbols blue again. Tweak our CSS selectors to fix this.

## Checklist:
- [ ] Automated tests are passing locally.

## Screenshots
### Before
![blue_plus](https://user-images.githubusercontent.com/3650110/120511542-688bdb80-c3c2-11eb-952f-49c709f34a5b.png)
![blue_minus](https://user-images.githubusercontent.com/3650110/120511540-688bdb80-c3c2-11eb-91cc-521cc3794d33.png)

### After
![red_plus](https://user-images.githubusercontent.com/3650110/120511538-688bdb80-c3c2-11eb-8f22-9e14a1941fd0.png)
![red_minus](https://user-images.githubusercontent.com/3650110/120511532-67f34500-c3c2-11eb-89ba-19ba169ca444.png)