### PR TITLE
NTBS-2446 Ensure transfer request created before logging out

### DIFF
--- a/ntbs-ui-tests/Features/TransferNotification.feature
+++ b/ntbs-ui-tests/Features/TransferNotification.feature
@@ -16,11 +16,10 @@ Feature: Transfer notification
     And I enter Patient likes travel into 'TransferRequest_OtherReasonDescription'
     And I enter I hope your service is doing well into 'TransferRequest_TransferRequestNote'
     And I click on the 'confirm-transfer-button' button
-    And I wait
-    Then An alert has been created for the notification with type TransferRequest
+    Then I should see the Notification
+    And An alert has been created for the notification with type TransferRequest
 
   Scenario: Pending transfer page has correct values
-    Then I should see the Notification
     When I expand manage notification section
     And I click on the 'transfer-button' button
 

--- a/ntbs-ui-tests/Steps/AssertSteps.cs
+++ b/ntbs-ui-tests/Steps/AssertSteps.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
@@ -158,11 +158,11 @@ namespace ntbs_ui_tests.Steps
                 using (var context = new NtbsContext(options.Options))
                 {
                     var alertType = Enum.Parse<AlertType>(title);
-                    var alert = context.Alert
+                    var matchingAlertsForNotificationInTest = context.Alert
                         .Where(a => a.NotificationId.HasValue
                                     && TestContext.AddedNotificationIds.Contains(a.NotificationId.Value)
                                     && a.AlertType == alertType);
-                    Assert.NotNull(alert);
+                    Assert.NotEmpty(matchingAlertsForNotificationInTest);
                 }
             });
         }


### PR DESCRIPTION
I have determined that the alert is definitely not being created during the failed transfer test. This commit concentrates on improving the test so that we get a better indication as to why it fails. In particular:
- Fix a bug with the "alert has been created" assertion
- Make sure that the notification overview has loaded after clicking the confirm transfer button. If the confirm fails, we should then see an error page, which will be logged.