### PR TITLE
NTBS-2360: Cascading dropdown doesn't remove inputted value

### DIFF
--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
@@ -141,7 +141,9 @@ namespace ntbs_service.Pages.Alerts
 
         public async Task<JsonResult> OnGetFilteredTbServiceListsByPhecCode(string value)
         {
-            var filteredTbServices = await _referenceDataRepository.GetTbServicesFromPhecCodeAsync(value);
+            var filteredTbServices = value != null
+                ? await _referenceDataRepository.GetTbServicesFromPhecCodeAsync(value)
+                : await _referenceDataRepository.GetAllTbServicesAsync();
 
             return new JsonResult(
                 new FilteredTransferPageSelectLists
@@ -150,8 +152,7 @@ namespace ntbs_service.Pages.Alerts
                     {
                         Value = n.Code.ToString(),
                         Text = n.Name
-                    }),
-                    CaseManagers = new List<OptionValue>()
+                    })
                 });
         }
 

--- a/ntbs-service/wwwroot/source/Components/CascadingDropdown.ts
+++ b/ntbs-service/wwwroot/source/Components/CascadingDropdown.ts
@@ -77,13 +77,14 @@ const CascadingDropdown = Vue.extend({
         },
         updateSelectList: function (refName: string, values: OptionValue[]) {
             const selectElement = this.getSelectElementInRef(refName);
+            const currentSelectedValue = selectElement.value;
 
             if (values) {
                 const optionInnerHtml = this.generateOptionInnerHtml(values);
                 selectElement.innerHTML = optionInnerHtml;
             }
 
-            selectElement.value = "";
+            this.setSelectToValueOrDefault(selectElement, currentSelectedValue);
         },
         getSelectElementInRef(refName: string) {
             const filterValueContainer = this.$refs[refName];
@@ -101,6 +102,17 @@ const CascadingDropdown = Vue.extend({
             let optionInnerHtml = DEFAULT_SELECT_INNER_HTML;
             values.forEach(item => optionInnerHtml += `<option value="${item.value}">${item.text}</option>`);
             return optionInnerHtml;
+        },
+        setSelectToValueOrDefault: function (selectElement: HTMLSelectElement, targetValue: string) {
+            for (let i = 0; i < selectElement.options.length; i++) {
+                if (selectElement.options[i].value === targetValue) {
+                    selectElement.value = targetValue;
+                    return;
+                }
+            }
+
+            selectElement.value = "";
+            selectElement.dispatchEvent(new Event('change'));
         },
     }
 });

--- a/ntbs-service/wwwroot/source/Components/CascadingDropdown.ts
+++ b/ntbs-service/wwwroot/source/Components/CascadingDropdown.ts
@@ -112,6 +112,7 @@ const CascadingDropdown = Vue.extend({
             }
 
             selectElement.value = "";
+            // Incase removing the value will result in other validation or filtering we dispatch a change event
             selectElement.dispatchEvent(new Event('change'));
         },
     }


### PR DESCRIPTION
## Description
The javascript for the cascading dropdown was removing any value inputted when it filtered the select, this has been changed so that if the option still exists it doesn't remove it. 
Also I fixed a bug where if you selected a PHEC and then selected "Please select" the TB services dropdown would be empty. I thought it would make sense to still have all the TB services as it does when loading the page initially.

This is being fixed as part of 2360 as the reason the tests were failing was due to a race condition with the TB services being filtered (and therefore removing the inputted value) and the value being inputted.

### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
