### PR TITLE
Ntbs 2446 transfer UI test

### DIFF
--- a/ntbs-ui-tests/Features/CreateNotifications.feature
+++ b/ntbs-ui-tests/Features/CreateNotifications.feature
@@ -85,7 +85,7 @@ Feature: Notification creation
     And I wait
     And I select SOLIHULL HOSPITAL for 'HospitalDetails_HospitalId'
     And I enter Dr Lawton into 'HospitalDetails_Consultant'
-    And I enter Birmingham UITester into 'HospitalDetails_CaseManagerId'
+    And I select Birmingham UITester for 'HospitalDetails_CaseManagerId'
     When I click on the 'submit-button' button
 
     Then I can see the value 'Birmingham & Solihull' for the field 'tb-service' in the 'HospitalDetails' overview section
@@ -100,7 +100,7 @@ Feature: Notification creation
     When I check 'NotificationSiteMap_PULMONARY_'
     And I check 'bcg-vaccination-yes'
     And I enter 1990 into 'ClinicalDetails_BCGVaccinationYear'
-    And I enter Not offered into 'ClinicalDetails_HIVTestState'
+    And I select Not offered for 'ClinicalDetails_HIVTestState'
     And I check 'symptomatic-yes'
     And I enter 2 into 'FormattedSymptomDate_Day'
     And I enter 2 into 'FormattedSymptomDate_Month'
@@ -162,9 +162,9 @@ Feature: Notification creation
     And I enter 1 into 'FormattedTestDate_Day'
     And I enter 1 into 'FormattedTestDate_Month'
     And I enter 2012 into 'FormattedTestDate_Year'
-    And I enter Smear into 'TestResultForEdit_ManualTestTypeId'
-    And I enter BronchialWashings into 'TestResultForEdit_SampleTypeId'
-    And I enter Negative into 'TestResultForEdit_Result'
+    And I select Smear for 'TestResultForEdit_ManualTestTypeId'
+    And I make selection 1 from Respiratory section for 'TestResultForEdit_SampleTypeId'
+    And I select Negative for 'TestResultForEdit_Result'
     And I click on the 'save-test-result-button' button
     When I click on the 'submit-button' button
 
@@ -314,11 +314,11 @@ Feature: Notification creation
     When I click 'Social context - venues' on the navigation bar
     Then I should be on the SocialContextVenues page
     When I click on the 'add-new-social-context-venue-button' button
-    And I enter Catering into 'Venue_VenueTypeId'
+    And I select Catering for 'Venue_VenueTypeId'
     And I enter Nandos into 'Venue_Name'
     And I enter 445 Star Gates into 'Venue_Address'
     And I enter S55 4EP into 'Venue_Postcode'
-    And I enter Monthly into 'Venue_Frequency'
+    And I select Monthly for 'Venue_Frequency'
     And I enter 23 into 'FormattedDateFrom_Day'
     And I enter 3 into 'FormattedDateFrom_Month'
     And I enter 2003 into 'FormattedDateFrom_Year'
@@ -354,9 +354,9 @@ Feature: Notification creation
     And I enter 31 into 'FormattedEventDate_Day'
     And I enter 1 into 'FormattedEventDate_Month'
     And I enter 2019 into 'FormattedEventDate_Year'
-    And I enter Treatment outcome into 'treatmentevent-type'
-    And I enter Cured into 'treatmentoutcome-type'
-    And I enter Multi-drug resistant regimen into 'treatmentoutcome-subtype'
+    And I select Treatment outcome for 'treatmentevent-type'
+    And I select Cured for 'treatmentoutcome-type'
+    And I select Multi-drug resistant regimen for 'treatmentoutcome-subtype'
     And I enter He did it into 'treatmentevent-note'
     And I click on the 'save-treatment-event-button' button
     And I wait

--- a/ntbs-ui-tests/Features/EditNotifications.feature
+++ b/ntbs-ui-tests/Features/EditNotifications.feature
@@ -50,7 +50,7 @@ Feature: Notification editing
     And I wait
     And I select GOOD HOPE HOSPITAL for 'HospitalDetails_HospitalId'
     And I enter Dr Howard Foreman into 'HospitalDetails_Consultant'
-    And I enter Birmingham UITester into 'HospitalDetails_CaseManagerId'
+    And I select Birmingham UITester for 'HospitalDetails_CaseManagerId'
     When I click on the 'save-button' button
 
     Then I can see the value 'Birmingham & Solihull' for the field 'tb-service' in the 'HospitalDetails' overview section
@@ -67,7 +67,7 @@ Feature: Notification editing
     And I check 'NotificationSiteMap_BONE_SPINE_'
     And I check 'NotificationSiteMap_CRYPTIC_'
     And I check 'bcg-vaccination-no'
