### PR TITLE
NTBS-1339 Add temporary starting events

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -46,6 +46,9 @@ namespace ntbs_integration_tests.Helpers
         public const int NOTIFICATION_WITH_TREATMENT_EVENTS = 10070;
         public const int NOTIFICATION_FOR_ADD_TREATMENT_OUTCOME = 10071;
         public const int NOTIFICATION_FOR_ADD_TREATMENT_RESTART = 10072;
+        public const int DRAFT_WITH_DIAGNOSIS_DATE = 10073;
+        public const int DRAFT_WITH_TREATMENT_START_DATE = 10074;
+        public const int DRAFT_WITH_NO_START_DATES = 10075;
 
         public const int CLINICAL_NOTIFICATION_EXTRA_PULMONARY_ID = 10080;
 

--- a/ntbs-integration-tests/NotificationPages/DraftEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DraftEditPageTests.cs
@@ -31,7 +31,11 @@ namespace ntbs_integration_tests.NotificationPages
         {
             return new List<Alert>
             {
-                new DataQualityDraftAlert { NotificationId = Utilities.DRAFT_NOTIFICATION_WITH_DRAFT_ALERT }
+                new DataQualityDraftAlert
+                {
+                    AlertId = Utilities.DRAFT_DATA_QUALITY_ALERT,
+                    NotificationId = Utilities.DRAFT_NOTIFICATION_WITH_DRAFT_ALERT
+                }
             };
         }
 

--- a/ntbs-integration-tests/NotificationPages/TreatmentEventsEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/TreatmentEventsEditPageTests.cs
@@ -89,6 +89,27 @@ namespace ntbs_integration_tests.NotificationPages
                 {
                     NotificationId = Utilities.NOTIFICATION_FOR_ADD_TREATMENT_OUTCOME,
                     NotificationStatus = NotificationStatus.Notified
+                },
+                new Notification
+                {
+                    NotificationId = Utilities.DRAFT_WITH_DIAGNOSIS_DATE,
+                    NotificationStatus = NotificationStatus.Draft,
+                    ClinicalDetails = new ClinicalDetails { DiagnosisDate = DateTime.Parse("2021-06-01") }
+                },
+                new Notification
+                {
+                    NotificationId = Utilities.DRAFT_WITH_TREATMENT_START_DATE,
+                    NotificationStatus = NotificationStatus.Draft,
+                    ClinicalDetails = new ClinicalDetails
+                    {
+                        TreatmentStartDate = DateTime.Parse("2021-05-15"),
+                        DiagnosisDate = DateTime.Parse("2021-06-01")
+                    }
+                },
+                new Notification
+                {
+                    NotificationId = Utilities.DRAFT_WITH_NO_START_DATES,
+                    NotificationStatus = NotificationStatus.Draft
                 }
             };
         }
@@ -142,6 +163,45 @@ namespace ntbs_integration_tests.NotificationPages
             // Will not duplicate check for date rendering
             Assert.Contains(TREATMENT_OUTCOME_TYPE.GetDisplayName(), treatmentOutcomeTextContent);
             Assert.Contains(TREATMENT_OUTCOME_SUBTYPE.GetDisplayName(), treatmentOutcomeTextContent);
