### PR TITLE
NTBS-2463 better notes validation

### DIFF
--- a/ntbs-integration-tests/ContactDetailsPages/EditContactDetailsTests.cs
+++ b/ntbs-integration-tests/ContactDetailsPages/EditContactDetailsTests.cs
@@ -93,6 +93,40 @@ namespace ntbs_integration_tests.ContactDetailsPages
         }
 
         [Fact]
+        public async Task EditDetails_TabInNotes_DisplayErrors()
+        {
+            var user = TestUser.NationalTeamUser;
+            var pageRoute = (RouteHelper.GetContactDetailsSubPath(user.Id, ContactDetailsSubPaths.Edit));
+            using (var client = Factory.WithUserAuth(user).CreateClientWithoutRedirects())
+            {
+                // Arrange
+                var initialPage = await client.GetAsync(pageRoute);
+                var initialDocument = await GetDocumentAsync(initialPage);
+
+                var formData = new Dictionary<string, string>
+                {
+                    ["ContactDetails.Username"] = user.Username,
+                    ["ContactDetails.JobTitle"] = "Teacher",
+                    ["ContactDetails.PhoneNumberPrimary"] = "0888192311",
+                    ["ContactDetails.PhoneNumberSecondary"] = "0123871623",
+                    ["ContactDetails.EmailPrimary"] = "primary@email",
+                    ["ContactDetails.EmailSecondary"] = "secondary@email",
+                    ["ContactDetails.Notes"] = "Notes\t"
+                };
+
+                // Act
+                var result = await client.SendPostFormWithData(initialDocument, formData, pageRoute);
+
+                // Assert
+                var resultDocument = await GetDocumentAsync(result);
+                result.EnsureSuccessStatusCode();
+
+                resultDocument.AssertErrorMessage("notes",
+                    string.Format(ValidationMessages.StringCannotContainTabs, "Notes"));
+            }
+        }
+
+        [Fact]
         public async Task EditDetails_EditingOtherUser_IsAllowedForAdmin()
         {
             var user = TestUser.NationalTeamUser;

--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -98,6 +98,30 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
+        public async Task PostDraft_ReturnsPageWithTabError_IfNotesContainTabs()
+        {
+            // Arrange
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
+                ["NotificationSiteMap[PULMONARY]"] = "true",
+                ["ClinicalDetails.Notes"] = "Notes\t",
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(initialDocument, formData, url);
+
+            // Assert
+            var resultDocument = await GetDocumentAsync(result);
+
+            result.EnsureSuccessStatusCode();
+            resultDocument.AssertErrorSummaryMessage("ClinicalDetails-Notes", "notes", "Notes cannot contain tabs. Use spaces instead");
+        }
+
+        [Fact]
         public async Task PostNotified_ReturnsPageWithAllModelErrors_IfModelNotValid()
         {
             // Arrange

--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
@@ -34,26 +34,30 @@ namespace ntbs_service_unit_tests.DataMigration
         public async Task ImportValidatorValidatesBaseModels()
         {
             // Arrange
-            var notification = new Notification
+            var notification = CreateBasicNotification();
+
+            notification.MDRDetails = new MDRDetails
             {
-                NotificationDate = new DateTime(2020,1,1),
-                TestData = new TestData{ManualTestResults = new List<ManualTestResult>()},
-                MDRDetails =
-                {
-                    RelationshipToCase = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
-                },
-                PatientDetails = new PatientDetails {FamilyName = "<>Davis<>"},
-                ClinicalDetails = new ClinicalDetails{DiagnosisDate = new DateTime(2000,1,1)},
-                TravelDetails = new TravelDetails{HasTravel = Status.Yes, TotalNumberOfCountries = 51},
-                ImmunosuppressionDetails = new ImmunosuppressionDetails{HasOther = true, OtherDescription = "<><>"},
-                HospitalDetails = new HospitalDetails{Consultant = "<>Fred<>"},
-                VisitorDetails = new VisitorDetails{HasVisitor = Status.Yes, StayLengthInMonths1 = 3},
-                ContactTracing = new ContactTracing{AdultsIdentified = -1},
-                PreviousTbHistory = new PreviousTbHistory{PreviousTbDiagnosisYear = 1899},
-                MBovisDetails = new MBovisDetails{MBovisExposureToKnownCases =
-                    new List<MBovisExposureToKnownCase>{new MBovisExposureToKnownCase()}, ExposureToKnownCasesStatus = Status.No},
-                DrugResistanceProfile = new DrugResistanceProfile{Species = "M. bovis"}
+                RelationshipToCase = "1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
             };
+            notification.PatientDetails = new PatientDetails { FamilyName = "<>Davis<>" };
+            notification.ClinicalDetails = new ClinicalDetails { DiagnosisDate = new DateTime(2000, 1, 1) };
+            notification.TravelDetails = new TravelDetails { HasTravel = Status.Yes, TotalNumberOfCountries = 51 };
+            notification.ImmunosuppressionDetails = new ImmunosuppressionDetails
+            {
+                HasOther = true,
+                OtherDescription = "<><>"
+            };
+            notification.HospitalDetails = new HospitalDetails { Consultant = "<>Fred<>" };
+            notification.VisitorDetails = new VisitorDetails{ HasVisitor = Status.Yes, StayLengthInMonths1 = 3 };
+            notification.ContactTracing = new ContactTracing { AdultsIdentified = -1 };
+            notification.PreviousTbHistory = new PreviousTbHistory { PreviousTbDiagnosisYear = 1899 };
+            notification.MBovisDetails.MBovisExposureToKnownCases = new List<MBovisExposureToKnownCase>
+            {
+                new MBovisExposureToKnownCase()
+            };
+            notification.MBovisDetails.ExposureToKnownCasesStatus = Status.No;
+            notification.DrugResistanceProfile = new DrugResistanceProfile { Species = "M. bovis" };
 
             // Act
             var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, notification);
@@ -84,20 +88,21 @@ namespace ntbs_service_unit_tests.DataMigration
         public async Task ImportValidatorValidatesCollectionModels()
         {
             // Arrange
-            var notification = new Notification
+            var notification = CreateBasicNotification();
+
+            notification.SocialContextAddresses.Add(new SocialContextAddress());
+            notification.SocialContextVenues.Add(new SocialContextVenue());
+            notification.TreatmentEvents.Add(new TreatmentEvent { EventDate = new DateTime(1899, 3, 3) });
+            notification.MBovisDetails = new MBovisDetails
             {
-                NotificationDate = new DateTime(2020,1,1),
-                TestData = new TestData{ManualTestResults = new List<ManualTestResult>()},
-                SocialContextAddresses = new List<SocialContextAddress>{new SocialContextAddress()},
-                SocialContextVenues = new List<SocialContextVenue>{new SocialContextVenue()},
-                TreatmentEvents = new List<TreatmentEvent>{new TreatmentEvent{EventDate = new DateTime(1899, 3, 3)}},
-                MBovisDetails = new MBovisDetails
-                {
-                    OccupationExposureStatus = Status.Yes, MBovisOccupationExposures = new List<MBovisOccupationExposure>(),
-                    ExposureToKnownCasesStatus = Status.Yes, MBovisExposureToKnownCases = new List<MBovisExposureToKnownCase>(),
-                    AnimalExposureStatus = Status.Yes, MBovisAnimalExposures = new List<MBovisAnimalExposure>(),
-                    UnpasteurisedMilkConsumptionStatus = Status.Yes, MBovisUnpasteurisedMilkConsumptions = new List<MBovisUnpasteurisedMilkConsumption>()
-                }
+                OccupationExposureStatus = Status.Yes,
+                MBovisOccupationExposures = new List<MBovisOccupationExposure>(),
+                ExposureToKnownCasesStatus = Status.Yes,
+                MBovisExposureToKnownCases = new List<MBovisExposureToKnownCase>(),
+                AnimalExposureStatus = Status.Yes,
+                MBovisAnimalExposures = new List<MBovisAnimalExposure>(),
+                UnpasteurisedMilkConsumptionStatus = Status.Yes,
+                MBovisUnpasteurisedMilkConsumptions = new List<MBovisUnpasteurisedMilkConsumption>()
             };
 
             // Act
@@ -126,11 +131,13 @@ namespace ntbs_service_unit_tests.DataMigration
         public async Task ImportValidatorCleansContactTracingValues()
         {
             // Arrange
-            var notification = new Notification
+            var notification = CreateBasicNotification();
+
+            // These values would fail validation
+            notification.ContactTracing = new ContactTracing
             {
-                NotificationDate = new DateTime(2020,1,1),
-                TestData = new TestData{ManualTestResults = new List<ManualTestResult>()},
-                ContactTracing = new ContactTracing{AdultsIdentified = 1, AdultsScreened = 3} // these values would fail validation
+                AdultsIdentified = 1,
+                AdultsScreened = 3
             };
 
             // Act
@@ -146,15 +153,12 @@ namespace ntbs_service_unit_tests.DataMigration
         public async Task ImportValidatorCleansTestDataValues()
         {
             // Arrange
-            var notification = new Notification
+            var notification = CreateBasicNotification();
+            notification.TestData = new TestData
             {
-                NotificationDate = new DateTime(2020,1,1),
-                TestData = new TestData
+                ManualTestResults = new List<ManualTestResult>
                 {
-                    ManualTestResults = new List<ManualTestResult>
-                    {
-                        new ManualTestResult { Result = Result.Positive, TestDate = null } // these values would fail validation
-                    }
+                    new ManualTestResult { Result = Result.Positive, TestDate = null } // these values would fail validation
                 }
             };
 
@@ -166,5 +170,82 @@ namespace ntbs_service_unit_tests.DataMigration
 
             Assert.Empty(errorMessages);
         }
+
+        [Fact]
+        public async Task ImportValidatorCleansStrings()
+        {
+            // Arrange
+            var notification = new Notification
+            {
+                TestData = new TestData { ManualTestResults = new List<ManualTestResult>() },
+                ClinicalDetails = new ClinicalDetails { Notes = " Clinical\t  notes" },
+                SocialContextAddresses = new List<SocialContextAddress>
+                {
+                    new SocialContextAddress { Address = "221B Baker St., London", Details = "  Elementary,\tWatson " }
+                },
+                SocialContextVenues = new List<SocialContextVenue>
+                {
+                    new SocialContextVenue { Address = "32 Windsor Gardens", Details = "  Peruvian\tbears " }
+                },
+                TreatmentEvents = new List<TreatmentEvent>
+                {
+                    new TreatmentEvent{ EventDate = new DateTime(1899, 3, 3), Note = " A \tnote   " }
+                },
+                MBovisDetails = new MBovisDetails
+                {
+                    OccupationExposureStatus = Status.Yes,
+                    MBovisOccupationExposures = new List<MBovisOccupationExposure>
+                    {
+                        new MBovisOccupationExposure { OtherDetails = " A friend\tat work  " }
+                    },
+                    ExposureToKnownCasesStatus = Status.Yes,
+                    MBovisExposureToKnownCases = new List<MBovisExposureToKnownCase>
+                    {
+                        new MBovisExposureToKnownCase { OtherDetails = "  His\tsister" }
+                    },
+                    AnimalExposureStatus = Status.Yes,
+                    MBovisAnimalExposures = new List<MBovisAnimalExposure>
+                    {
+                        new MBovisAnimalExposure { OtherDetails = " Cows and\t badgers  " }
+                    },
+                    UnpasteurisedMilkConsumptionStatus = Status.Yes,
+                    MBovisUnpasteurisedMilkConsumptions = new List<MBovisUnpasteurisedMilkConsumption>
+                    {
+                        new MBovisUnpasteurisedMilkConsumption { OtherDetails = "\tCheese  " }
+                    }
+                }
+            };
+
+            // Act
+            await _importValidator.CleanAndValidateNotification(null, RunId, notification);
+
+            // Assert
+            Assert.Equal("Clinical   notes", notification.ClinicalDetails.Notes);
+            Assert.Equal("Elementary, Watson", notification.SocialContextAddresses.First().Details);
+            Assert.Equal("Peruvian bears", notification.SocialContextVenues.First().Details);
+            Assert.Equal("A  note", notification.TreatmentEvents.First().Note);
+            Assert.Equal("His sister", notification.MBovisDetails.MBovisExposureToKnownCases.First().OtherDetails);
+            Assert.Equal("A friend at work", notification.MBovisDetails.MBovisOccupationExposures.First().OtherDetails);
+            Assert.Equal("Cows and  badgers", notification.MBovisDetails.MBovisAnimalExposures.First().OtherDetails);
+            Assert.Equal("Cheese", notification.MBovisDetails.MBovisUnpasteurisedMilkConsumptions.First().OtherDetails);
+        }
+
+        private static Notification CreateBasicNotification() =>
+            new Notification
+            {
+                NotificationDate = new DateTime(2020,1,1),
+                TestData = new TestData { ManualTestResults = new List<ManualTestResult>() },
+                ClinicalDetails = new ClinicalDetails(),
+                SocialContextAddresses = new List<SocialContextAddress>(),
+                SocialContextVenues = new List<SocialContextVenue>(),
+                TreatmentEvents = new List<TreatmentEvent>(),
+                MBovisDetails = new MBovisDetails
+                {
+                    MBovisOccupationExposures = new List<MBovisOccupationExposure>(),
+                    MBovisExposureToKnownCases = new List<MBovisExposureToKnownCase>(),
+                    MBovisAnimalExposures = new List<MBovisAnimalExposure>(),
+                    MBovisUnpasteurisedMilkConsumptions = new List<MBovisUnpasteurisedMilkConsumption>()
+                }
+            };
     }
 }

--- a/ntbs-service-unit-tests/Models/ContainsNoTabsValidatingTest.cs
+++ b/ntbs-service-unit-tests/Models/ContainsNoTabsValidatingTest.cs
@@ -1,0 +1,51 @@
+using ntbs_service.Models.Validations;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Models
+{
+    public class ContainsNoTabsValidatingTest
+    {
+        [Fact]
+        public void EmptyString_IsValid()
+        {
+            Assert.True(ValidateContainsNoTabs(""));
+        }
+
+        [Fact]
+        public void NullString_IsValid()
+        {
+            Assert.True(ValidateContainsNoTabs(null));
+        }
+
+        [Fact]
+        public void StringWithNormalText_IsValid()
+        {
+            Assert.True(ValidateContainsNoTabs("Hello there"));
+        }
+
+        [Fact]
+        public void StringWithOtherWhitespace_IsValid()
+        {
+            Assert.True(ValidateContainsNoTabs("Hello there\r\nGeneral Kenobi!"));
+        }
+
+        [Fact]
+        public void StringWithJustTabs_IsInvalid()
+        {
+            Assert.False(ValidateContainsNoTabs("\t\t"));
+        }
+
+        [Fact]
+        public void StringWithNormalTextAndTabs_IsInvalid()
+        {
+            Assert.False(ValidateContainsNoTabs("Hello there\tGeneral Kenobi!"));
+        }
+
+        private static bool ValidateContainsNoTabs(string notes)
+        {
+            var validator = new ContainsNoTabsAttribute();
+
+            return validator.IsValid(notes);
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/Alerts/TransferRejectedAlert.cs
+++ b/ntbs-service/Models/Entities/Alerts/TransferRejectedAlert.cs
@@ -15,6 +15,7 @@ namespace ntbs_service.Models.Entities.Alerts
         }
 
         [MaxLength(200)]
+        [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -47,7 +47,7 @@ namespace ntbs_service.Models.Entities
         /// "Starting" date is a bit of an informal name for the concept for a date which is important from analytical
         /// perspective for the notification. This is the date that corresponds to the "starting event" created for the
         /// notification, and is the date based on which further history of the notification is assessed, e.g.
-        /// the "outcome at 12 months" means 12 months after the starting date. 
+        /// the "outcome at 12 months" means 12 months after the starting date.
         /// </summary>
         public DateTime? StartingDate => TreatmentStartDate ?? DiagnosisDate;
 
@@ -81,6 +81,7 @@ namespace ntbs_service.Models.Entities
 
         [Display(Name = "Notes")]
         [MaxLength(1000, ErrorMessage = ValidationMessages.MaximumTextLength)]
+        [ContainsNoTabs]
         [RegularExpression(ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string Notes { get; set; }

--- a/ntbs-service/Models/Entities/MBovisAnimalExposure.cs
+++ b/ntbs-service/Models/Entities/MBovisAnimalExposure.cs
@@ -50,6 +50,7 @@ namespace ntbs_service.Models.Entities
         public virtual Country Country { get; set; }
 
         [MaxLength(150)]
+        [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]

--- a/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
+++ b/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
@@ -43,6 +43,7 @@ namespace ntbs_service.Models.Entities
             || ExposureNotificationId.Value != NotificationId;
 
         [MaxLength(150)]
+        [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]

--- a/ntbs-service/Models/Entities/MBovisOccupationExposure.cs
+++ b/ntbs-service/Models/Entities/MBovisOccupationExposure.cs
@@ -40,6 +40,7 @@ namespace ntbs_service.Models.Entities
         public virtual Country Country { get; set; }
 
         [MaxLength(200)]
+        [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]

--- a/ntbs-service/Models/Entities/MBovisUnpasteurisedMilkConsumption.cs
+++ b/ntbs-service/Models/Entities/MBovisUnpasteurisedMilkConsumption.cs
@@ -39,7 +39,7 @@ namespace ntbs_service.Models.Entities
         public virtual Country Country { get; set; }
 
         [MaxLength(150)]
-
+        [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]

--- a/ntbs-service/Models/Entities/SocialContextBase.cs
+++ b/ntbs-service/Models/Entities/SocialContextBase.cs
@@ -36,6 +36,7 @@ namespace ntbs_service.Models.Entities
         public DateTime? DateTo { get; set; }
 
         [MaxLength(250)]
+        [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]

--- a/ntbs-service/Models/Entities/TreatmentEvent.cs
+++ b/ntbs-service/Models/Entities/TreatmentEvent.cs
@@ -34,6 +34,7 @@ namespace ntbs_service.Models.Entities
         public virtual TreatmentOutcome TreatmentOutcome { get; set; }
 
         [MaxLength(1000)]
+        [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,
             ErrorMessage = ValidationMessages.InvalidCharacter)]

--- a/ntbs-service/Models/Entities/User.cs
+++ b/ntbs-service/Models/Entities/User.cs
@@ -52,6 +52,7 @@ namespace ntbs_service.Models.Entities
         public string PhoneNumberSecondary { get; set; }
 
         [MaxLength(500)]
+        [ContainsNoTabs]
         [Display(Name = "Notes")]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,

--- a/ntbs-service/Models/Validations/ContainsNoTabsAttribute.cs
+++ b/ntbs-service/Models/Validations/ContainsNoTabsAttribute.cs
@@ -1,7 +1,9 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace ntbs_service.Models.Validations
 {
+    [AttributeUsage(AttributeTargets.Property)]
     public class ContainsNoTabsAttribute : ValidationAttribute
     {
         public ContainsNoTabsAttribute()

--- a/ntbs-service/Models/Validations/ContainsNoTabsAttribute.cs
+++ b/ntbs-service/Models/Validations/ContainsNoTabsAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace ntbs_service.Models.Validations
+{
+    public class ContainsNoTabsAttribute : ValidationAttribute
+    {
+        public ContainsNoTabsAttribute()
+        {
+            ErrorMessage = ValidationMessages.StringCannotContainTabs;
+        }
+
+        public override bool IsValid(object value)
+        {
+            var notes = (string)value;
+
+            return string.IsNullOrEmpty(notes) || !notes.Contains('\t');
+        }
+    }
+}

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -17,6 +17,7 @@
         public const string StandardStringFormat = "{0} can only contain letters and the symbols ' - . ,";
         public const string StandardStringWithNumbersFormat = "{0} can only contain letters, numbers and the symbols ' - . ,";
         public const string StringWithNumbersAndForwardSlashFormat = "{0} can only contain letters, numbers and the symbols ' - . , /";
+        public const string StringCannotContainTabs = "{0} cannot contain tabs. Use spaces instead";
         public const string MinTwoCharacters = "Enter at least 2 characters";
         public const string MaximumTextLength = "Too many characters entered into the {0} field";
         public const string InvalidCharacter = "Invalid character found in {0}";


### PR DESCRIPTION
## Description
* Add a custom `ContainsNoTabs` attribute: This is caught by our regexes already but a custom attribute gives us the ability to have a custom error message for this issue. Add some unit tests for this class as well.
* Add `ContainsNoTabs` to all long-form notes fields: specifically the fields using our most generous text validation `CharacterValidationWithNumbersForwardSlashExtendedWithNewLine`, giving a more helpful message when there are illegal `\t` characters in the field. This can't be typed in easily, but could be copied and pasted or migrated in, causing this more helpful error to trigger.
* Add integration tests to two of the pages using ContainsNoTabs.
* Trim and replace `\t` with a space during import, for long form notes field. Add a unit test for this, and fix the `ImportValidator` unit tests that weren't fully initialising notifications for their tests.


## Checklist:
- [x] Automated tests are passing locally.

## Screenshots
### Validation for valid notes
![valid_notes](https://user-images.githubusercontent.com/3650110/122542970-31a10100-d023-11eb-942b-fbebd85127b5.png)
### Validation for notes with a tab
![tab_error](https://user-images.githubusercontent.com/3650110/122542975-32399780-d023-11eb-8d9a-5ed0dfa429a0.png)
### Validation for notes with a tab and other unwanted characters
![tab_and_special_chars](https://user-images.githubusercontent.com/3650110/122542972-31a10100-d023-11eb-9111-ab5f5d2578f3.png)
### Validation for notes with just other unwanted characters
![just_special_chars](https://user-images.githubusercontent.com/3650110/122542971-31a10100-d023-11eb-8a34-2b2a976bdb8f.png)
### The import error message for a record with tabs in the notes
![failed_import](https://user-images.githubusercontent.com/3650110/122542965-31086a80-d023-11eb-8101-1468202d6ab8.png)