### PR TITLE
NTBS-2440 Revert back to checking read-only from claim

### DIFF
--- a/ntbs-service-unit-tests/Pages/HomePageTests.cs
+++ b/ntbs-service-unit-tests/Pages/HomePageTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Moq;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
@@ -118,7 +119,8 @@ namespace ntbs_service_unit_tests.Pages
                 _mockAlertRepository.Object,
                 _mockAuthorizationService.Object,
                 _mockUserService.Object,
-                _mockHomepageKpiService.Object);
+                _mockHomepageKpiService.Object,
+                new Mock<IUserHelper>().Object);
             pageModel.MockOutSession();
 
             // Act
@@ -163,7 +165,8 @@ namespace ntbs_service_unit_tests.Pages
                 _mockAlertRepository.Object,
                 _mockAuthorizationService.Object,
                 _mockUserService.Object,
-                _mockHomepageKpiService.Object);
+                _mockHomepageKpiService.Object,
+                new Mock<IUserHelper>().Object);
             pageModel.MockOutSession();
 
             // Act
@@ -188,7 +191,8 @@ namespace ntbs_service_unit_tests.Pages
                 _mockAlertRepository.Object,
                 _mockAuthorizationService.Object,
                 _mockUserService.Object,
-                _mockHomepageKpiService.Object);
+                _mockHomepageKpiService.Object,
+                new Mock<IUserHelper>().Object);
             pageModel.MockOutSession();
 
             // Act
@@ -211,7 +215,8 @@ namespace ntbs_service_unit_tests.Pages
                 _mockAlertRepository.Object,
                 _mockAuthorizationService.Object,
                 _mockUserService.Object,
-                _mockHomepageKpiService.Object);
+                _mockHomepageKpiService.Object,
+                new Mock<IUserHelper>().Object);
             pageModel.MockOutSession();
 
             // Act
@@ -237,7 +242,8 @@ namespace ntbs_service_unit_tests.Pages
                 _mockAlertRepository.Object,
                 _mockAuthorizationService.Object,
                 _mockUserService.Object,
-                _mockHomepageKpiService.Object);
+                _mockHomepageKpiService.Object,
+                new Mock<IUserHelper>().Object);
             pageModel.MockOutSession();
 
             // Act

--- a/ntbs-service-unit-tests/Pages/SearchPageTest.cs
+++ b/ntbs-service-unit-tests/Pages/SearchPageTest.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Moq;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
@@ -88,7 +89,8 @@ namespace ntbs_service_unit_tests.Pages
                 _mockAuthorizationService.Object,
                 _mockReferenceDataRepository.Object,
                 _mockLegacySearchService.Object,
-                _mockUserService.Object)
+                _mockUserService.Object,
+                new Mock<IUserHelper>().Object)
             {
                 SearchParameters = new SearchParameters(),
                 PageContext = pageContext

--- a/ntbs-service/Helpers/UserHelper.cs
+++ b/ntbs-service/Helpers/UserHelper.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Options;
 using ntbs_service.Properties;
 
@@ -7,6 +8,7 @@ namespace ntbs_service.Helpers
     public interface IUserHelper
     {
         bool CurrentUserMatchesUsernameOrIsAdmin(HttpContext context, string username);
+        bool UserIsReadOnly(ClaimsPrincipal user);
     }
     
     public class UserHelper : IUserHelper
@@ -27,6 +29,11 @@ namespace ntbs_service.Helpers
         public bool CurrentUserMatchesUsernameOrIsAdmin(HttpContext context, string username)
         {
             return context.User.Username() == username || context.User.IsInRole(_adOptions.AdminUserGroup);
+        }
+
+        public bool UserIsReadOnly(ClaimsPrincipal user)
+        {
+            return user.IsInRole(_adOptions.ReadOnlyUserGroup);
         }
     }
 }

--- a/ntbs-service/Pages/Alerts/TransferRejected.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRejected.cshtml.cs
@@ -25,7 +25,8 @@ namespace ntbs_service.Pages.Alerts
             IAlertService alertService,
             IAlertRepository alertRepository,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(notificationService, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IUserHelper userHelper) : base(notificationService, authorizationService, userHelper, notificationRepository)
         {
             _alertService = alertService;
             _alertRepository = alertRepository;

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
@@ -41,8 +41,9 @@ namespace ntbs_service.Pages.Alerts
             IAlertRepository alertRepository,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IReferenceDataRepository referenceDataRepository)