+        }
+
+        [Theory]
+        [InlineData(Utilities.DRAFT_WITH_DIAGNOSIS_DATE, TreatmentEventType.DiagnosisMade, "01 Jun 2021")]
+        [InlineData(Utilities.DRAFT_WITH_TREATMENT_START_DATE, TreatmentEventType.TreatmentStart, "15 May 2021")]
+        public async Task GetTreatmentEvents_AddsStartingEvent_ForDraftNotification(int notificationId,
+            TreatmentEventType expectedEventType,
+            string expectedDate)
+        {
+            // Arrange
+            var url = GetCurrentPathForId(notificationId);
+
+            // Act
+            var document = await GetDocumentForUrlAsync(url);
+
+            // Assert
+            var treatmentTable = document.QuerySelector("#treatment-events");
+            Assert.NotNull(treatmentTable);
+
+            var treatmentOutcomeRow = treatmentTable.QuerySelector("#treatment-event-0");
+            Assert.NotNull(treatmentOutcomeRow);
+            var treatmentOutcomeTextContent = treatmentOutcomeRow.TextContent;
+            // Will not duplicate check for date rendering
+            Assert.Contains(expectedEventType.GetDisplayName(), treatmentOutcomeTextContent);
+            Assert.Contains(expectedDate, treatmentOutcomeTextContent);
+        }
+
+        [Fact]
+        public async Task GetTreatmentEvents_DoesNotAddStartingEvent_ForDraftWithoutStartingDates()
+        {
+            // Arrange
+            var url = GetCurrentPathForId(Utilities.DRAFT_WITH_NO_START_DATES);
+
+            // Act
+            var document = await GetDocumentForUrlAsync(url);
+
+            // Assert
+            var treatmentTable = document.QuerySelector("#treatment-events");
+            Assert.Null(treatmentTable);
         }
 
         [Fact]

--- a/ntbs-service/Models/Entities/NotificationDisplay.cs
+++ b/ntbs-service/Models/Entities/NotificationDisplay.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using ntbs_service.Helpers;
@@ -45,6 +46,17 @@ namespace ntbs_service.Models.Entities
 
         public bool IsMBovisQuestionnaireComplete =>
             DrugResistanceHelper.IsMBovisQuestionnaireComplete(MBovisDetails);
+
+        public ICollection<TreatmentEvent> GetTreatmentEventsWithStartingEvent()
+        {
+            var treatmentEvents = TreatmentEvents.ToList();
+            if (NotificationStatus == NotificationStatus.Draft && ClinicalDetails.StartingDate != null)
+            {
+                treatmentEvents.Add(NotificationHelper.CreateTreatmentStartEvent(this));
+            }
+
+            return treatmentEvents;
+        }
 
         public override bool? IsLegacy => LTBRID != null || ETSID != null;
 

--- a/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/TreatmentEvent.cshtml.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Threading.Tasks;
-using Castle.Core.Internal;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
@@ -38,6 +37,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
         [BindProperty]
         public TreatmentOutcomeSubType? SelectedTreatmentOutcomeSubType { get; set; }
         public IEnumerable<SelectListItem> TreatmentEventTypes { get; set; }
+
+        public IList<TreatmentEvent> TreatmentEvents { get; private set; }
 
         public TreatmentEventModel(
             INotificationService service,
@@ -81,6 +82,8 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
                     Value = ((int)t).ToString(),
                     Text = t.GetDisplayName()
                 });
+
+            TreatmentEvents = Notification.GetTreatmentEventsWithStartingEvent().OrderForEpisodes().ToList();
 
             return Page();
         }

--- a/ntbs-service/Pages/Notifications/Edit/Items/_TreatmentEvent.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_TreatmentEvent.cshtml
@@ -87,7 +87,7 @@
                                     var hasTreatmentEventTypeError = !Model.IsValid("TreatmentEvent.TreatmentEventType");
                                     var treatmentEventTypeGroupState = hasTreatmentEventTypeError ? Error : Standard;
                                 }
-                                <nhs-form-group nhs-form-group-type="@treatmentEventTypeGroupState" 
+                                <nhs-form-group nhs-form-group-type="@treatmentEventTypeGroupState"
                                                 aria-describedby="treatmentevent-type-error"
                                                 id="TreatmentEvent-TreatmentEventType">
                                     <label nhs-label-type="Standard" for="treatmentevent-type">
@@ -120,7 +120,7 @@
                                             var outcomeTypeGroupState = hasOutcomeTypeError ? Error : Standard;
                                             var outcomeTypeSelectErrorState = hasOutcomeTypeError ? SelectType.Error : SelectType.Standard;
                                         }
