### PR TITLE
NTBS-2510 Remove waiting period from duplicate check alert

### DIFF
--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -267,8 +267,6 @@ OR
 (P1.[GivenName] = P2.[FamilyName] and P1.[FamilyName] = P2.[GivenName]))
 AND P1.[Dob] = P2.[Dob]
 AND P1.[NotificationId] <> P2.[NotificationId]
-AND N1.[NotificationDate] < DATEADD(day, -45.0E0, GETDATE())
-AND N2.[NotificationDate] < DATEADD(day, -45.0E0, GETDATE())
 AND (N1.[NotificationStatus] IN ('Notified', 'Closed')) 
 AND (N2.[NotificationStatus] IN ('Notified', 'Closed')) 
 AND (N1.[GroupId] <> N2.[GroupId] OR N1.[GroupId] is NULL or N2.[GroupId] is NULL)")
@@ -289,14 +287,11 @@ AND (N1.[GroupId] <> N2.[GroupId] OR N1.[GroupId] is NULL or N2.[GroupId] is NUL
                         (
                             t.notification.PatientDetails.NhsNumber == t.duplicate.PatientDetails.NhsNumber &&
                             t.notification.PatientDetails.NhsNumber != null
-                        ) // check that the notifications have happened long enough in the past
+                        )
+                        // Check that the notifications are different
                         &&
                         (
-                            t.notification.NotificationId != t.duplicate.NotificationId &&
-                            t.notification.NotificationDate <
-                            DateTime.Now.AddDays(-DataQualityPotentialDuplicateAlert.MinNumberDaysNotifiedForAlert) &&
-                            t.duplicate.NotificationDate <
-                            DateTime.Now.AddDays(-DataQualityPotentialDuplicateAlert.MinNumberDaysNotifiedForAlert)
+                            t.notification.NotificationId != t.duplicate.NotificationId
                         )
                         // Check that the notifications are complete and have not been discarded (denotified or deleted)
                         && (


### PR DESCRIPTION
## Description
Remove waiting period from duplicate check alert

This for Release-1.0.2 so is being merged into `live`

There are no tests for this, so none needed to be amended. It would be nice to have some, but all of the duplicate checking logic is in handwritten SQL which precludes unit testing. I think the integration testing setup might work for this, but I'm not sure how I would trigger the Hangfire job as part of the integration test.

## Checklist:
- [x] Automated tests are passing locally.