### PR TITLE
NTBS-2494 Expand the MBovis OtherDetails fields

### DIFF
--- a/ntbs-service/Migrations/20210629101707_ExpandMBovisExposuresOtherDetails.Designer.cs
+++ b/ntbs-service/Migrations/20210629101707_ExpandMBovisExposuresOtherDetails.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210629101707_ExpandMBovisExposuresOtherDetails")]
+    partial class ExpandMBovisExposuresOtherDetails
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210629101707_ExpandMBovisExposuresOtherDetails.cs
+++ b/ntbs-service/Migrations/20210629101707_ExpandMBovisExposuresOtherDetails.cs
@@ -1,0 +1,101 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class ExpandMBovisExposuresOtherDetails : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisUnpasteurisedMilkConsumption",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(150)",
+                oldMaxLength: 150,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisOccupationExposures",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(200)",
+                oldMaxLength: 200,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisExposureToKnownCase",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(150)",
+                oldMaxLength: 150,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisAnimalExposure",
+                type: "nvarchar(250)",
+                maxLength: 250,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(150)",
+                oldMaxLength: 150,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisUnpasteurisedMilkConsumption",
+                type: "nvarchar(150)",
+                maxLength: 150,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisOccupationExposures",
+                type: "nvarchar(200)",
+                maxLength: 200,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisExposureToKnownCase",
+                type: "nvarchar(150)",
+                maxLength: 150,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "OtherDetails",
+                table: "MBovisAnimalExposure",
+                type: "nvarchar(150)",
+                maxLength: 150,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(250)",
+                oldMaxLength: 250,
+                oldNullable: true);
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/MBovisAnimalExposure.cs
+++ b/ntbs-service/Models/Entities/MBovisAnimalExposure.cs
@@ -49,7 +49,7 @@ namespace ntbs_service.Models.Entities
         public int? CountryId { get; set; }
         public virtual Country Country { get; set; }
 
-        [MaxLength(150)]
+        [MaxLength(250)]
         [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,

--- a/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
+++ b/ntbs-service/Models/Entities/MBovisExposureToKnownCase.cs
@@ -42,7 +42,7 @@ namespace ntbs_service.Models.Entities
             || NotificationId == default
             || ExposureNotificationId.Value != NotificationId;
 
-        [MaxLength(150)]
+        [MaxLength(250)]
         [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,

--- a/ntbs-service/Models/Entities/MBovisOccupationExposure.cs
+++ b/ntbs-service/Models/Entities/MBovisOccupationExposure.cs
@@ -39,7 +39,7 @@ namespace ntbs_service.Models.Entities
         public int? CountryId { get; set; }
         public virtual Country Country { get; set; }
 
-        [MaxLength(200)]
+        [MaxLength(250)]
         [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,

--- a/ntbs-service/Models/Entities/MBovisUnpasteurisedMilkConsumption.cs
+++ b/ntbs-service/Models/Entities/MBovisUnpasteurisedMilkConsumption.cs
@@ -38,7 +38,7 @@ namespace ntbs_service.Models.Entities
         public int? CountryId { get; set; }
         public virtual Country Country { get; set; }
 
-        [MaxLength(150)]
+        [MaxLength(250)]
         [ContainsNoTabs]
         [RegularExpression(
             ValidationRegexes.CharacterValidationWithNumbersForwardSlashExtendedWithNewLine,


### PR DESCRIPTION
## Description
Expand the OtherDetails fields for MBovis Animal Exposure, Exposure to Known Cases, Occupation Exposure and Unpasteurised Milk Consumption from 150 nvarchars to 250.

## Checklist:
- [x] Automated tests are passing locally.