### PR TITLE
NTBS-2360: Wait for warning messages with implicit wait

### DIFF
--- a/ntbs-ui-tests/Features/CreateNotifications.feature
+++ b/ntbs-ui-tests/Features/CreateNotifications.feature
@@ -129,7 +129,7 @@ Feature: Notification creation
     And I check 'enhanced-case-management-yes'
     And I check 'ecm-2'
     And I check 'regimen-standardTherapy'
-    And I enter Patient has been doing well into 'ClinicalDetails_Notes'
+    And I enter Patient has been doing well into 'notes'
     When I click on the 'submit-button' button
 
     Then I can see the value 'Pulmonary' for the field 'sites' in the 'ClinicalDetails' overview section

--- a/ntbs-ui-tests/Features/EditNotifications.feature
+++ b/ntbs-ui-tests/Features/EditNotifications.feature
@@ -93,7 +93,7 @@ Feature: Notification editing
     And I check 'dot-status-DotRefused'
     And I check 'enhanced-case-management-yes'
     And I check 'ecm-1'
-    And I enter Patient has no cool shoes into 'ClinicalDetails_Notes'
+    And I enter Patient has no cool shoes into 'notes'
     When I click on the 'save-button' button
 
     Then I can see the value 'Pulmonary, Spine, Cryptic' for the field 'sites' in the 'ClinicalDetails' overview section

--- a/ntbs-ui-tests/Features/TransferNotification.feature
+++ b/ntbs-ui-tests/Features/TransferNotification.feature
@@ -33,7 +33,8 @@ Feature: Transfer notification
     Given I choose to log in with a different account
     Given I have logged in as LeedsServiceUser
     When I navigate to the url of the current notification
-    And I take action on the alert with title Transfer request
+    Then I can see the value Birmingham & Solihull for element with id 'banner-tb-service'
+    When I take action on the alert with title Transfer request
 
     Then I can see the value Birmingham & Solihull for 'Sending TB service' transfer information
     Then I can see the value Birmingham UITester for 'Sending case manager' transfer information
@@ -53,7 +54,9 @@ Feature: Transfer notification
     Given I choose to log in with a different account
     Given I have logged in as LeedsServiceUser
     When I navigate to the url of the current notification
-    And I take action on the alert with title Transfer request
+    Then I can see the value Birmingham & Solihull for element with id 'banner-tb-service'
+    When I take action on the alert with title Transfer request
+
     And I check 'decline-transfer-input'
     And I enter Do not want this patient here into 'DeclineTransferReason'
     And I click on the 'submit-transfer-button' button

--- a/ntbs-ui-tests/Features/TransferNotification.feature
+++ b/ntbs-ui-tests/Features/TransferNotification.feature
@@ -33,8 +33,7 @@ Feature: Transfer notification
     Given I choose to log in with a different account
     Given I have logged in as LeedsServiceUser
     When I navigate to the url of the current notification
-    Then I can see the value Birmingham & Solihull for element with id 'banner-tb-service'
-    When I take action on the alert with title Transfer request
+    And I take action on the alert with title Transfer request
 
     Then I can see the value Birmingham & Solihull for 'Sending TB service' transfer information
     Then I can see the value Birmingham UITester for 'Sending case manager' transfer information
@@ -54,8 +53,7 @@ Feature: Transfer notification
     Given I choose to log in with a different account
     Given I have logged in as LeedsServiceUser
     When I navigate to the url of the current notification
-    Then I can see the value Birmingham & Solihull for element with id 'banner-tb-service'
-    When I take action on the alert with title Transfer request
+    And I take action on the alert with title Transfer request
 
     And I check 'decline-transfer-input'
     And I enter Do not want this patient here into 'DeclineTransferReason'

--- a/ntbs-ui-tests/Steps/ActSteps.cs
+++ b/ntbs-ui-tests/Steps/ActSteps.cs
@@ -7,6 +7,7 @@ using ntbs_ui_tests.Hooks;
 using OpenQA.Selenium;
 using OpenQA.Selenium.Support.UI;
 using TechTalk.SpecFlow;
+using Xunit;
 
 namespace ntbs_ui_tests.Steps
 {
@@ -30,6 +31,8 @@ namespace ntbs_ui_tests.Steps
         public void WhenINavigateToCurrentNotificationUrl()
         {
             Browser.Navigate().GoToUrl($"{Settings.EnvironmentConfig.RootUri}/Notifications/{TestContext.AddedNotificationIds.Single()}");
+            // Verify that the page has loaded
+            Assert.NotNull(Browser.FindElement(By.ClassName("notification-banner-title-text")));
         }
         
         [When(@"I click '(.*)' on the navigation bar")]

--- a/ntbs-ui-tests/Steps/AssertSteps.cs
+++ b/ntbs-ui-tests/Steps/AssertSteps.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Microsoft.CodeAnalysis.CodeActions;
 using ntbs_service.Models.Validations;
 using ntbs_ui_tests.Helpers;
 using ntbs_ui_tests.Hooks;
@@ -94,7 +95,13 @@ namespace ntbs_ui_tests.Steps
         public void ThenICanSeeTheWarningForId(string warningMessage, string warningId)
         {
             var warningElement = HtmlElementHelper.FindElementById(Browser, warningId);
-            Assert.Contains(warningMessage, warningElement.Text);
+            try {
+                var wait = new WebDriverWait(Browser, Settings.ImplicitWait);
+                wait.Until(ExpectedConditions.TextToBePresentInElement(warningElement, warningMessage));
+            }
+            catch (WebDriverTimeoutException) {
+                Assert.Contains(warningElement.Text, warningMessage);
+            }
         }
 
         #endregion


### PR DESCRIPTION
## Description
Use implicit wait when checking for the warning messages and also check for an overview element on the transfer request tests so that we know we're on the overview page.

## Checklist:
- [ ] Automated tests are passing locally.