-            : base(notificationService, authorizationService, notificationRepository)
+            IReferenceDataRepository referenceDataRepository,
+            IUserHelper userHelper)
+            : base(notificationService, authorizationService, userHelper, notificationRepository)
         {
             _alertService = alertService;
             _alertRepository = alertRepository;

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -53,7 +53,9 @@ namespace ntbs_service.Pages.Alerts
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
-            ITreatmentEventRepository treatmentEventRepository) : base(notificationService, authorizationService, notificationRepository)
+            ITreatmentEventRepository treatmentEventRepository,
+            IUserHelper userHelper)
+            : base(notificationService, authorizationService, userHelper, notificationRepository)
         {
             _treatmentEventRepository = treatmentEventRepository;
             _alertService = alertService;

--- a/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
+++ b/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
@@ -47,7 +47,7 @@ namespace ntbs_service.Pages.ContactDetails
             RegionalMemberships = await this._referenceDataRepository.GetPhecsByAdGroups(ContactDetails.AdGroups);
 
             ViewData["IsEditable"] = _userHelper.CurrentUserMatchesUsernameOrIsAdmin(HttpContext, ContactDetails.Username)
-                && !(await _userService.GetUser(HttpContext.User)).IsReadOnly;
+                && !_userHelper.UserIsReadOnly(User);
 
             ContactDetails.CaseManagerTbServices = ContactDetails?.CaseManagerTbServices
                 .OrderBy(x => x.TbService.PHEC.Name)

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -9,7 +9,7 @@
 <nhs-width-container container-width="Standard">
     <h1>Dashboard</h1>
     <a href="/Search" role="button" draggable="false" class="nhsuk-button ntbsuk-button--primary">
-        @(await Model.UserIsReadOnly() ? "Search notifications" : "Search and create notification")
+        @(Model.UserIsReadOnly() ? "Search notifications" : "Search and create notification")
     </a>
 
     @if (Model.KpiFilter.Any())

--- a/ntbs-service/Pages/Index.cshtml.cs
+++ b/ntbs-service/Pages/Index.cshtml.cs
@@ -20,18 +20,21 @@ namespace ntbs_service.Pages
         private readonly IAuthorizationService _authorizationService;
         private readonly IUserService _userService;
         private readonly IHomepageKpiService _homepageKpiService;
+        private readonly IUserHelper _userHelper;
 
         public IndexModel(INotificationRepository notificationRepository,
             IAlertRepository alertRepository,
             IAuthorizationService authorizationService,
             IUserService userService,
-            IHomepageKpiService homepageKpiService)
+            IHomepageKpiService homepageKpiService,
+            IUserHelper userHelper)
         {
             _notificationRepository = notificationRepository;
             _authorizationService = authorizationService;
             _alertRepository = alertRepository;
             _userService = userService;
             _homepageKpiService = homepageKpiService;
+            _userHelper = userHelper;
         }
 
         public IList<AlertWithTbServiceForDisplay> Alerts { get; set; }
@@ -88,9 +91,9 @@ namespace ntbs_service.Pages
             Alerts = await _authorizationService.FilterAlertsForUserAsync(User, alertsForTbServices);
         }
 
-        public async Task<bool> UserIsReadOnly()
+        public bool UserIsReadOnly()
         {
-            return (await _userService.GetUser(HttpContext.User)).IsReadOnly;
+            return _userHelper.UserIsReadOnly(User);
         }
     }
 }

--- a/ntbs-service/Pages/LabResults/Index.cshtml.cs
+++ b/ntbs-service/Pages/LabResults/Index.cshtml.cs
@@ -2,7 +2,6 @@
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
@@ -25,17 +24,20 @@ namespace ntbs_service.Pages.LabResults
         private readonly INotificationRepository _notificationRepository;
         private readonly ISpecimenService _specimenService;
         private readonly IUserService _userService;
