### PR TITLE
NTBS-2478: No longer add seed treatment outcome to notification

### DIFF
--- a/ntbs-service-unit-tests/Models/Entities/NotificationTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/NotificationTest.cs
@@ -71,7 +71,7 @@ namespace ntbs_service_unit_tests.Models.Entities
         }
 
         [Fact]
-        public void ShouldBeClosedThrowsExceptionWhenOutcomeNotLoaded()
+        public void ShouldBeClosedFalseWhenFetchedOutcomeIsStillOnTreatment()
         {
             // Arrange
             var notification = new Notification
@@ -81,7 +81,7 @@ namespace ntbs_service_unit_tests.Models.Entities
                     new TreatmentEvent
                     {
                         TreatmentEventType = TreatmentEventType.TreatmentOutcome,
-                        TreatmentOutcomeId = 7,
+                        TreatmentOutcomeId = 16,
                         TreatmentOutcome = null,
                         EventDate = new DateTime(2003, 4, 15)
                     }
@@ -89,7 +89,7 @@ namespace ntbs_service_unit_tests.Models.Entities
             };
 
             // Assert
-            Assert.Throws<ApplicationException>(() => notification.ShouldBeClosed());
+            Assert.False(notification.ShouldBeClosed());
         }
     }
 }

--- a/ntbs-service/DataMigration/TreatmentEventMapper.cs
+++ b/ntbs-service/DataMigration/TreatmentEventMapper.cs
@@ -49,11 +49,6 @@ namespace ntbs_service.DataMigration
                 TreatmentOutcomeId = rawEvent.TreatmentOutcomeId,
                 Note = rawEvent.Note
             };
-            if (ev.TreatmentOutcomeId != null)
-            {
-                ev.TreatmentOutcome = Models.SeedData.TreatmentOutcomes.GetTreatmentOutcomes()
-                    .Single(oc => oc.TreatmentOutcomeId == ev.TreatmentOutcomeId);
-            }
 
             await TryAddTbServiceAndCaseManagerToTreatmentEvent(ev, rawEvent.NtbsHospitalId, rawEvent.CaseManager);
 

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -122,12 +122,11 @@ namespace ntbs_service.Models.Entities
 
             bool NotStillOnTreatmentAndOlderThanOneYear(TreatmentEvent treatmentEvent)
             {
-                if (treatmentEvent.TreatmentOutcome == null)
-                {
-                    throw new ApplicationException("ShouldBeClosed cannot be called without loaded outcome events.");
-                }
+                var treatmentOutcome = treatmentEvent.TreatmentOutcome
+                                       ?? SeedData.TreatmentOutcomes.GetTreatmentOutcomes()
+                                           .Single(oc => oc.TreatmentOutcomeId == treatmentEvent.TreatmentOutcomeId);
 
-                return treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType != TreatmentOutcomeSubType.StillOnTreatment 
+                return treatmentOutcome.TreatmentOutcomeSubType != TreatmentOutcomeSubType.StillOnTreatment 
                        && treatmentEvent.EventDate < DateTime.Today.AddYears(-1);
             }
         }


### PR DESCRIPTION
## Description
Move the fetching of treatment outcome to the ShouldBeClosed method.
Removed the exception, changed the test to check that the method is fetching the outcome and then properly setting ShouldBeClosed.

## Checklist:
- [x] Automated tests are passing locally.
