### PR TITLE
NTBS-2455: No longer show inactive users in case manager dropdowns

### DIFF
--- a/ntbs-integration-tests/Helpers/TestUser.cs
+++ b/ntbs-integration-tests/Helpers/TestUser.cs
@@ -26,6 +26,7 @@ namespace ntbs_integration_tests.Helpers
         public IEnumerable<string> AdGroups { get; }
         public IEnumerable<string> TbServiceCodes { get; }
         public bool IsReadOnly { get; }
+        public bool IsActive { get; }
 
         private TestUser(
             int id,
@@ -34,7 +35,8 @@ namespace ntbs_integration_tests.Helpers
             UserType type,
             IEnumerable<string> adGroups,
             IEnumerable<string> tbServiceCodes = null,
-            bool isReadOnly = false)
+            bool isReadOnly = false,
+            bool isActive = true)
         {
             Id = id;
             Username = username;
@@ -43,6 +45,7 @@ namespace ntbs_integration_tests.Helpers
             AdGroups = adGroups;
             TbServiceCodes = tbServiceCodes ?? new List<string>();
             IsReadOnly = isReadOnly;
+            IsActive = isActive;
         }
 
         public static IEnumerable<TestUser> GetAll() => new[]
@@ -55,6 +58,7 @@ namespace ntbs_integration_tests.Helpers
             AbingdonCaseManager2,
             GatesheadCaseManager,
             GatesheadCaseManager2,
+            InactiveGatesheadCaseManager,
             Developer,
             ReadOnlyUser
         };
@@ -123,6 +127,15 @@ namespace ntbs_integration_tests.Helpers
             UserType.NhsUser,
             new[] { "App.Auth.NIS.NTBS.Service_Gateshead" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID });
+
+        public static TestUser InactiveGatesheadCaseManager = new TestUser(
+            Utilities.CASEMANAGER_GATESHEAD_INACTIVE_ID,
+            Utilities.CASEMANAGER_GATESHEAD_INACTIVE_EMAIL,
+            Utilities.CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME,
+            UserType.NhsUser,
+            new[] { "App.Auth.NIS.NTBS.Service_Gateshead" },
+            tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID },
+            isActive: false);
 
         public static TestUser Developer = new TestUser(
             7890,

--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -38,6 +38,7 @@ namespace ntbs_integration_tests.Helpers
         public const int NOTIFIED_WITH_TBSERVICE = 10041;
         public const int DRAFT_WITH_TBSERVICE = 10042;
         public const int NOTIFIED_WITH_ACTIVE_HOSPITAL = 10043;
+        public const int NOTIFIED_WITH_INACTIVE_CASEMANAGER = 10111;
         public const int NOTIFIED_WITH_LEGACY_HOSPITAL = 10044;
         public const int MDR_DETAILS_EXIST = 10050;
 
@@ -131,14 +132,17 @@ namespace ntbs_integration_tests.Helpers
         public const string PERMITTED_POSTCODE = "TW153AA";
         public const string UNPERMITTED_POSTCODE = "NW51TL";
         public const string CASEMANAGER_ABINGDON_EMAIL = "pheNtbs_nhsUser2@ntbs.phe.com";
+        public const string CASEMANAGER_ABINGDON_EMAIL2 = "pheNtbs_nhsUser3@ntbs.phe.com";
         public const int CASEMANAGER_ABINGDON_ID = 1234;
-        public const string CASEMANAGER_GATESHEAD_EMAIL1 = "pheNtbs_nhsUser_gateshead1@ntbs.phe.com";
         public const int CASEMANAGER_GATESHEAD_ID1 = 5431;
-        public const string CASEMANAGER_GATESHEAD_EMAIL2 = "pheNtbs_nhsUser_gateshead2@ntbs.phe.com";
+        public const string CASEMANAGER_GATESHEAD_EMAIL1 = "pheNtbs_nhsUser_gateshead1@ntbs.phe.com";
         public const string CASEMANAGER_GATESHEAD_DISPLAY_NAME1 = "Gateshead User 1";
         public const int CASEMANAGER_GATESHEAD_ID2 = 5432;
-        public const string CASEMANAGER_ABINGDON_EMAIL2 = "pheNtbs_nhsUser3@ntbs.phe.com";
+        public const string CASEMANAGER_GATESHEAD_EMAIL2 = "pheNtbs_nhsUser_gateshead2@ntbs.phe.com";
         public const string CASEMANAGER_GATESHEAD_DISPLAY_NAME2 = "Gateshead User 2";
+        public const int CASEMANAGER_GATESHEAD_INACTIVE_ID = 5433;
+        public const string CASEMANAGER_GATESHEAD_INACTIVE_EMAIL = "pheNtbs_nhsUser_gateshead3@ntbs.phe.com";
+        public const string CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME = "Gateshead Inactive User";
 
         public static void SeedDatabase(NtbsContext context)
         {
@@ -201,9 +205,9 @@ namespace ntbs_integration_tests.Helpers
                 Username = user.Username,
                 DisplayName = user.DisplayName,
                 AdGroups = string.Join(',', user.AdGroups),
-                IsActive = true,
                 IsCaseManager = true,
-                IsReadOnly = user.IsReadOnly
+                IsReadOnly = user.IsReadOnly,
+                IsActive = user.IsActive
             });
         }
 

