### PR TITLE
NTBS-2459 add application insights

### DIFF
--- a/ntbs-service/Pages/Health.cshtml
+++ b/ntbs-service/Pages/Health.cshtml
@@ -34,6 +34,7 @@
         <div>Cluster matching: @(Model.ClusterMatchingEnabled ? Tick : Cross)</div>
         <div>Reference lab results: @(Model.ReferenceLabResultsEnabled ? Tick : Cross)</div>
         <div>Reporting services: @(Model.ReportingServicesEnabled ? Tick : Cross)</div>
+        <div>Application insights: @(Model.ApplicationInsightsEnabled ? Tick : Cross)</div>
     </div>
 
     <div>

--- a/ntbs-service/Pages/Health.cshtml.cs
+++ b/ntbs-service/Pages/Health.cshtml.cs
@@ -29,6 +29,12 @@ namespace ntbs_service.Pages
             ReportingServicesEnabled = !string.IsNullOrEmpty(reportingDbString);
 
             configuration.GetSection("ScheduledJobsConfig").Bind(ScheduledJobsConfig);
+
+            var applicationInsightsOptions = new ApplicationInsightsOptions();
+            var applicationInsightsConfig = configuration.GetSection("ApplicationInsightsOptions");
+            applicationInsightsConfig.Bind(applicationInsightsOptions);
+            ApplicationInsightsEnabled = applicationInsightsOptions.Enabled == true
+                                         && !string.IsNullOrWhiteSpace(applicationInsightsOptions.ConnectionString);
         }
 
         public string Release { get; }
@@ -37,6 +43,7 @@ namespace ntbs_service.Pages
         public bool ClusterMatchingEnabled { get; }
         public bool ReferenceLabResultsEnabled { get; }
         public bool ReportingServicesEnabled { get; }
+        public bool ApplicationInsightsEnabled { get; }
 
         public ScheduledJobsConfig ScheduledJobsConfig { get; } = new ScheduledJobsConfig();
     }

--- a/ntbs-service/Pages/Shared/_Layout.cshtml
+++ b/ntbs-service/Pages/Shared/_Layout.cshtml
@@ -5,25 +5,26 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - NTBS</title>
     <link rel="stylesheet" href="~/dist/main.css" asp-append-version="true">
+    @Html.Raw(JavaScriptSnippet.FullScript)
 </head>
 <body>
     <div id="app">
         <div>
             @RenderSection("SkipLink", false)
             @* nhs-main-wrapper renders <main id="maincontent"></main> *@
-            <a nhs-anchor-type="SkipLink" href="#maincontent">Skip navigation</a> 
-            
+            <a nhs-anchor-type="SkipLink" href="#maincontent">Skip navigation</a>
+
             <partial name="./_Header.cshtml" />
-            
+
             <nhs-main-wrapper classes="main-wrapper">
                 @RenderBody()
             </nhs-main-wrapper>
 
             <partial name="./_Footer.cshtml" />
-                
+
             <inactivity-checker> </inactivity-checker>
         </div>
-        
+
         <vue-accessible-modal/>
     </div>
 

--- a/ntbs-service/Pages/_ViewImports.cshtml
+++ b/ntbs-service/Pages/_ViewImports.cshtml
@@ -3,3 +3,4 @@
 @addTagHelper *, NHSUK.FrontEndLibrary.TagHelpers
 @* addTagHelper requires an assembly name not a namespace *@
 @addTagHelper *, ntbs-service
+@inject Microsoft.ApplicationInsights.AspNetCore.IJavaScriptSnippet JavaScriptSnippet

--- a/ntbs-service/Properties/ApplicationInsightsOptions.cs
+++ b/ntbs-service/Properties/ApplicationInsightsOptions.cs
@@ -1,0 +1,9 @@
+﻿namespace ntbs_service.Properties
+{
+    public class ApplicationInsightsOptions
+    {
+        public bool? Enabled { get; set; }
+        public bool? EnableSqlCommandTextInstrumentation { get; set; }
+        public string ConnectionString { get; set; }
+    }
+}

--- a/ntbs-service/Services/BlankJavaScriptSnippet.cs
+++ b/ntbs-service/Services/BlankJavaScriptSnippet.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.ApplicationInsights.AspNetCore;
+
+namespace ntbs_service.Services
+{
+    // This is based on https://stackoverflow.com/a/49458076
+    // They allow us to avoid the dependency injection issues that happen if Application Insights is conditionally
+    // injected
+
+    public class BlankJavaScriptSnippet : IJavaScriptSnippet
+    {
+        public string FullScript => string.Empty;
+    }
+}

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -8,12 +8,15 @@ using EFAuditer;
 using Hangfire;
 using Hangfire.Console;
 using Hangfire.SqlServer;
