### PR TITLE
NTBS-2459 Add Application Insights Profiler

### DIFF
--- a/ntbs-service/Properties/ApplicationInsightsOptions.cs
+++ b/ntbs-service/Properties/ApplicationInsightsOptions.cs
@@ -4,6 +4,9 @@
     {
         public bool? Enabled { get; set; }
         public bool? EnableSqlCommandTextInstrumentation { get; set; }
+        public bool? EnableProfiler { get; set; }
+        public float? RandomProfilingOverhead { get; set; }
+        public int? ProfilerDurationSeconds { get; set; }
         public string ConnectionString { get; set; }
     }
 }

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -495,6 +495,16 @@ namespace ntbs_service
                     module.EnableSqlCommandTextInstrumentation =
                         applicationInsightsOptions.EnableSqlCommandTextInstrumentation ?? false;
                 });
+
+                if (applicationInsightsOptions.EnableProfiler == true)
+                {
+                    services.AddServiceProfiler(options =>
+                    {
+                        options.RandomProfilingOverhead = applicationInsightsOptions.RandomProfilingOverhead ?? 0.05F;
+                        options.Duration =
+                            TimeSpan.FromSeconds(applicationInsightsOptions.ProfilerDurationSeconds ?? 120);
+                    });
+                }
             }
             else
             {

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -18,6 +18,9 @@
   "ApplicationInsightsOptions": {
     "Enabled": false,
     "EnableSqlCommandTextInstrumentation": false,
+    "EnableProfiler": false,
+    "RandomProfilingOverhead": 0.05,
+    "ProfilerDurationSeconds": 120,
     "ConnectionString": ""
   },
   "AppConfig": {

--- a/ntbs-service/deployments/load-test.yml
+++ b/ntbs-service/deployments/load-test.yml
@@ -81,6 +81,8 @@ spec:
             value: "true"
           - name: ApplicationInsightsOptions__EnableSqlCommandTextInstrumentation
             value: "true"
+          - name: ApplicationInsightsOptions__EnableProfiler
+            value: "false"
         resources:
           limits:
             cpu: 500m

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Markdig" Version="0.24.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.17.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.6" />


### PR DESCRIPTION
## Description
Add Application Insights Profiler, and relevant options to config. 

I've tested this locally and this works, but I don't know how useful the profiling will actually be (most of the stuff seems to be calls to Sentry, so the Application Insights might not be playing nicely with Sentry).

## Checklist:
- [x] Automated tests are passing locally.