### PR TITLE
NTBS-2330: Get linked notifications before checking permissions

### DIFF
--- a/ntbs-service/Pages/Notifications/TestResults.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/TestResults.cshtml.cs
@@ -36,7 +36,8 @@ namespace ntbs_service.Pages.Notifications
             {
                 return NotFound();
             }
-            
+
+            await GetLinkedNotificationsAsync();
             await AuthorizeAndSetBannerAsync();
             if (PermissionLevel == PermissionLevel.None)
             {


### PR DESCRIPTION
Fixed a small bug where a user couldn't view test results of a notification linked to a notification in their TB service.