### PR TITLE
NTBS-2477: Set show padlock on legacy notification page

### DIFF
--- a/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
+++ b/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
@@ -19,6 +19,7 @@ namespace ntbs_service.Pages.LegacyNotifications
         private readonly INotificationImportRepository _notificationImportRepository;
         private readonly INotificationRepository _notificationRepository;
         private readonly IUserHelper _userHelper;
+        private readonly IAuthorizationService _authorizationService;
 
         public NotificationBannerModel NotificationBannerModel { get; set; }
 
@@ -32,13 +33,15 @@ namespace ntbs_service.Pages.LegacyNotifications
             INotificationImportService notificationImportService,
             INotificationImportRepository notificationImportRepository,
             INotificationRepository notificationRepository,
-            IUserHelper userHelper)
+            IUserHelper userHelper,
+            IAuthorizationService authorizationService)
         {
             _legacySearchService = legacySearchService;
             _notificationImportService = notificationImportService;
             _notificationImportRepository = notificationImportRepository;
             _notificationRepository = notificationRepository;
             _userHelper = userHelper;
+            _authorizationService = authorizationService;
         }
 
         public async Task<IActionResult> OnGetAsync()
@@ -87,6 +90,7 @@ namespace ntbs_service.Pages.LegacyNotifications
             }
 
             NotificationBannerModel.ShowLink = false;
+            NotificationBannerModel.ShowPadlock = !await _authorizationService.CanEditBannerModelAsync(User, NotificationBannerModel);
             return Page();
         }
     }

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -23,6 +23,9 @@ namespace ntbs_service.Services
         Task SetFullAccessOnNotificationBannersAsync(
             IEnumerable<NotificationBannerModel> notificationBanners,
             ClaimsPrincipal user);
+        Task<bool> CanEditBannerModelAsync(
+            ClaimsPrincipal user,
+            NotificationBannerModel notificationBannerModel);
     }
 
     public class AuthorizationService : IAuthorizationService
@@ -120,7 +123,7 @@ namespace ntbs_service.Services
             return (PermissionLevel.None, Messages.UnauthorizedWarning);
         }
 
-        private async Task<bool> CanEditBannerModelAsync(
+        public async Task<bool> CanEditBannerModelAsync(
             ClaimsPrincipal user,
             NotificationBannerModel notificationBannerModel)
         {


### PR DESCRIPTION
## Description
The padlock was always showing on the legacy notification page, this was because we actually weren't checking for the users permissions at all like we do on the search page.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