+        private readonly IUserHelper _userHelper;
 
         public IndexModel(
             ISpecimenService specimenService,
             IUserService userService,
             INotificationRepository notificationRepository,
-            IAuthorizationService authorizationService)
+            IAuthorizationService authorizationService,
+            IUserHelper userHelper)
         {
             _specimenService = specimenService;
             _userService = userService;
             _notificationRepository = notificationRepository;
             _authorizationService = authorizationService;
+            _userHelper = userHelper;
             ValidationService = new ValidationService(this);
         }
 
@@ -49,7 +51,7 @@ namespace ntbs_service.Pages.LabResults
 
         public async Task<IActionResult> OnGetAsync()
         {
-            if ((await _userService.GetUser(HttpContext.User)).IsReadOnly)
+            if (_userHelper.UserIsReadOnly(User))
             {
                 return RedirectToPage(RouteHelper.AccessDeniedPath);
             }

--- a/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
+++ b/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
@@ -18,7 +18,7 @@ namespace ntbs_service.Pages.LegacyNotifications
         private readonly INotificationImportService _notificationImportService;
         private readonly INotificationImportRepository _notificationImportRepository;
         private readonly INotificationRepository _notificationRepository;
-        private readonly IUserService _userService;
+        private readonly IUserHelper _userHelper;
 
         public NotificationBannerModel NotificationBannerModel { get; set; }
 
@@ -32,18 +32,18 @@ namespace ntbs_service.Pages.LegacyNotifications
             INotificationImportService notificationImportService,
             INotificationImportRepository notificationImportRepository,
             INotificationRepository notificationRepository,
-            IUserService userService)
+            IUserHelper userHelper)
         {
             _legacySearchService = legacySearchService;
             _notificationImportService = notificationImportService;
             _notificationImportRepository = notificationImportRepository;
             _notificationRepository = notificationRepository;
-            _userService = userService;
+            _userHelper = userHelper;
         }
 
         public async Task<IActionResult> OnGetAsync()
         {
-            if ((await _userService.GetUser(User)).IsReadOnly)
+            if (_userHelper.UserIsReadOnly(User))
             {
                 return RedirectToPage(RouteHelper.AccessDeniedPath);
             }

--- a/ntbs-service/Pages/Notifications/CaseManagerDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/CaseManagerDetails.cshtml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Services;
@@ -22,8 +23,9 @@ namespace ntbs_service.Pages.Notifications
             IAuthorizationService authorizationService,
             IUserRepository userRepository,
             IReferenceDataRepository referenceDataRepository,
-            INotificationRepository notificationRepository)
-            : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IUserHelper userHelper)
+            : base(service, authorizationService, userHelper, notificationRepository)
         {
             _userRepository = userRepository;
             _referenceDataRepository = referenceDataRepository;

--- a/ntbs-service/Pages/Notifications/Create.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Create.cshtml.cs
@@ -10,17 +10,17 @@ namespace ntbs_service.Pages.Notifications
     public class CreateModel : PageModel
     {
         private readonly INotificationService _notificationService;
-        private readonly IUserService _userService;
+        private readonly IUserHelper _userHelper;
 
-        public CreateModel(INotificationService notificationService, IUserService userService)
+        public CreateModel(INotificationService notificationService, IUserHelper userHelper)
         {
             _notificationService = notificationService;
-            _userService = userService;
+            _userHelper = userHelper;
         }
 
         public async Task<IActionResult> OnGetAsync()
         {
-            if ((await _userService.GetUser(User)).IsReadOnly)
+            if (_userHelper.UserIsReadOnly(User))
             {
                 return RedirectToPage(RouteHelper.AccessDeniedPath);
             }

--- a/ntbs-service/Pages/Notifications/Delete.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Delete.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models;
 using ntbs_service.Models.Enums;
 using ntbs_service.Models.Validations;
@@ -23,7 +24,8 @@ namespace ntbs_service.Pages.Notifications
         public DeleteModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IUserHelper userHelper) : base(service, authorizationService, userHelper, notificationRepository)
         {
             ValidationService = new ValidationService(this);
         }

--- a/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Denotify.cshtml.cs
@@ -23,7 +23,8 @@ namespace ntbs_service.Pages.Notifications
         public DenotifyModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IUserHelper userHelper) : base(service, authorizationService, userHelper, notificationRepository)
         {
             ValidationService = new ValidationService(this);
 

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -44,8 +44,9 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationRepository notificationRepository,
             IAlertRepository alertRepository,
             IReferenceDataRepository referenceDataRepository,
-            IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService)
-            : base(service, authorizationService, notificationRepository, alertRepository)
+            IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
+            IUserHelper userHelper)
+            : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
             _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;