-                                        <nhs-form-group nhs-form-group-type="@outcomeTypeGroupState" 
+                                        <nhs-form-group nhs-form-group-type="@outcomeTypeGroupState"
                                                         aria-describedby="treatmentoutcome-type-error"
                                                         id="SelectedTreatmentOutcomeType">
                                             <label nhs-label-type="Standard" for="treatmentoutcome-type">
@@ -149,7 +149,7 @@
                                         var outcomeSubTypeGroupState = hasOutcomeSubTypeError ? Error : Standard;
                                         var outcomeSubTypeSelectErrorState = hasOutcomeSubTypeError ? SelectType.Error : SelectType.Standard;
                                     }
-                                    <nhs-form-group nhs-form-group-type="@outcomeSubTypeGroupState" 
+                                    <nhs-form-group nhs-form-group-type="@outcomeSubTypeGroupState"
                                                     aria-describedby="treatmentoutcome-subtype-error"
                                                     id="SelectedTreatmentOutcomeSubType">
                                         <label nhs-label-type="Standard" for="treatmentoutcome-subtype">
@@ -180,7 +180,7 @@
                         var noteTextAreaType = hasNoteError ? TextAreaType.Error : TextAreaType.Standard;
                     }
                     <validate-input model="TreatmentEvent" property="Note" inline-template>
-                        <nhs-form-group nhs-form-group-type="@noteFormState" 
+                        <nhs-form-group nhs-form-group-type="@noteFormState"
                                         aria-describedby="treatmentevent-note-error"
                                         id="TreatmentEvent-Note">
                             <label nhs-label-type="Standard" for="treatmentevent-note">
@@ -219,12 +219,12 @@
         </form>
     </nhs-width-container>
 </div>
-@if (Model.Notification.TreatmentEvents.Count > 0)
+@if (Model.TreatmentEvents.Count > 0)
 {
     <nhs-width-container container-width="Standard">
         <h2> Treatment events </h2>
 
-        <partial name="_TreatmentEventTable" for="Notification.TreatmentEvents"/>
+        <partial name="_TreatmentEventTable" for="TreatmentEvents"/>
     </nhs-width-container>
 }
 

--- a/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml
@@ -15,7 +15,7 @@
 <h2> @title </h2>
 
 <div>
-    <partial name="_TreatmentEventTable" for="Notification.TreatmentEvents" />
+    <partial name="_TreatmentEventTable" for="TreatmentEvents" />
 
     <button id="add-new-treatment-event-button"
             nhs-button-type="Standard"

--- a/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/TreatmentEvents.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
@@ -10,7 +11,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 {
     public class TreatmentEventsModel : NotificationEditModelBase
     {
-        public IEnumerable<TreatmentEvent> TreatmentEvents { get; set; }
+        public IList<TreatmentEvent> TreatmentEvents { get; set; }
 
         public TreatmentEventsModel(
             INotificationService notificationService,
@@ -23,7 +24,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         protected override async Task<IActionResult> PrepareAndDisplayPageAsync(bool isBeingSubmitted)
         {
-            TreatmentEvents = Notification.TreatmentEvents.OrderForEpisodes();
+            TreatmentEvents = Notification.GetTreatmentEventsWithStartingEvent().OrderForEpisodes().ToList();
             await SetNotificationProperties(isBeingSubmitted);
 
             return Page();


### PR DESCRIPTION
## Description
Show a temporary treatment event for treatment start or diagnosis made on treatment event editing pages, to show the treatment event that will be created when the notification is submitted.

Add integration tests to check that a starting event is displayed on the treatment events page even though it won't be made until the treatment event is submitted.

Fix integration test seeding bug: add an explicit ID for a draft data quality alert, to fix a weird integration test bug that would prevent adding another notification to the in-memory test database.

## Checklist:
- [x] Automated tests are passing locally (including UI tests).
