### PR TITLE
NTBS-2517 Fix read-only AD groups

### DIFF
--- a/ntbs-service/Constants.cs
+++ b/ntbs-service/Constants.cs
@@ -18,6 +18,7 @@
         public const string ExternalLinks = "ExternalLinks";
         public const string EnvironmentDescription = "EnvironmentDescription";
         public const string EnvironmentName = "EnvironmentDescription:EnvironmentName";
+        public const string AdOptionsReadOnlyUserGroupName = "AdOptions:ReadOnlyUserGroup";
 
         public const int SqlServerDefaultCommandTimeOut = 600;
     }

--- a/ntbs-service/Pages/Health.cshtml
+++ b/ntbs-service/Pages/Health.cshtml
@@ -25,7 +25,8 @@
 
     <div>
         <h2>Environment</h2>
-        Environment: @Model.EnvironmentName
+        <div>Environment: <code>@Model.EnvironmentName</code></div>
+        <div>Read Only User Group Name: <code>@Model.ReadOnlyUserGroupName</code></div>
     </div>
 
     <div>

--- a/ntbs-service/Pages/Health.cshtml.cs
+++ b/ntbs-service/Pages/Health.cshtml.cs
@@ -14,6 +14,8 @@ namespace ntbs_service.Pages
 
             EnvironmentName = configuration.GetValue<string>(Constants.EnvironmentName);
 
+            ReadOnlyUserGroupName = configuration.GetValue<string>(Constants.AdOptionsReadOnlyUserGroupName);
+
             AuditEnabled = configuration.GetValue<bool>(Constants.AuditEnabledConfigValue);
 
             // Note the value negation, since we're turning mocked => enabled
@@ -39,6 +41,7 @@ namespace ntbs_service.Pages
 
         public string Release { get; }
         public string EnvironmentName { get; }
+        public string ReadOnlyUserGroupName { get; }
         public bool AuditEnabled { get; }
         public bool ClusterMatchingEnabled { get; }
         public bool ReferenceLabResultsEnabled { get; }

--- a/ntbs-service/appsettings.json
+++ b/ntbs-service/appsettings.json
@@ -3,7 +3,7 @@
   "AdOptions": {
     "BaseUserGroup": "App.Auth.NIS.NTBS",
     "AdminUserGroup": "App.Auth.NIS.NTBS.Admin",
-    "ReadOnlyUserGroup": "App.Auth.NIS.NTBS.Read_Only_User",
+    "ReadOnlyUserGroup": "App.Auth.NIS.NTBS.Read_Only",
     "NationalTeamAdGroup": "App.Auth.NIS.NTBS.NTS",
     "ServiceGroupAdPrefix": "App.Auth.NIS.NTBS.Service",
     "MaxSessionCookieLifetimeInMinutes": 720

--- a/ntbs-service/deployments/training.yml
+++ b/ntbs-service/deployments/training.yml
@@ -58,6 +58,8 @@ spec:
                 key: migrationDb
           - name: AzureAdOptions__Enabled
             value: "true"
+          - name: AzureAdOptions__ReadOnlyUserGroup
+            value: "App.Auth.NIS.NTBS.Read_Only_Training"
           - name: AzureAdOptions__ClientId
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
## Description
* Add read-only user group name to the health page
* Use correct ReadOnlyUser group name, `App.Auth.NIS.NTBS.Read_Only`
    * But use a deliberately incorrect one in training, to allow read-only users in other environments to do training.

## Checklist:
- [x] Automated tests are passing locally.
- [ ] Update Aptemus AD read-only group name so UI tests won't break