### PR TITLE
NTBS-2446 Fix option group select UI tests

### DIFF
--- a/ntbs-ui-tests/Features/CreateNotifications.feature
+++ b/ntbs-ui-tests/Features/CreateNotifications.feature
@@ -58,7 +58,7 @@ Feature: Notification creation
     And I enter 1999 into 'year-of-entry'
     And I enter 44 Poodle Terrace into 'PatientDetails_Address'
     And I select radio value 'postcode-no'
-    And I make selection 28 from Other section for 'PatientDetails_OccupationId'
+    And I make selection Other from Other section for 'PatientDetails_OccupationId'
     And I enter Software Developer into 'occupation-other'
     When I click on the 'submit-button' button
 
@@ -163,7 +163,7 @@ Feature: Notification creation
     And I enter 1 into 'FormattedTestDate_Month'
     And I enter 2012 into 'FormattedTestDate_Year'
     And I select Smear for 'TestResultForEdit_ManualTestTypeId'
-    And I make selection 1 from Respiratory section for 'TestResultForEdit_SampleTypeId'
+    And I make selection Bronchial washings from Respiratory section for 'TestResultForEdit_SampleTypeId'
     And I select Negative for 'TestResultForEdit_Result'
     And I click on the 'save-test-result-button' button
     When I click on the 'submit-button' button
@@ -314,7 +314,7 @@ Feature: Notification creation
     When I click 'Social context - venues' on the navigation bar
     Then I should be on the SocialContextVenues page
     When I click on the 'add-new-social-context-venue-button' button
-    And I select Catering for 'Venue_VenueTypeId'
+    And I make selection Catering from Workplace section for 'Venue_VenueTypeId'
     And I enter Nandos into 'Venue_Name'
     And I enter 445 Star Gates into 'Venue_Address'
     And I enter S55 4EP into 'Venue_Postcode'

--- a/ntbs-ui-tests/Features/EditNotifications.feature
+++ b/ntbs-ui-tests/Features/EditNotifications.feature
@@ -25,7 +25,7 @@ Feature: Notification editing
     And I enter 56 Schnowzer Boulevard into 'PatientDetails_Address'
     And I select radio value 'postcode-yes'
     And I enter ST1 1AA into 'PatientDetails_Postcode'
-    And I make selection 26 from Other section for 'PatientDetails_OccupationId'
+    And I make selection Retired from Other section for 'PatientDetails_OccupationId'
     When I click on the 'save-button' button
 
     Then I can see the value 'LEICESTER, Jester' for the field 'full-name' in the 'PatientDetails' overview section
@@ -125,7 +125,7 @@ Feature: Notification editing
     And I enter 3 into 'FormattedTestDate_Month'
     And I enter 2011 into 'FormattedTestDate_Year'
     And I select Histology for 'TestResultForEdit_ManualTestTypeId'
-    And I make selection 7 from Non-Respiratory section for 'TestResultForEdit_SampleTypeId'
+    And I make selection Bone and joint from Non-Respiratory section for 'TestResultForEdit_SampleTypeId'
     And I select Negative for 'TestResultForEdit_Result'
     And I click on the 'save-test-result-button' button
     When I click on the 'save-button' button
@@ -265,7 +265,7 @@ Feature: Notification editing
     When I go to edit the 'SocialContextVenues' section
     Then I should be on the SocialContextVenues page
     When I click on the Edit link
-    And I select Nursery for 'Venue_VenueTypeId'
+    And I make selection Nursery from Childcare & education section for 'Venue_VenueTypeId'
     And I enter McDonalds into 'Venue_Name'
     And I enter 666 Stan Drive into 'Venue_Address'
     And I enter LS6 2EB into 'Venue_Postcode'

--- a/ntbs-ui-tests/Steps/ActSteps.cs
+++ b/ntbs-ui-tests/Steps/ActSteps.cs
@@ -39,7 +39,7 @@ namespace ntbs_ui_tests.Steps
                 Assert.NotNull(Browser.FindElement(By.ClassName("notification-banner-title-text")));
             });
         }
-        
+
         [When(@"I click '(.*)' on the navigation bar")]
         public void ClickOnTheNavigationBar(string label)
         {
@@ -200,13 +200,19 @@ namespace ntbs_ui_tests.Steps
                 }
             });
         }
-        
+
         [When(@"I make selection (.*) from (.*) section for '(.*)'")]
-        public void WhenISelectValueFromGroupForFieldWithId(string value, string group, string elementId)
+        public void WhenISelectValueFromGroupForFieldWithId(string option, string group, string selectId)
         {
             WithErrorLogging(() =>
             {
-                var selection = HtmlElementHelper.FindElementByXpath(Browser, $"//select[@id='{elementId}']/optgroup[@label='{group}']/option[@value='{value}']");
+                var optionXPath =
+                    $"//select[@id='{selectId}']/optgroup[@label='{group}']/option[normalize-space(text())='{option}']";
+
+                var wait = new WebDriverWait(Browser, Settings.ImplicitWait);
+                wait.Until(ExpectedConditions.ElementIsVisible(By.XPath(optionXPath)));
+
+                var selection = HtmlElementHelper.FindElementByXpath(Browser, optionXPath);
                 selection.Click();
                 if (!Settings.IsHeadless)
                 {


### PR DESCRIPTION
## Description
Fix the social context venue tests, to be able to select values from select groups.

Also, use option text to make selections from option group selects, instead of ID numbers.

## Checklist:
- [x] Automated tests are passing locally (including all changed UI tests)
- [ ] [GitHub action run](https://github.com/publichealthengland/ntbs_Beta/runs/2996907803) passes (mostly, it did manage to lose the submit button somehow but `Create notification with all test results fields` passes locally for me)