--- a/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Comorbidities.cshtml.cs
@@ -35,7 +35,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             CurrentPage = NotificationSubPaths.EditComorbidities;
         }

--- a/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ContactTracing.cshtml.cs
@@ -13,7 +13,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             CurrentPage = NotificationSubPaths.EditContactTracing;
         }

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -37,7 +37,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             IReferenceDataRepository referenceDataRepository,
             IAuthorizationService authorizationService,
             IUserService userService,
-            NtbsContext context) : base(notificationService, authorizationService, notificationRepository, alertRepository)
+            NtbsContext context,
+            IUserHelper userHelper) : base(notificationService, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _context = context;
             _userService = userService;

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -19,6 +19,7 @@ namespace ntbs_service.Pages.Notifications.Edit
     {
         private readonly NtbsContext _context;
         private readonly IReferenceDataRepository _referenceDataRepository;
+        private readonly IUserService _userService;
 
         public SelectList TbServices { get; set; }
         public SelectList Hospitals { get; set; }

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisAnimalExposure.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisAnimalExposure.cshtml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Models.Validations;
@@ -29,7 +30,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
             IItemRepository<MBovisAnimalExposure> mBovisAnimalExposureRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
             _mBovisAnimalExposureRepository = mBovisAnimalExposureRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisExposureToKnownCase.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
 using ntbs_service.Models.Validations;
@@ -24,7 +25,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IItemRepository<MBovisExposureToKnownCase> mBovisExposureToKnownCasesRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _mBovisExposureToKnownCasesRepository = mBovisExposureToKnownCasesRepository;
         }

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisOccupationExposure.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisOccupationExposure.cshtml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Models.Validations;
@@ -29,7 +30,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
             IItemRepository<MBovisOccupationExposure> mBovisOccupationExposureRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
             _mBovisOccupationExposureRepository = mBovisOccupationExposureRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/MBovisUnpasteurisedMilkConsumption.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/MBovisUnpasteurisedMilkConsumption.cshtml.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Models.Validations;
@@ -29,7 +30,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
             IItemRepository<MBovisUnpasteurisedMilkConsumption> mBovisUnpasteurisedMilkConsumptionRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
             _mBovisUnpasteurisedMilkConsumptionRepository = mBovisUnpasteurisedMilkConsumptionRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -36,8 +36,9 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
             IItemRepository<ManualTestResult> testResultsRepository,
-            IAlertRepository alertRepository)
-            : base(notificationService, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(notificationService, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
             _testResultsRepository = testResultsRepository;

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextAddress.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextAddress.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -17,8 +18,9 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationRepository notificationRepository,
             IItemRepository<SocialContextAddress> socialContextAddressRepository,
             IAlertService alertService,
-            IAlertRepository alertRepository)
-            : base(service, authorizationService, notificationRepository, socialContextAddressRepository, alertService, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(service, authorizationService, notificationRepository, socialContextAddressRepository, alertService, alertRepository, userHelper)
         {
         }
 

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextBase.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
@@ -31,8 +31,9 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             INotificationRepository notificationRepository,
             IItemRepository<T> socialContextRepository,
             IAlertService alertService,
-            IAlertRepository alertRepository)
-            : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _socialContextRepository = socialContextRepository;
             _alertService = alertService;

--- a/ntbs-service/Pages/Notifications/Edit/Items/SocialContextVenue.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/SocialContextVenue.cshtml.cs
@@ -1,8 +1,9 @@
-using System.Linq;
+﻿using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Services;
 
@@ -23,8 +24,9 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IReferenceDataRepository referenceDataRepository,
             IItemRepository<SocialContextVenue> socialContextVenueRepository,
             IAlertService alertService,
-            IAlertRepository alertRepository)
-            : base(service, authorizationService, notificationRepository, socialContextVenueRepository, alertService, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(service, authorizationService, notificationRepository, socialContextVenueRepository, alertService, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
         }

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -46,8 +46,9 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             IReferenceDataRepository referenceDataRepository,
             ITreatmentEventRepository treatmentEventRepository,
             IAlertRepository alertRepository,
-            IAlertService alertService)
-            : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertService alertService,
+            IUserHelper userHelper)
+            : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
             _treatmentEventRepository = treatmentEventRepository;

