### PR TITLE
NTBS-2441 Set up notifications with consistent status

### DIFF
--- a/load-test-data-generation/NotificationGenerator.cs
+++ b/load-test-data-generation/NotificationGenerator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Bogus;
 using load_test_data_generation.Notifications;
@@ -22,8 +21,8 @@ namespace load_test_data_generation
         private static readonly DateTime EndOf2020 = new DateTime(2020, 12, 31, 23, 59, 59);
 
         private readonly Faker<Notification> testNotifications = new Faker<Notification>()
-            .RuleFor(n => n.NotificationStatus, f => NotificationStatus.Notified)
             .RuleFor(n => n.NotificationDate, f => f.Date.Between(StartOf2015, EndOf2020))
+            .RuleFor(n => n.NotificationStatus, f => NotificationStatus.Notified)
             .RuleFor(n => n.SubmissionDate, (f, u) => u.NotificationDate.Value.Add(f.Date.Timespan(TimeSpan.FromDays(2))))
             .RuleFor(n => n.ETSID, f => null)
             .RuleFor(n => n.LTBRID, f => null)
@@ -74,7 +73,17 @@ namespace load_test_data_generation
             notification.TestData = testResultGenerator.GenerateTestData();
             notification.TreatmentEvents = TreatmentEventsGenerator.GenerateTreatmentEvents(notification);
 
+            EnsureConsistentStatus(notification);
+
             return notification;
+        }
+
+        private static void EnsureConsistentStatus(Notification notification)
+        {
+            if (notification.ShouldBeClosed())
+            {
+                notification.NotificationStatus = NotificationStatus.Closed;
+            }
         }
     }
 }

--- a/load-test-data-generation/Notifications/TreatmentEventsGenerator.cs
+++ b/load-test-data-generation/Notifications/TreatmentEventsGenerator.cs
@@ -1,8 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Bogus;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;


### PR DESCRIPTION
Change the load test generation program so that it sets notifications to be Closed when appropriate.

I have tested this by clearing out the load-test database and re-generating the data.
