### PR TITLE
NTBS-2438: Set correct audit user on login

### DIFF
--- a/EFAuditer-tests/UnitTests/Services/EFAuditServiceExtensionsTest.cs
+++ b/EFAuditer-tests/UnitTests/Services/EFAuditServiceExtensionsTest.cs
@@ -185,6 +185,39 @@ namespace EFAuditer_tests.UnitTests.Services
         }
 
         [Fact]
+        public void AuditAction_UsesOverrideUserInsteadOfAppUserWhenProvided()
+        {
+            // Arrange
+            var ev = new AuditEvent
+            {
+                Environment = new AuditEventEnvironment
+                {
+                    UserName = "Env user"
+                },
+                CustomFields = new Dictionary<string, object>
+                {
+                    {CustomFields.AuditDetails, "Notified"},
+                    {CustomFields.AppUser, "User 1"},
+                    {CustomFields.OverrideUser, "SYSTEM"}
+                }
+            };
+            var entry = new EventEntry
+            {
+                PrimaryKey = new Dictionary<string, object> { { "EntityId", "123" } },
+                EntityType = typeof(Entity),
+                Action = "Update",
+                Table = "EntityTable"
+            };
+            var audit = new AuditLog();
+
+            // Act
+            EFAuditServiceExtensions.AuditAction(ev, entry, audit);
+
+            // Assert
+            Assert.Equal("SYSTEM", audit.AuditUser);
+        }
+
+        [Fact]
         public void AuditActionForIOwnedEntity_SetsUpdateValuesCorrectly()
         {
             // Arrange

--- a/EFAuditer/CustomFields.cs
+++ b/EFAuditer/CustomFields.cs
@@ -6,5 +6,6 @@
         public const string AppUser = "AppUser";
         public const string RootEntity = "RootEntity";
         public const string RootId = "RootId";
+        public const string OverrideUser = "OverrideUser";
     }
 }

--- a/EFAuditer/EFAuditServiceExtensions.cs
+++ b/EFAuditer/EFAuditServiceExtensions.cs
@@ -28,14 +28,15 @@ namespace EFAuditer
 
                 if (user != null)
                 {
-                    var userName = user.FindFirstValue(ClaimTypes.Upn);
-                    // Fallbacks if user doesn't have an email associated with them - as is the case with our test users
-                    if (string.IsNullOrEmpty(userName))
-                    {
-                        userName = user.Identity.Name;
-                    }
+                    // Fallback if user doesn't have an email associated with them - as is the case with our test users
+                    var userName = !string.IsNullOrEmpty(user.FindFirstValue(ClaimTypes.Upn))
+                        ? user.FindFirstValue(ClaimTypes.Upn)
+                        : user.Identity.Name;
 
-                    scope.SetCustomField(CustomFields.AppUser, userName);
+                    if (userName != null)
+                    {
+                        scope.SetCustomField(CustomFields.AppUser, userName);
+                    }
                 }
             });
 

--- a/EFAuditer/EFAuditServiceExtensions.cs
+++ b/EFAuditer/EFAuditServiceExtensions.cs
@@ -58,7 +58,9 @@ namespace EFAuditer
             audit.EventType = entry.Action;
             audit.AuditDetails = GetCustomKey(ev, CustomFields.AuditDetails);
             audit.AuditDateTime = DateTime.Now;
-            audit.AuditUser = GetCustomKey(ev, CustomFields.AppUser) ?? ev.Environment.UserName;
+            audit.AuditUser = GetCustomKey(ev, CustomFields.OverrideUser)
+                ?? GetCustomKey(ev, CustomFields.AppUser)
+                ?? ev.Environment.UserName;
 
             var serializerSettings = Audit.Core.Configuration.JsonSettings;
             serializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter());

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -60,7 +60,7 @@ namespace ntbs_service.DataAccess
             _context.AddAuditCustomField(CustomFields.AuditDetails, auditType);
             if (auditUserOverride != null)
             {
-                _context.AddAuditCustomField(CustomFields.AppUser, auditUserOverride);
+                _context.AddAuditCustomField(CustomFields.OverrideUser, auditUserOverride);
             }
 
             await _context.SaveChangesAsync();

--- a/ntbs-service/DataAccess/UserRepository.cs
+++ b/ntbs-service/DataAccess/UserRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EFAuditer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using ntbs_service.Models.Entities;
@@ -59,6 +60,7 @@ namespace ntbs_service.DataAccess
 
         public async Task AddUserLoginEvent(UserLoginEvent userLoginEvent)
         {
+            _context.AddAuditCustomField(CustomFields.AppUser, userLoginEvent.Username);
             await _context.UserLoginEvent.AddAsync(userLoginEvent);
             await _context.SaveChangesAsync();
         }

--- a/ntbs-service/DataMigration/NotificationImportRepository.cs
+++ b/ntbs-service/DataMigration/NotificationImportRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.Extensions.Configuration;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -39,7 +39,7 @@ namespace ntbs_service.DataMigration
 
         public void AddSystemUserToAudits()
         {
-            _context.AddAuditCustomField(CustomFields.AppUser, AuditService.AuditUserSystem);
+            _context.AddAuditCustomField(CustomFields.OverrideUser, AuditService.AuditUserSystem);
         }
 
         public async Task<List<Notification>> AddLinkedNotificationsAsync(List<Notification> notifications)

--- a/ntbs-service/Jobs/HangfireJobContext.cs
+++ b/ntbs-service/Jobs/HangfireJobContext.cs
@@ -8,7 +8,7 @@ namespace ntbs_service.Jobs
     {
         protected HangfireJobContext(NtbsContext auditDbContext)
         {
-            auditDbContext.AddAuditCustomField(CustomFields.AppUser, AuditService.AuditUserSystem);
+            auditDbContext.AddAuditCustomField(CustomFields.OverrideUser, AuditService.AuditUserSystem);
         }
     }
 }


### PR DESCRIPTION
## Description
Not as easy a change as I thought, until I realised that our custom field for user was getting overwritten with nulls in this case so I've updated that to only set a custom field if we actually find a non null username.

## Checklist:
- [ ] Automated tests are passing locally.