--- a/ntbs-service/Pages/Notifications/Edit/MBovisAnimalExposures.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisAnimalExposures.cshtml.cs
@@ -19,8 +19,14 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
-            IAlertRepository alertRepository) : base(notificationService, authorizationService,
-                notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(
+                notificationService,
+                authorizationService,
+                notificationRepository,
+                alertRepository,
+                userHelper)
         {
             CurrentPage = NotificationSubPaths.EditMBovisAnimalExposures;
             _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;

--- a/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisExposureToKnownCases.cshtml.cs
@@ -19,8 +19,14 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
-            IAlertRepository alertRepository) : base(notificationService, authorizationService,
-                notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(
+                notificationService,
+                authorizationService,
+                notificationRepository,
+                alertRepository,
+                userHelper)
         {
             CurrentPage = NotificationSubPaths.EditMBovisExposureToKnownCases;
             _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;

--- a/ntbs-service/Pages/Notifications/Edit/MBovisOccupationExposures.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisOccupationExposures.cshtml.cs
@@ -19,8 +19,14 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
-            IAlertRepository alertRepository) : base(notificationService, authorizationService,
-                notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(
+                notificationService,
+                authorizationService,
+                notificationRepository,
+                alertRepository,
+                userHelper)
         {
             CurrentPage = NotificationSubPaths.EditMBovisOccupationExposures;
             _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;

--- a/ntbs-service/Pages/Notifications/Edit/MBovisUnpasteurisedMilkConsumptions.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MBovisUnpasteurisedMilkConsumptions.cshtml.cs
@@ -19,8 +19,14 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
-            IAlertRepository alertRepository) : base(notificationService, authorizationService,
-                notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(
+                notificationService,
+                authorizationService,
+                notificationRepository,
+                alertRepository,
+                userHelper)
         {
             CurrentPage = NotificationSubPaths.EditMBovisUnpasteurisedMilkConsumptions;
             _enhancedSurveillanceAlertsService = enhancedSurveillanceAlertsService;

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -25,10 +25,14 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationRepository notificationRepository,
             IReferenceDataRepository referenceDataRepository,
             IEnhancedSurveillanceAlertsService enhancedSurveillanceAlertsService,
-            IAlertRepository alertRepository) : base(service,
-            authorizationService,
-            notificationRepository,
-            alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(
+                service,
+                authorizationService,
+                notificationRepository,
+                alertRepository,
+                userHelper)
         {
             CurrentPage = NotificationSubPaths.EditMDRDetails;
             _referenceDataRepository = referenceDataRepository;

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -38,7 +38,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationRepository notificationRepository,
             IAlertRepository alertRepository,
             IPostcodeService postcodeService,
-            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IReferenceDataRepository referenceDataRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _postcodeService = postcodeService;
             _referenceDataRepository = referenceDataRepository;

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml.cs
@@ -20,7 +20,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IAlertRepository alertRepository,
-            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IReferenceDataRepository referenceDataRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _referenceDataRepository = referenceDataRepository;
             CurrentPage = NotificationSubPaths.EditPreviousHistory;

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextAddresses.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
@@ -16,7 +16,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             CurrentPage = NotificationSubPaths.EditSocialContextAddresses;
         }

--- a/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
@@ -16,7 +16,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             CurrentPage = NotificationSubPaths.EditSocialContextVenues;
         }

--- a/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/SocialRiskFactors.cshtml.cs
@@ -16,7 +16,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IAlertRepository alertRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             CurrentPage = NotificationSubPaths.EditSocialRiskFactors;
         }

--- a/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TestResults.cshtml.cs
@@ -21,7 +21,9 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationRepository notificationRepository,
             IAlertRepository alertRepository,
             ICultureAndResistanceService cultureAndResistanceService,
-            ISpecimenService specimenService) : base(notificationService, authorizationService, notificationRepository, alertRepository)
+            ISpecimenService specimenService,
+            IUserHelper userHelper)
+            : base(notificationService, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             _cultureAndResistanceService = cultureAndResistanceService;
             _specimenService = specimenService;

--- a/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Travel.cshtml.cs
@@ -25,7 +25,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             IAlertRepository alertRepository,
-            IReferenceDataRepository referenceDataRepository) : base(service, authorizationService, notificationRepository, alertRepository)
+            IReferenceDataRepository referenceDataRepository,
+            IUserHelper userHelper) : base(service, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             HighTbIncidenceCountries = new SelectList(
                 referenceDataRepository.GetAllHighTbIncidenceCountriesAsync().Result,

--- a/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml.cs
@@ -16,7 +16,9 @@ namespace ntbs_service.Pages.Notifications.Edit
             INotificationService notificationService,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IAlertRepository alertRepository) : base(notificationService, authorizationService, notificationRepository, alertRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(notificationService, authorizationService, notificationRepository, alertRepository, userHelper)
         {
             CurrentPage = NotificationSubPaths.EditTreatmentEvents;
         }

--- a/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/LinkedNotifications.cshtml.cs
@@ -16,7 +16,8 @@ namespace ntbs_service.Pages.Notifications
         public LinkedNotificationsModel(
             INotificationService service,
             IAuthorizationService authorizationService,
-            INotificationRepository notificationRepository) : base(service, authorizationService, notificationRepository)
+            INotificationRepository notificationRepository,
+            IUserHelper userHelper) : base(service, authorizationService, userHelper, notificationRepository)
         {
         }
 

--- a/ntbs-service/Pages/Notifications/NotificationChanges.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/NotificationChanges.cshtml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Enums;
 using ntbs_service.Services;
 using ntbs_service.TagHelpers;
@@ -20,8 +21,9 @@ namespace ntbs_service.Pages.Notifications
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            INotificationChangesService notificationChangesService)
-            : base(service, authorizationService, notificationRepository)
+            INotificationChangesService notificationChangesService,
+            IUserHelper userHelper)
+            : base(service, authorizationService, userHelper, notificationRepository)
         {
             _notificationChangesService = notificationChangesService;
         }

