### PR TITLE
NTBS-2514: Don't show inactive users in service directory

### DIFF
--- a/ntbs-integration-tests/ServiceDirectory/ServiceDirectoryRegionPageTest.cs
+++ b/ntbs-integration-tests/ServiceDirectory/ServiceDirectoryRegionPageTest.cs
@@ -1,0 +1,32 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_service;
+using Xunit;
+
+namespace ntbs_integration_tests.ServiceDirectory
+{
+    public class ServiceDirectoryRegionPageTest : TestRunnerBase
+    {
+        public ServiceDirectoryRegionPageTest(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
+
+        public const string PageRoute = "ServiceDirectory/Region/E45000009";
+
+        [Fact]
+        public async Task GetRegionPage_IncludesOnlyActiveUsers()
+        {
+            // Arrange
+            var initialPage = await Client.GetAsync(PageRoute);
+            var pageContent = await GetDocumentAsync(initialPage);
+
+            // Act
+            var gatesheadSection = pageContent.GetElementsByClassName("govuk-accordion__section")
+                .Single(elem => elem.TextContent.Contains("Gateshead"));
+
+            // Assert
+            Assert.Contains(Utilities.CASEMANAGER_GATESHEAD_DISPLAY_NAME1, gatesheadSection.TextContent);
+            Assert.Contains(Utilities.CASEMANAGER_GATESHEAD_DISPLAY_NAME2, gatesheadSection.TextContent);
+            Assert.DoesNotContain(Utilities.CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME, gatesheadSection.TextContent);
+        }
+    }
+}

--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -50,7 +50,7 @@ namespace ntbs_service.DataAccess
         Task<IList<TreatmentOutcome>> GetTreatmentOutcomesForType(TreatmentOutcomeType type);
         Task<TreatmentOutcome> GetTreatmentOutcomeForTypeAndSubType(TreatmentOutcomeType type, TreatmentOutcomeSubType? subType);
         Task<string> GetLocationPhecCodeForPostcodeAsync(string postcode);
-        Task<IList<User>> GetUsersByPhecAdGroup(string phecAdGroup);
+        Task<IList<User>> GetActiveUsersByPhecAdGroup(string phecAdGroup);
         Task<IList<PHEC>> GetPhecsByAdGroups(string adGroups);
     }
 
@@ -321,9 +321,9 @@ namespace ntbs_service.DataAccess
                 .ToListAsync();
         }
 
-        public async Task<IList<User>> GetUsersByPhecAdGroup(string phecAdGroup)
+        public async Task<IList<User>> GetActiveUsersByPhecAdGroup(string phecAdGroup)
         {
-            return await _context.User.Where(u => u.AdGroups.Contains(phecAdGroup)).ToListAsync();
+            return await _context.User.Where(u => u.AdGroups.Contains(phecAdGroup) && u.IsActive).ToListAsync();
         }
 
         public async Task<IList<PHEC>> GetPhecsByAdGroups(string adGroupsString)

--- a/ntbs-service/Pages/ServiceDirectory/Region.cshtml.cs
+++ b/ntbs-service/Pages/ServiceDirectory/Region.cshtml.cs
@@ -35,13 +35,14 @@ namespace ntbs_service.Pages.ServiceDirectory
                     service => service,
                     service => service.CaseManagerTbServices
                         .Select(c => c.CaseManager)
-                        .OrderBy(c => c.DisplayName)
+                        .Where(cm => cm.IsActive)
+                        .OrderBy(cm => cm.DisplayName)
                         .ToList()
                     );
 
             Phec = await _referenceDataRepository.GetPhecByCode(PhecCode);
 
-            RegionalCaseManagers = await _referenceDataRepository.GetUsersByPhecAdGroup(Phec.AdGroup);
+            RegionalCaseManagers = await _referenceDataRepository.GetActiveUsersByPhecAdGroup(Phec.AdGroup);
 
             PrepareBreadcrumbs();
 


### PR DESCRIPTION
## Description
Previous tickets dealt with searches but not the region pages. Now filter by isActive on those pages too.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