--- a/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
@@ -58,6 +58,17 @@ namespace ntbs_integration_tests.NotificationPages
                 },
                 new Notification
                 {
+                    NotificationId = Utilities.NOTIFIED_WITH_INACTIVE_CASEMANAGER,
+                    NotificationStatus = NotificationStatus.Notified,
+                    HospitalDetails = new HospitalDetails
+                    {
+                        TBServiceCode = Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID,
+                        HospitalId = Guid.Parse(Utilities.HOSPITAL_SOUTH_TYNESIDE_DISTRICT_HOSPITAL_ID),
+                        CaseManagerId = Utilities.CASEMANAGER_GATESHEAD_INACTIVE_ID,
+                    }
+                },
+                new Notification
+                {
                     NotificationId = Utilities.NOTIFIED_WITH_LEGACY_HOSPITAL,
                     NotificationStatus = NotificationStatus.Notified,
                     HospitalDetails = new HospitalDetails
@@ -282,6 +293,46 @@ namespace ntbs_integration_tests.NotificationPages
                 ["HospitalDetails.TBServiceCode"] = Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID,
                 ["HospitalDetails.Consultant"] = "Consultant",
                 ["HospitalDetails.CaseManagerId"] = Utilities.CASEMANAGER_ABINGDON_ID.ToString(),
+                ["FormattedNotificationDate.Day"] = "1",
+                ["FormattedNotificationDate.Month"] = "1",
+                ["FormattedNotificationDate.Year"] = "2012",
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(initialDocument, formData, url);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Redirect, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task OnGetNotifiedWithInactiveCaseManager_HasCaseManagerInDropdown()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_WITH_INACTIVE_CASEMANAGER;
+            var url = GetCurrentPathForId(id);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+
+            // Assert
+            var caseManagerDropdown = initialDocument.GetElementById("HospitalDetails_CaseManagerId");
+            Assert.Contains(Utilities.CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME, caseManagerDropdown.Children.Select(c => c.TextContent));
+        }
+
+        [Fact]
+        public async Task PostNotified_WithInactiveCaseManager_RedirectToNextPage_IfModelIsValid()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_WITH_INACTIVE_CASEMANAGER;
+            var url = GetCurrentPathForId(id);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+                ["HospitalDetails.HospitalId"] = Utilities.HOSPITAL_DUNSTON_HILL_HOSPITAL_GATESHEAD_ID,
+                ["HospitalDetails.TBServiceCode"] = Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID,
+                ["HospitalDetails.Consultant"] = "Consultant",
+                ["HospitalDetails.CaseManagerId"] = Utilities.CASEMANAGER_GATESHEAD_INACTIVE_ID.ToString(),
                 ["FormattedNotificationDate.Day"] = "1",
                 ["FormattedNotificationDate.Month"] = "1",
                 ["FormattedNotificationDate.Year"] = "2012",

--- a/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using AngleSharp.Html.Dom;
 using Newtonsoft.Json;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
@@ -314,8 +315,24 @@ namespace ntbs_integration_tests.NotificationPages
             var initialDocument = await GetDocumentForUrlAsync(url);
 
             // Assert
-            var caseManagerDropdown = initialDocument.GetElementById("HospitalDetails_CaseManagerId");
-            Assert.Contains(Utilities.CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME, caseManagerDropdown.Children.Select(c => c.TextContent));
+            var caseManagerDropdown = (IHtmlSelectElement)initialDocument.GetElementById("HospitalDetails_CaseManagerId");
+            Assert.Contains(Utilities.CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME, caseManagerDropdown.Options.Select(c => c.Label));
+        }
+
+        [Fact]
+        public async Task OnGetNotifiedWithActiveCaseManager_HasNoInactiveCaseManagerInDropdown()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_WITH_ACTIVE_HOSPITAL;
+            var url = GetCurrentPathForId(id);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+
+            // Assert
+            var caseManagerDropdown = (IHtmlSelectElement)initialDocument.GetElementById("HospitalDetails_CaseManagerId");
+            var caseManagerOptions = caseManagerDropdown.Options
+                .Where(option => !string.IsNullOrEmpty(option.Value))
+                .Select(option => new OptionValue {Text = option.TextContent, Value = option.Value});
+            AssertAreGatesheadCaseManagers(caseManagerOptions);
         }
 
         [Fact]