--- a/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationEditModelBase.cs
@@ -23,8 +23,9 @@ namespace ntbs_service.Pages.Notifications
             INotificationService service,
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
-            IAlertRepository alertRepository)
-            : base(service, authorizationService, notificationRepository)
+            IAlertRepository alertRepository,
+            IUserHelper userHelper)
+            : base(service, authorizationService, userHelper, notificationRepository)
         {
             ValidationService = new ValidationService(this);
             _alertRepository = alertRepository;

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -19,16 +19,19 @@ namespace ntbs_service.Pages.Notifications
         protected INotificationService Service;
         protected IAuthorizationService _authorizationService;
         protected INotificationRepository NotificationRepository;
+        protected IUserHelper _userHelper;
         protected IUserService _userService;
 
         protected NotificationModelBase(
             INotificationService service,
             IAuthorizationService authorizationService,
+            IUserHelper userHelper,
             INotificationRepository notificationRepository = null,
             IUserService userService = null)
         {
             Service = service;
             _authorizationService = authorizationService;
+            _userHelper = userHelper;
             NotificationRepository = notificationRepository;
             _userService = userService;
         }
@@ -97,9 +100,9 @@ namespace ntbs_service.Pages.Notifications
             return StatusCode((int)HttpStatusCode.Forbidden);
         }
 
-        public async Task<bool> UserIsReadOnly()
+        public bool UserIsReadOnly()
         {
-            return (await _userService.GetUser(User)).IsReadOnly;
+            return _userHelper.UserIsReadOnly(User);
         }
 
         private async Task<NotificationGroup> GetNotificationGroupAsync()

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -20,20 +20,17 @@ namespace ntbs_service.Pages.Notifications
         protected IAuthorizationService _authorizationService;
         protected INotificationRepository NotificationRepository;
         protected IUserHelper _userHelper;