+using Microsoft.ApplicationInsights.AspNetCore;
+using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+using Microsoft.ApplicationInsights.DependencyCollector;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authentication.WsFederation;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
@@ -75,14 +78,17 @@ namespace ntbs_service
             var adConfig = Configuration.GetSection("AdOptions");
             var adfsConfig = Configuration.GetSection("AdfsOptions");
             var azureAdConfig = Configuration.GetSection("AzureAdOptions");
+            var applicationInsightsConfig = Configuration.GetSection("ApplicationInsightsOptions");
 
             var adOptions = new AdOptions();
             var adfsOptions = new AdfsOptions();
             var azureAdOptions = new AzureAdOptions();
+            var applicationInsightsOptions = new ApplicationInsightsOptions();
 
             adConfig.Bind(adOptions);
             adfsConfig.Bind(adfsOptions);
             azureAdConfig.Bind(azureAdOptions);
+            applicationInsightsConfig.Bind(applicationInsightsOptions);
 
             services.Configure<AdOptions>(adConfig);
             services.Configure<AdfsOptions>(adfsConfig);
@@ -235,6 +241,7 @@ namespace ntbs_service
             AddReportingServices(services);
             AddMicrosoftGraphServices(services, azureAdOptions);
             AddAdImportService(services, azureAdOptions);
+            AddApplicationInsightsMonitoring(services, applicationInsightsOptions);
 
         }
 
@@ -471,6 +478,28 @@ namespace ntbs_service
                 services.AddScoped<IAdImportService, AdImportService>();
             }
 
+        }
+
+        private void AddApplicationInsightsMonitoring(IServiceCollection services,
+            ApplicationInsightsOptions applicationInsightsOptions)
+        {
+            if (applicationInsightsOptions.Enabled == true)
+            {
+                services.AddApplicationInsightsTelemetry(new ApplicationInsightsServiceOptions
+                {
+                    ConnectionString = applicationInsightsOptions.ConnectionString
+                });
+
+                services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((module, o) =>
+                {
+                    module.EnableSqlCommandTextInstrumentation =
+                        applicationInsightsOptions.EnableSqlCommandTextInstrumentation ?? false;
+                });
+            }
+            else
+            {
+                services.AddSingleton<IJavaScriptSnippet, BlankJavaScriptSnippet>();
+            }
         }
 
         private void AddNotificationClusterRepository(IServiceCollection services)

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -15,6 +15,11 @@
     "CallbackPath": "/signin-oidc",
     "Enabled": true
   },
+  "ApplicationInsightsOptions": {
+    "Enabled": false,
+    "EnableSqlCommandTextInstrumentation": false,
+    "ConnectionString": ""
+  },
   "AppConfig": {
     "AuditingEnabled": true,
     "LegacySearchEnabled": true

--- a/ntbs-service/deployments/load-test.yml
+++ b/ntbs-service/deployments/load-test.yml
@@ -56,6 +56,11 @@ spec:
               secretKeyRef:
                 name: load-test-connection-strings
                 key: migrationDb
+          - name: ApplicationInsightsOptions__ConnectionString
+            valueFrom:
+              secretKeyRef:
+                name: load-test-connection-strings
+                key: applicationInsights
           - name: AdOptions__UseDummyAuth
             value: "true"
           - name: MigrationConfig__NtbsEnvironment
@@ -72,6 +77,10 @@ spec:
             value: "development"
           - name: EnvironmentDescription__EnvironmentName
             value: "azure-load-test"
+          - name: ApplicationInsightsOptions__Enabled
+            value: "true"
+          - name: ApplicationInsightsOptions__EnableSqlCommandTextInstrumentation
+            value: "true"
         resources:
           limits:
             cpu: 500m

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.23" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Markdig" Version="0.24.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.6" />


### PR DESCRIPTION
## Description
* Add Application Insights monitoring: 
    * Do this for both the C# backend, and the web frontend (via Razor).
    * Only add this monitoring based on a configuration flag.
    * Flag when this is enabled on the health page.
* Add AppInsights configuration: have this disabled by default, only enable it `load-test`
    * A secret has been added to the `load-test-connection-strings` for the load test Application Insights connection string
* On Azure, an Azure Application Insights resource `NTBS_LoadTest_Insights` has been added.

## Checklist:
- [x] Automated tests are passing locally.