--- a/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
@@ -412,7 +412,7 @@ namespace ntbs_service_unit_tests.Services
 
             _mockUserService.Setup(c => c.GetDefaultTbService(mockPrincipal1.Object)).Returns(Task.FromResult(tbService));
             _mockReferenceDataRepository
-                .Setup(c => c.GetCaseManagersByTbServiceCodesAsync(new List<string> { serviceCode }))
+                .Setup(c => c.GetActiveCaseManagersByTbServiceCodesAsync(new List<string> { serviceCode }))
                 .Returns(Task.FromResult((IList<User>)(new List<User> { user1, user2 })));
 
             // Act

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml.cs
@@ -122,7 +122,7 @@ namespace ntbs_service.Pages.Alerts
         {
             var tbServices = await _referenceDataRepository.GetAllTbServicesAsync();
             TbServices = new SelectList(tbServices, nameof(TBService.Code), nameof(TBService.Name));
-            var caseManagers = await _referenceDataRepository.GetAllCaseManagers();
+            var caseManagers = await _referenceDataRepository.GetAllActiveCaseManagers();
             CaseManagers = new SelectList(caseManagers,
                 nameof(Models.Entities.User.Id),
                 nameof(Models.Entities.User.DisplayName));
@@ -160,7 +160,7 @@ namespace ntbs_service.Pages.Alerts
         public async Task<JsonResult> OnGetFilteredCaseManagersListByTbServiceCode(string value)
         {
             var filteredCaseManagers =
-                await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(new List<string> { value });
+                await _referenceDataRepository.GetActiveCaseManagersByTbServiceCodesAsync(new List<string> { value });
 
             return new JsonResult(
                 new FilteredCaseManagerList

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -86,7 +86,7 @@ namespace ntbs_service.Pages.Alerts
             Hospitals = new SelectList(hospitals,
                 nameof(Hospital.HospitalId),
                 nameof(Hospital.Name));
-            var caseManagers = await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(
+            var caseManagers = await _referenceDataRepository.GetActiveCaseManagersByTbServiceCodesAsync(
                 new List<string> { TransferAlert.TbServiceCode });
             CaseManagers = new SelectList(caseManagers,
                 nameof(Models.Entities.User.Id),

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -98,7 +98,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
             Hospitals = new SelectList(hospitals, nameof(Hospital.HospitalId), nameof(Hospital.Name));
 
-            var caseManagers = await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(tbServiceCodes);
+            var caseManagers = await GetCaseManagerDropdownValues(tbServiceCodes);
             CaseManagers = new SelectList(
                 caseManagers,
                 nameof(Models.Entities.User.Id),
@@ -169,6 +169,17 @@ namespace ntbs_service.Pages.Notifications.Edit
             await GetRelatedEntities();
         }
 
+        private async Task<IList<User>> GetCaseManagerDropdownValues(IList<string> tbServiceCodes)
+        {
+            var caseManagersToReturn = await _referenceDataRepository.GetActiveCaseManagersByTbServiceCodesAsync(tbServiceCodes);
+            if (HospitalDetails.CaseManager?.IsActive == false)
+            {
+                caseManagersToReturn.Add(Notification.HospitalDetails.CaseManager);
+            }
+
+            return caseManagersToReturn;
+        }
+
         private async Task GetRelatedEntities()
         {
             if (HospitalDetails.HospitalId.HasValue)
@@ -194,7 +205,7 @@ namespace ntbs_service.Pages.Notifications.Edit
                 await GetActiveOrCurrentHospitalsByTbServiceCodesAsync(tbServiceCodeAsList, notification);
 
             var filteredCaseManagers =
-                await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(tbServiceCodeAsList);
+                await _referenceDataRepository.GetActiveCaseManagersByTbServiceCodesAsync(tbServiceCodeAsList);
 
             var filteredHospitalDetailsPageSelectLists = new FilteredHospitalDetailsPageSelectLists
             {

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -452,7 +452,7 @@ namespace ntbs_service.Services
         private async Task<int?> GetDefaultCaseManagerId(ClaimsPrincipal user, string tbServiceCode)
         {
             var caseManagersForTbService =
-                await _referenceDataRepository.GetCaseManagersByTbServiceCodesAsync(new List<string> { tbServiceCode });
+                await _referenceDataRepository.GetActiveCaseManagersByTbServiceCodesAsync(new List<string> { tbServiceCode });
             var username = user.Username();
             var upperUserEmail = username?.ToUpperInvariant();
 


### PR DESCRIPTION
## Description
Filter case manager dropdowns so that they only show active case managers. 
For hospital details in the case that the current case manager is inactive (either due to it being a legacy case manager OR the user sync has made the user inactive) the dropdown contains this case manager as an option.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
