### PR TITLE
NTBS-2454: Use regional membership in contact details breadcrumbs

### DIFF
--- a/ntbs-integration-tests/ContactDetailsPages/ContactDetailsPageTests.cs
+++ b/ntbs-integration-tests/ContactDetailsPages/ContactDetailsPageTests.cs
@@ -1,0 +1,60 @@
+﻿using System.Linq;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_integration_tests.TestServices;
+using ntbs_service;
+using ntbs_service.Helpers;
+using Xunit;
+
+namespace ntbs_integration_tests.ContactDetailsPages
+{
+    public class ContactDetailsPageTests : TestRunnerBase
+    {
+        public ContactDetailsPageTests(NtbsWebApplicationFactory<Startup> factory)
+            : base(factory) { }
+
+        [Fact]
+        public async Task CorrectBreadcrumbsForCaseManagerPresent()
+        {
+            var user = TestUser.AbingdonCaseManager;
+            var pageRoute = (RouteHelper.GetContactDetailsSubPath(user.Id, null));
+            using (var client = Factory.WithUserAuth(user).CreateClientWithoutRedirects())
+            {
+                client.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue(UserAuthentication.SchemeName);
+                // Arrange
+                var initialPage = await client.GetAsync(pageRoute);
+                var pageContent = await GetDocumentAsync(initialPage);
+
+                // Assert
+                var breadcrumbs = pageContent.GetElementsByClassName("nhsuk-breadcrumb__list").Single().TextContent;
+                Assert.Contains("Service Directory", breadcrumbs);
+                Assert.Contains("South East", breadcrumbs);
+                Assert.Contains("TestCase TestManager", breadcrumbs);
+            }
+        }
+
+        [Fact]
+        public async Task BreadcrumbForRegionPresentForRegionalUser()
+        {
+            var user = TestUser.PheUserWithPermittedPhecCode;
+            var pageRoute = (RouteHelper.GetContactDetailsSubPath(user.Id, null));
+            using (var client = Factory.WithUserAuth(user).CreateClientWithoutRedirects())
+            {
+                client.DefaultRequestHeaders.Authorization =
+                    new AuthenticationHeaderValue(UserAuthentication.SchemeName);
+                // Arrange
+                var initialPage = await client.GetAsync(pageRoute);
+                var pageContent = await GetDocumentAsync(initialPage);
+
+                // Assert
+                var breadcrumbs = pageContent.GetElementsByClassName("nhsuk-breadcrumb__list").Single().TextContent;
+                Assert.Contains("Service Directory", breadcrumbs);
+                Assert.Contains("South East", breadcrumbs);
+                Assert.Contains("Permitted Phec", breadcrumbs);
+            }
+        }
+    }
+}
+

--- a/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
+++ b/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
@@ -65,7 +65,7 @@ namespace ntbs_service.Pages.ContactDetails
 
         private void PrepareBreadcrumbs()
         {
-            var region = ContactDetails.CaseManagerTbServices.FirstOrDefault()?.TbService.PHEC;
+            var region = RegionalMemberships.FirstOrDefault() ?? ContactDetails.CaseManagerTbServices.FirstOrDefault()?.TbService.PHEC;
             var breadcrumbs = new List<Breadcrumb>
             {
                 new Breadcrumb {Label = "Service Directory", Url = "/ServiceDirectory"}


### PR DESCRIPTION
## Description
Bug where regional users without any TB service membership didn't have the breadcrumbs for the region.

This actually doesn't have a release in JIRA, so I'm not sure it should be merged into master, but it might as well be reviewed on this PR.

## Checklist:
- [ ] Automated tests are passing locally.