-        protected IUserService _userService;
 
         protected NotificationModelBase(
             INotificationService service,
             IAuthorizationService authorizationService,
             IUserHelper userHelper,
-            INotificationRepository notificationRepository = null,
-            IUserService userService = null)
+            INotificationRepository notificationRepository = null)
         {
             Service = service;
             _authorizationService = authorizationService;
             _userHelper = userHelper;
             NotificationRepository = notificationRepository;
-            _userService = userService;
         }
         public int NumberOfLinkedNotifications { get; set; }
         public int? LatestLinkedNotificationId { get; private set; }

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -32,10 +32,9 @@ namespace ntbs_service.Pages.Notifications
             IAuthorizationService authorizationService,
             IAlertService alertService,
             INotificationRepository notificationRepository,
-            IUserService userService,
             ICultureAndResistanceService cultureAndResistanceService,
             IAuditService auditService,
-            IUserHelper userHelper) : base(service, authorizationService, userHelper, notificationRepository, userService)
+            IUserHelper userHelper) : base(service, authorizationService, userHelper, notificationRepository)
         {
             _alertService = alertService;
             _cultureAndResistanceService = cultureAndResistanceService;

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -34,7 +34,8 @@ namespace ntbs_service.Pages.Notifications
             INotificationRepository notificationRepository,
             IUserService userService,
             ICultureAndResistanceService cultureAndResistanceService,
-            IAuditService auditService) : base(service, authorizationService, notificationRepository, userService)
+            IAuditService auditService,
+            IUserHelper userHelper) : base(service, authorizationService, userHelper, notificationRepository, userService)
         {
             _alertService = alertService;
             _cultureAndResistanceService = cultureAndResistanceService;
@@ -95,7 +96,7 @@ namespace ntbs_service.Pages.Notifications
 
         public async Task<IActionResult> OnPostCreateLinkAsync()
         {
-            if (await UserIsReadOnly())
+            if (UserIsReadOnly())
             {
                 return Page();
             }

--- a/ntbs-service/Pages/Notifications/TestResults.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/TestResults.cshtml.cs
@@ -2,6 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
 using ntbs_service.Services;
@@ -18,7 +19,8 @@ namespace ntbs_service.Pages.Notifications
             IAuthorizationService authorizationService,
             INotificationRepository notificationRepository,
             ICultureAndResistanceService cultureAndResistanceService,
-            ISpecimenService specimenService) : base(service, authorizationService, notificationRepository)
+            ISpecimenService specimenService,
+            IUserHelper userHelper) : base(service, authorizationService, userHelper, notificationRepository)
         {
             _cultureAndResistanceService = cultureAndResistanceService;
             _specimenService = specimenService;

--- a/ntbs-service/Pages/Search/Index.cshtml
+++ b/ntbs-service/Pages/Search/Index.cshtml
@@ -252,7 +252,7 @@
                 <br/>
                 Draft notifications are displayed before submitted records.
             </p>
-            @if (!await Model.UserIsReadOnly())
+            @if (!Model.UserIsReadOnly())
             {
                 <div class="create-notification-button-container">
                     <a href="/Notifications/Create" role="button" draggable="false" class="nhsuk-button create-notification-button--right ntbsuk-button--primary" id="create-button">
@@ -284,7 +284,7 @@
                                     previous-link-text="@Model.SearchResults.PreviousPageText" previous-url="@Model.PreviousPageUrl"></nhs-pagination>
                 </ul>
             </nav>
-            @if(Model.SearchResults?.Count > 3 && !await Model.UserIsReadOnly())
+            @if(Model.SearchResults?.Count > 3 && !Model.UserIsReadOnly())
             {
                 <a href="/Notifications/Create" role="button" draggable="false" class="nhsuk-button ntbsuk-button--primary">
                     Create Notification

--- a/ntbs-service/Pages/Search/Index.cshtml.cs
+++ b/ntbs-service/Pages/Search/Index.cshtml.cs
@@ -23,6 +23,7 @@ namespace ntbs_service.Pages.Search
         private readonly ILegacySearchService _legacySearchService;
         private readonly IReferenceDataRepository _referenceDataRepository;
         private readonly IUserService _userService;
+        private readonly IUserHelper _userHelper;
 
         public ValidationService ValidationService;
 
@@ -44,7 +45,8 @@ namespace ntbs_service.Pages.Search
             IAuthorizationService authorizationService,
             IReferenceDataRepository referenceDataRepository,
             ILegacySearchService legacySearchService,
-            IUserService userService)
+            IUserService userService,
+            IUserHelper userHelper)
         {
             _authorizationService = authorizationService;
             _searchService = searchService;
@@ -52,6 +54,7 @@ namespace ntbs_service.Pages.Search
             _legacySearchService = legacySearchService;
             _referenceDataRepository = referenceDataRepository;
             _userService = userService;
+            _userHelper = userHelper;
 
             ValidationService = new ValidationService(this);
 
@@ -279,9 +282,9 @@ namespace ntbs_service.Pages.Search
             return searchParameterDictionary;
         }
 
-        public async Task<bool> UserIsReadOnly()
+        public bool UserIsReadOnly()
         {
-            return (await _userService.GetUser(HttpContext.User)).IsReadOnly;
+            return _userHelper.UserIsReadOnly(User);
         }
     }
 }

