### PR TITLE
NTBS-NONE Increase header buffer sizes in Azure nginx

### DIFF
--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -107,6 +107,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      http2_max_header_size 16k;
+      http2_max_field_size 16k;
 spec:
   tls:
     - hosts:

--- a/ntbs-service/deployments/load-test.yml
+++ b/ntbs-service/deployments/load-test.yml
@@ -110,6 +110,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      http2_max_header_size 16k;
+      http2_max_field_size 16k;
 spec:
   tls:
     - hosts:

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -111,6 +111,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    nginx.ingress.kubernetes.io/server-snippet: |
+        http2_max_header_size 16k;
+        http2_max_field_size 16k;
 spec:
   tls:
     - hosts:

--- a/ntbs-service/deployments/training.yml
+++ b/ntbs-service/deployments/training.yml
@@ -107,6 +107,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      http2_max_header_size 16k;
+      http2_max_field_size 16k;
 spec:
   tls:
     - hosts:

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -107,6 +107,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/proxy-buffer-size: 16k
+    nginx.ingress.kubernetes.io/server-snippet: |
+      http2_max_header_size 16k;
+      http2_max_field_size 16k;
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
## Description
Fix a weird issue where IE11 was not able to go through the OIDC authentication flow and let the users sign in, probably because the cookies were too big.

This has been tested on `test` using a hotfix image already.

Some links that helped me track this issue down:
* [An Identity Server issue](https://github.com/IdentityServer/IdentityServer4/issues/3101)
* [A kubernetes-nginx issue](https://github.com/kubernetes/ingress-nginx/issues/3499)
* [StackOverflow, to write the Kubernetes YAML](https://stackoverflow.com/a/63195215)
* Our nginx logs for one of these during one of these failures
![sketchy_nginx_logs](https://user-images.githubusercontent.com/3650110/123819495-bb897d80-d8f1-11eb-92ec-871182a96675.png)
