### PR TITLE
NTBS-2330: Remove inline template tag

### DIFF
--- a/ntbs-service/Pages/Notifications/TestResults.cshtml
+++ b/ntbs-service/Pages/Notifications/TestResults.cshtml
@@ -19,39 +19,33 @@
 <partial name="Edit/_SpecimenDetails" for="@Model.Specimens" />
 
 <div>
-    <input type="hidden" asp-for="TestData.NotificationId">
+    <h3>Manually-entered test results</h3>
+    @if (Model.TestData.HasTestCarriedOut ?? false)
+    {
+        <nhs-form-group nhs-form-group-type="Standard" id="TestData-HasTestCarriedOut">
+            <nhs-fieldset aria-describedby="test-carried-out-error">
+                <nhs-fieldset-legend nhs-legend-size="Standard">
+                    @Html.DisplayNameFor(m => m.TestData.HasTestCarriedOut)
+                </nhs-fieldset-legend>
+                <nhs-radios nhs-radios-type="Standard">
+                    <nhs-radios-item>
+                        <input nhs-input-type="Radios" asp-for="TestData.HasTestCarriedOut" id="test-carried-out-yes" ref="conditional-true" type="radio" value="true" disabled="true"/>
+                        <label nhs-label-type="Radios" for="test-carried-out-yes">Yes</label>
+                    </nhs-radios-item>
+                    <nhs-radios-item>
+                        <input nhs-input-type="Radios" asp-for="TestData.HasTestCarriedOut" id="test-carried-out-no" type="radio" value="false" disabled="true"/>
+                        <label nhs-label-type="Radios" for="test-carried-out-no">No</label>
+                    </nhs-radios-item>
+                </nhs-radios>
+            </nhs-fieldset>
+        </nhs-form-group>
+    }
 
-        <div inline-template>
-            <div>
-                <h3>Manually-entered test results</h3>
-                @if (Model.TestData.HasTestCarriedOut ?? false)
-                {
-                    <nhs-form-group nhs-form-group-type="Standard" id="TestData-HasTestCarriedOut">
-                        <nhs-fieldset aria-describedby="test-carried-out-error">
-                            <nhs-fieldset-legend nhs-legend-size="Standard">
-                                @Html.DisplayNameFor(m => m.TestData.HasTestCarriedOut)
-                            </nhs-fieldset-legend>
-                            <nhs-radios nhs-radios-type="Standard">
-                                <nhs-radios-item>
-                                    <input nhs-input-type="Radios" asp-for="TestData.HasTestCarriedOut" id="test-carried-out-yes" ref="conditional-true" type="radio" value="true" disabled="true"/>
-                                    <label nhs-label-type="Radios" for="test-carried-out-yes">Yes</label>
-                                </nhs-radios-item>
-                                <nhs-radios-item>
-                                    <input nhs-input-type="Radios" asp-for="TestData.HasTestCarriedOut" id="test-carried-out-no" type="radio" value="false" disabled="true"/>
-                                    <label nhs-label-type="Radios" for="test-carried-out-no">No</label>
-                                </nhs-radios-item>
-                            </nhs-radios>
-                        </nhs-fieldset>
-                    </nhs-form-group>
-                }
-
-                <div ref="conditional-section">
-                    @{
-                        ViewData["ShowManualResultsEditLinks"] = false;
-                    }
-                    <partial name="_ManualTestResultTable" for="TestData.ManualTestResults"/>
-                </div>
-            </div>
-        </div>
+    <div>
+        @{
+            ViewData["ShowManualResultsEditLinks"] = false;
+        }
+        <partial name="_ManualTestResultTable" for="TestData.ManualTestResults"/>
+    </div>
     <nhs-back-link data-ignore-form-leave-checker="true" href="@RouteHelper.GetNotificationOverviewPathWithSectionAnchor(Model.NotificationId, NotificationSubPaths.EditTestResults)">Go back</nhs-back-link>
 </div>


### PR DESCRIPTION
## Description
The inline-template tag on in the html was making the manually entered test results flicker - it would show them on initial page load and then immediately hide them.

## Checklist:
- [ ] Automated tests are passing locally.
