### PR TITLE
Fix user contact details field lengths

### DIFF
--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -548,11 +548,11 @@ namespace ntbs_service.DataAccess
                 entity.Property(e => e.FamilyName).HasMaxLength(64);
                 entity.Property(e => e.GivenName).HasMaxLength(64);
                 entity.Property(e => e.DisplayName).HasMaxLength(256);
-                entity.Property(e => e.JobTitle).HasMaxLength(50);
+                entity.Property(e => e.JobTitle).HasMaxLength(100);
                 entity.Property(e => e.PhoneNumberPrimary).HasMaxLength(100);
                 entity.Property(e => e.PhoneNumberSecondary).HasMaxLength(100);
                 entity.Property(e => e.EmailPrimary).HasMaxLength(100);
-                entity.Property(e => e.EmailSecondary).HasMaxLength(50);
+                entity.Property(e => e.EmailSecondary).HasMaxLength(100);
                 entity.Property(e => e.Notes).HasMaxLength(500);
 
                 entity.HasIndex(e => e.Username).IsUnique();

--- a/ntbs-service/Migrations/20210603104536_ExpandUserContactDetailsFields.Designer.cs
+++ b/ntbs-service/Migrations/20210603104536_ExpandUserContactDetailsFields.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210603104536_ExpandUserContactDetailsFields")]
+    partial class ExpandUserContactDetailsFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210603104536_ExpandUserContactDetailsFields.cs
+++ b/ntbs-service/Migrations/20210603104536_ExpandUserContactDetailsFields.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class ExpandUserContactDetailsFields : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "JobTitle",
+                table: "User",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmailSecondary",
+                table: "User",
+                type: "nvarchar(100)",
+                maxLength: 100,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "JobTitle",
+                table: "User",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "EmailSecondary",
+                table: "User",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(100)",
+                oldMaxLength: 100,
+                oldNullable: true);
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/User.cs
+++ b/ntbs-service/Models/Entities/User.cs
@@ -16,36 +16,42 @@ namespace ntbs_service.Models.Entities
         public bool IsCaseManager { get; set; }
         public bool IsReadOnly { get; set; }
 
+        [MaxLength(100)]
         [Display(Name = "Job title")]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtended,
             ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string JobTitle { get; set; }
 
+        [MaxLength(100)]
         [Display(Name = "Email #1")]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtended,
             ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string EmailPrimary { get; set; }
 
+        [MaxLength(100)]
         [Display(Name = "Email #2")]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtended,
             ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string EmailSecondary { get; set; }
 
+        [MaxLength(100)]
         [Display(Name = "Phone number #1")]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtended,
             ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string PhoneNumberPrimary { get; set; }
 
+        [MaxLength(100)]
         [Display(Name = "Phone number #2")]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtended,
             ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string PhoneNumberSecondary { get; set; }
 
+        [MaxLength(500)]
         [Display(Name = "Notes")]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,


### PR DESCRIPTION
## Description
* Add validation to User entity to reflect the contact details widths in the database. ASP.NET will then add width limiting HTML and validation
* Extend the `JobTitle` field to 100 characters, and extend the `EmaiSecondary` field to 100 from 50, like `EmailPrimary` at 100.

The ticket also asked for a warning when the user is up to the character limit for that input box. This is not something we have for any of the other width-limited text boxes in `PatientDetails`, `ClinicalDetails`, etc. and looks pretty tricky to implement given our current validation process (we don't really have a notion of a warning, only errors). We could make a follow on tech debt ticket for this, but I suppose it depends on how much we actually want that feature.

## Checklist:
- [x] Automated tests are passing locally.