### PR TITLE
NTBS-2461 trim text fields on import

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
@@ -177,19 +177,61 @@ namespace ntbs_service_unit_tests.DataMigration
             // Arrange
             var notification = new Notification
             {
-                TestData = new TestData { ManualTestResults = new List<ManualTestResult>() },
-                ClinicalDetails = new ClinicalDetails { Notes = " Clinical\t  notes" },
-                SocialContextAddresses = new List<SocialContextAddress>
+                PatientDetails = new PatientDetails
                 {
-                    new SocialContextAddress { Address = "221B Baker St., London", Details = "  Elementary,\tWatson " }
+                    GivenName = " Sher\tlock  ",
+                    FamilyName = "Holm\t es",
+                    LocalPatientId = "  PatientID\t1234 ",
+                    Address = " 123 \t Some Street  ",
+                    Postcode = " NW1\t6XE  ",
+                    OccupationOther = "  Detective \tWork "
                 },
-                SocialContextVenues = new List<SocialContextVenue>
+                ClinicalDetails = new ClinicalDetails
                 {
-                    new SocialContextVenue { Address = "32 Windsor Gardens", Details = "  Peruvian\tbears " }
+                    Notes = " Clinical\t  notes",
+                    HealthcareDescription = " health \t\t care  ",
+                    TreatmentRegimenOtherDescription = " treatment \t regimen "
+                },
+                HospitalDetails = new HospitalDetails {  Consultant = " Dr\tJohn\tDorian  " },
+                ImmunosuppressionDetails = new ImmunosuppressionDetails
+                {
+                    OtherDescription = "  immune  system\tsuppressed "
+                },
+                DenotificationDetails = new DenotificationDetails
+                {
+                    OtherDescription = "  notification was  a\tmistake   "
+                },
+                MDRDetails = new MDRDetails
+                {
+                    RelationshipToCase = "  mystery\tsolving partner   "
+                },
+                TestData = new TestData { ManualTestResults = new List<ManualTestResult>() },
+                NotificationSites = new List<NotificationSite>
+                {
+                    new NotificationSite { SiteDescription = " Hair\tand fingernails  "}
                 },
                 TreatmentEvents = new List<TreatmentEvent>
                 {
                     new TreatmentEvent{ EventDate = new DateTime(1899, 3, 3), Note = " A \tnote   " }
+                },
+                SocialContextAddresses = new List<SocialContextAddress>
+                {
+                    new SocialContextAddress
+                    {
+                        Address = " 221B\tBaker St., London   ",
+                        Details = "  Elementary,\tWatson ",
+                        Postcode = " NW1\t6XE  "
+                    }
+                },
+                SocialContextVenues = new List<SocialContextVenue>
+                {
+                    new SocialContextVenue
+                    {
+                        Address = "  32 Windsor\tGardens ",
+                        Details = "  Peruvian\tbears ",
+                        Name = "      Favourite bear's\thouse   ",
+                        Postcode = "  W9\t3RG "
+                    }
                 },
                 MBovisDetails = new MBovisDetails
                 {
@@ -220,10 +262,36 @@ namespace ntbs_service_unit_tests.DataMigration
             await _importValidator.CleanAndValidateNotification(null, RunId, notification);
 
             // Assert
+            Assert.Equal("Sher lock", notification.PatientDetails.GivenName);
+            Assert.Equal("Holm  es", notification.PatientDetails.FamilyName);
+            Assert.Equal("PatientID 1234", notification.PatientDetails.LocalPatientId);
+            Assert.Equal("123   Some Street", notification.PatientDetails.Address);
+            Assert.Equal("NW1 6XE", notification.PatientDetails.Postcode);
+            Assert.Equal("Detective  Work", notification.PatientDetails.OccupationOther);
+
             Assert.Equal("Clinical   notes", notification.ClinicalDetails.Notes);
-            Assert.Equal("Elementary, Watson", notification.SocialContextAddresses.First().Details);
-            Assert.Equal("Peruvian bears", notification.SocialContextVenues.First().Details);
+            Assert.Equal("health    care", notification.ClinicalDetails.HealthcareDescription);
+            Assert.Equal("treatment   regimen", notification.ClinicalDetails.TreatmentRegimenOtherDescription);
+
+            Assert.Equal("Dr John Dorian", notification.HospitalDetails.Consultant);
+            Assert.Equal("immune  system suppressed", notification.ImmunosuppressionDetails.OtherDescription);
+            Assert.Equal("notification was  a mistake", notification.DenotificationDetails.OtherDescription);
+            Assert.Equal("mystery solving partner", notification.MDRDetails.RelationshipToCase);
+
+            Assert.Equal("Hair and fingernails", notification.NotificationSites.First().SiteDescription);
             Assert.Equal("A  note", notification.TreatmentEvents.First().Note);
+
+            var socialContextAddress = notification.SocialContextAddresses.First();
+            Assert.Equal("221B Baker St., London", socialContextAddress.Address);
+            Assert.Equal("Elementary, Watson", socialContextAddress.Details);
+            Assert.Equal("NW1 6XE", socialContextAddress.Postcode);
+
+            var socialContextVenue = notification.SocialContextVenues.First();
+            Assert.Equal("32 Windsor Gardens", socialContextVenue.Address);
+            Assert.Equal("Peruvian bears", socialContextVenue.Details);
+            Assert.Equal("Favourite bear's house", socialContextVenue.Name);
+            Assert.Equal("W9 3RG", socialContextVenue.Postcode);
+
             Assert.Equal("His sister", notification.MBovisDetails.MBovisExposureToKnownCases.First().OtherDetails);
             Assert.Equal("A friend at work", notification.MBovisDetails.MBovisOccupationExposures.First().OtherDetails);
             Assert.Equal("Cows and  badgers", notification.MBovisDetails.MBovisAnimalExposures.First().OtherDetails);

--- a/ntbs-service/Models/Entities/MBovisDetails.cs
+++ b/ntbs-service/Models/Entities/MBovisDetails.cs
@@ -18,6 +18,7 @@ namespace ntbs_service.Models.Entities
         [AssertThat(nameof(ExposureToKnownCasesStatusIsValid), ErrorMessage = ValidationMessages.HasNoExposureRecords)]
         [Display(Name = "Has the patient been exposed to a known TB case?")]
         public Status? ExposureToKnownCasesStatus { get; set; }
+        [ValidationChildEnumerable]
         public virtual ICollection<MBovisExposureToKnownCase> MBovisExposureToKnownCases { get; set; }
 
         [NotMapped]
@@ -36,6 +37,7 @@ namespace ntbs_service.Models.Entities
         [AssertThat(nameof(UnpasteurisedMilkConsumptionStatusIsValid), ErrorMessage = ValidationMessages.HasNoUnpasteurisedMilkConsumptionRecords)]
         [Display(Name = "Has the patient consumed unpasteurised milk products?")]
         public Status? UnpasteurisedMilkConsumptionStatus { get; set; }
+        [ValidationChildEnumerable]
         public virtual ICollection<MBovisUnpasteurisedMilkConsumption> MBovisUnpasteurisedMilkConsumptions { get; set; }
 
         [NotMapped]
@@ -54,6 +56,7 @@ namespace ntbs_service.Models.Entities
         [AssertThat(nameof(OccupationExposureStatusIsValid), ErrorMessage = ValidationMessages.HasNoOccupationExposureRecords)]
         [Display(Name = "Is there a possible occupational exposure to M. bovis?")]
         public Status? OccupationExposureStatus { get; set; }
+        [ValidationChildEnumerable]
         public virtual ICollection<MBovisOccupationExposure> MBovisOccupationExposures { get; set; }
 
         [NotMapped]
@@ -72,6 +75,7 @@ namespace ntbs_service.Models.Entities
         [AssertThat(nameof(AnimalExposureStatusIsValid), ErrorMessage = ValidationMessages.HasNoAnimalExposureRecords)]
         [Display(Name = "Has the patient been exposed to animals?")]
         public Status? AnimalExposureStatus { get; set; }
+        [ValidationChildEnumerable]
         public virtual ICollection<MBovisAnimalExposure> MBovisAnimalExposures { get; set; }
 
         [NotMapped]

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -73,29 +73,50 @@ namespace ntbs_service.Models.Entities
         #region Navigation Properties
 
         [AssertThat("NotificationSites.Count > 0 || !ShouldValidateFull", ErrorMessage = ValidationMessages.DiseaseSiteIsRequired)]
+        [ValidationChildEnumerable]
         public virtual List<NotificationSite> NotificationSites { get; set; }
+        [ValidationChild]
         public virtual PatientDetails PatientDetails { get; set; }
+        [ValidationChild]
         public virtual ClinicalDetails ClinicalDetails { get; set; }
+        [ValidationChild]
         public virtual HospitalDetails HospitalDetails { get; set; }
+        [ValidationChild]
         public virtual PreviousTbHistory PreviousTbHistory { get; set; }
+        [ValidationChild]
         public virtual ContactTracing ContactTracing { get; set; }
+        [ValidationChild]
         public virtual SocialRiskFactors SocialRiskFactors { get; set; }
+        [ValidationChild]
         public virtual ImmunosuppressionDetails ImmunosuppressionDetails { get; set; }
+        [ValidationChild]
         public virtual TravelDetails TravelDetails { get; set; }
+        [ValidationChild]
         public virtual VisitorDetails VisitorDetails { get; set; }
+        [ValidationChild]
         public virtual DenotificationDetails DenotificationDetails { get; set; }
+        [ValidationChild]
         public virtual ComorbidityDetails ComorbidityDetails { get; set; }
+        [ValidationChild]
         public virtual MDRDetails MDRDetails { get; set; }
+        [ValidationChild]
         public virtual NotificationGroup Group { get; set; }
+        [ValidationChild]
         public virtual TestData TestData { get; set; }
+        [ValidationChild]
         public virtual MBovisDetails MBovisDetails { get; set; }
+        [ValidationChildEnumerable]
         public virtual ICollection<Alert> Alerts { get; set; }
         [Display(Name = "Social context - venues")]
+        [ValidationChildEnumerable]
         public virtual ICollection<SocialContextVenue> SocialContextVenues { get; set; }
         [Display(Name = "Social context - addresses")]
+        [ValidationChildEnumerable]
         public virtual ICollection<SocialContextAddress> SocialContextAddresses { get; set; }
         [Display(Name = "Treatment events")]
+        [ValidationChildEnumerable]
         public virtual ICollection<TreatmentEvent> TreatmentEvents { get; set; }
+        [ValidationChild]
         public virtual DrugResistanceProfile DrugResistanceProfile { get; set; }
         public virtual ICollection<PreviousTbService> PreviousTbServices { get; set; }
 

--- a/ntbs-service/Models/Entities/SocialRiskFactors.cs
+++ b/ntbs-service/Models/Entities/SocialRiskFactors.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using EFAuditer;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Enums;
+using ntbs_service.Models.Validations;
 
 namespace ntbs_service.Models.Entities
 {
@@ -29,12 +30,16 @@ namespace ntbs_service.Models.Entities
         public Status? ImmigrationDetaineeStatus { get; set; }
 
         [Display(Name = "History of smoking")]
+        [ValidationChild]
         public virtual RiskFactorDetails RiskFactorSmoking { get; set; }
         [Display(Name = "History of drug misuse")]
+        [ValidationChild]
         public virtual RiskFactorDetails RiskFactorDrugs { get; set; }
         [Display(Name = "History of homelessness")]
+        [ValidationChild]
         public virtual RiskFactorDetails RiskFactorHomelessness { get; set; }
         [Display(Name = "History of imprisonment")]
+        [ValidationChild]
         public virtual RiskFactorDetails RiskFactorImprisonment { get; set; }
 
         string IOwnedEntityForAuditing.RootEntityType => RootEntities.Notification;

--- a/ntbs-service/Models/Entities/TestData.cs
+++ b/ntbs-service/Models/Entities/TestData.cs
@@ -20,6 +20,7 @@ namespace ntbs_service.Models.Entities
         [RequiredIf(nameof(ShouldValidateFull), ErrorMessage = ValidationMessages.Mandatory)]
         [AssertThat(nameof(ResultAddedIfTestCarriedOut), ErrorMessage = ValidationMessages.NoTestResult)]
         public bool? HasTestCarriedOut { get; set; }
+        [ValidationChildEnumerable]
         public virtual ICollection<ManualTestResult> ManualTestResults { get; set; }
 
         [NotMapped]

--- a/ntbs-service/Models/Validations/ValidationChildAttribute.cs
+++ b/ntbs-service/Models/Validations/ValidationChildAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace ntbs_service.Models.Validations
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ValidationChildAttribute : Attribute
+    {
+    }
+
+    [AttributeUsage(AttributeTargets.Property)]
+    public class ValidationChildEnumerableAttribute : Attribute
+    {
+    }
+}


### PR DESCRIPTION
## Description
First draft of trimming whitespace of all free-text fields. I thought I would get this up for review before I went on holiday, and ask a few questions. 

The general approach is to modify the code used to clean all the `[ContainsNoTabs]` fields to hit every `string` in a notification. I have asked Nancy on the ticket whether this will cause any issues, and put a full list of fields that will get cleaned on there. I still need to amend the tests to cover the new strings being clean.