-    And I enter Offered and done into 'ClinicalDetails_HIVTestState'
+    And I select Offered and done for 'ClinicalDetails_HIVTestState'
     And I check 'symptomatic-yes'
     And I enter 1 into 'FormattedSymptomDate_Day'
     And I enter 2 into 'FormattedSymptomDate_Month'
@@ -124,9 +124,9 @@ Feature: Notification editing
     And I enter 11 into 'FormattedTestDate_Day'
     And I enter 3 into 'FormattedTestDate_Month'
     And I enter 2011 into 'FormattedTestDate_Year'
-    And I enter Histology into 'TestResultForEdit_ManualTestTypeId'
-    And I enter Bone and joint into 'TestResultForEdit_SampleTypeId'
-    And I enter Negative into 'TestResultForEdit_Result'
+    And I select Histology for 'TestResultForEdit_ManualTestTypeId'
+    And I make selection 7 from Non-Respiratory section for 'TestResultForEdit_SampleTypeId'
+    And I select Negative for 'TestResultForEdit_Result'
     And I click on the 'save-test-result-button' button
     When I click on the 'save-button' button
 
@@ -265,11 +265,11 @@ Feature: Notification editing
     When I go to edit the 'SocialContextVenues' section
     Then I should be on the SocialContextVenues page
     When I click on the Edit link
-    And I enter Nursery into 'Venue_VenueTypeId'
+    And I select Nursery for 'Venue_VenueTypeId'
     And I enter McDonalds into 'Venue_Name'
     And I enter 666 Stan Drive into 'Venue_Address'
     And I enter LS6 2EB into 'Venue_Postcode'
-    And I enter Daily into 'Venue_Frequency'
+    And I select Daily for 'Venue_Frequency'
     And I enter 4 into 'FormattedDateFrom_Day'
     And I enter 4 into 'FormattedDateFrom_Month'
     And I enter 2004 into 'FormattedDateFrom_Year'
@@ -307,9 +307,9 @@ Feature: Notification editing
     And I enter 5 into 'FormattedEventDate_Day'
     And I enter 4 into 'FormattedEventDate_Month'
     And I enter 2012 into 'FormattedEventDate_Year'
-    And I enter Treatment outcome into 'treatmentevent-type'
-    And I enter Lost to follow-up into 'treatmentoutcome-type'
-    And I enter Patient left UK into 'treatmentoutcome-subtype'
+    And I select Treatment outcome for 'treatmentevent-type'
+    And I select Lost to follow-up for 'treatmentoutcome-type'
+    And I select Patient left UK for 'treatmentoutcome-subtype'
     And I enter Moved to Yemen we think into 'treatmentevent-note'
     And I click on the 'save-treatment-event-button' button
     And I click on the Notification details link

--- a/ntbs-ui-tests/Features/TransferNotification.feature
+++ b/ntbs-ui-tests/Features/TransferNotification.feature
@@ -8,10 +8,10 @@ Feature: Transfer notification
 
     When I expand manage notification section
     And I click on the 'transfer-button' button
-    And I enter Yorkshire and Humber into 'PhecCode'
-    And I enter LCHC (Leeds Community Healthcare NHS Trust) into 'TransferRequest_TbServiceCode'
+    And I select Yorkshire and Humber for 'PhecCode'
+    And I select LCHC (Leeds Community Healthcare NHS Trust) for 'TransferRequest_TbServiceCode'
     And I wait
-    And I enter Leeds UITester into 'TransferRequest_CaseManagerId'
+    And I select Leeds UITester for 'TransferRequest_CaseManagerId'
     And I check 'transfer-radio-Other'
     And I enter Patient likes travel into 'TransferRequest_OtherReasonDescription'
     And I enter I hope your service is doing well into 'TransferRequest_TransferRequestNote'

--- a/ntbs-ui-tests/Features/TransferNotification.feature
+++ b/ntbs-ui-tests/Features/TransferNotification.feature
@@ -9,8 +9,8 @@ Feature: Transfer notification
     When I expand manage notification section
     And I click on the 'transfer-button' button
     And I select Yorkshire and Humber for 'PhecCode'
+    And I wait for Bath to be missing from 'TransferRequest_TbServiceCode'
     And I select LCHC (Leeds Community Healthcare NHS Trust) for 'TransferRequest_TbServiceCode'
-    And I wait
     And I select Leeds UITester for 'TransferRequest_CaseManagerId'
     And I check 'transfer-radio-Other'
     And I enter Patient likes travel into 'TransferRequest_OtherReasonDescription'


### PR DESCRIPTION
Update UI tests to prefer selecting elements from dropdowns, rather than entering text.

Update the transfer tests so that we wait for prior API calls to complete before making the next selection. I wasn't able to identify a specific bug that this fixed, but I'm optimistic that it will make the test less flaky.

## Checklist:
- [x] Automated tests are passing locally.