--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -49,7 +49,7 @@
     <nhs-grid-column grid-column-width="OneThird">
         <div class="@manageNotificationClass">
             <nhs-details display-text="Manage notification" nhs-details-type="Expander" id="manage-notification">
-                @if (Model.Notification.IsLastLinkedNotificationOverOneYearOld && !await Model.UserIsReadOnly())
+                @if (Model.Notification.IsLastLinkedNotificationOverOneYearOld && !Model.UserIsReadOnly())
                 {
                     <form method="post">
                         <input type="hidden" value="@Model.NotificationId" name="NotificationId"/>

--- a/ntbs-service/Pages/Shared/_Header.cshtml
+++ b/ntbs-service/Pages/Shared/_Header.cshtml
@@ -7,8 +7,10 @@
 @inject ntbs.IReportingLinksService ReportingLinksService
 
 @using Microsoft.Extensions.Configuration
+@using ntbs_service.Helpers
 @using ntbs_service.Properties
 @inject IConfiguration Configuration
+@inject IUserHelper UserHelper
 
 @{
     var breadcrumbs = ViewData["Breadcrumbs"];
@@ -24,7 +26,7 @@
 
             <div class="govuk-header__logo header-logo-container header-logo">
                 <span class="govuk-header__logotype">
-                    <img src="~/Images/PHE_3268_DIGI_AW-100px.png" alt="Public Health England logo"/>
+                    <img src="~/Images/PHE_3268_DIGI_AW-100px.png" alt="Public Health England logo" />
                 </span>
             </div>
             <div class=" govuk-header__link--service-name header-title">
@@ -66,7 +68,7 @@
                             Search
                         </a>
                     </li>
-                    @if (!(await UserService.GetUser(Context.User)).IsReadOnly)
+                    @if (!UserHelper.UserIsReadOnly(User))
                     {
                         <li class="govuk-header__navigation-item header-navigation-link">
                             <a class="govuk-header__link header-navigation-list-item" href="/LabResults">


### PR DESCRIPTION
With apologies to @LeoCie because this reverts a change I asked him to make a while ago!

## Description
I've reverted checking whether the user is read-only or not to use the `ClaimPrincipal` rather than the `User` object in the database.

The immediate reason for this is that in scenarios where we're using dummy auth (i.e. for the load tests) the `User` object does not exist and so the old code was failing. I could have worked around this, but in doing so I realised that we're still getting the TB Service AD groups directly from the claim, and this made the alternatives doubly weird. At some point in the future, I think we may shift across to using the `CaseManagerTbService` table consistently across the site, and when we do I think it would also make sense to re-revert this change.

The review looks horrible but it's basically one simple change.

## Checklist:
- [x] Automated tests are passing locally.

