### PR TITLE
NTBS-2497 Improve duplicate NHS number query performance

### DIFF
--- a/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryFixture.cs
+++ b/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryFixture.cs
@@ -1,0 +1,29 @@
+﻿using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using ntbs_service.DataAccess;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataAccess
+{
+    // ReSharper disable once ClassNeverInstantiated.Global
+    public class DataQualityRepositoryFixture : IAsyncLifetime
+    {
+        public NtbsContext Context;
+
+        public async Task InitializeAsync()
+        {
+            var contextOptions = new DbContextOptionsBuilder<NtbsContext>()
+                .UseSqlite($"Filename={nameof(DataQualityRepositoryTests)}.db")
+                .Options;
+
+            Context = new NtbsContext(contextOptions);
+            await Context.Database.EnsureDeletedAsync();
+            await Context.Database.EnsureCreatedAsync();
+        }
+
+        public async Task DisposeAsync()
+        {
+            await Context.DisposeAsync();
+        }
+    }
+}

--- a/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryTests.cs
+++ b/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryTests.cs
@@ -7,14 +7,12 @@ using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
+using ntbs_service.Models.QueryEntities;
 using Xunit;
 
 namespace ntbs_service_unit_tests.DataAccess
 {
-    // This suite attempts to test EF queries, close to the context. It draws on this article for the setup inspiration
-    // (albeit without the extensive multi-provider support):
-    // https://docs.microsoft.com/en-us/ef/core/miscellaneous/testing/testing-sample
-    public class DataQualityRepositoryTests : IClassFixture<DataQualityRepositoryFixture>
+    public class DataQualityRepositoryTests : IClassFixture<DataQualityRepositoryFixture>, IDisposable
     {
         private readonly NtbsContext _context;
 
@@ -61,6 +59,260 @@ namespace ntbs_service_unit_tests.DataAccess
             Assert.Equal(2, notifications.Count);
         }
 
+        [Theory]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "9620869346", "9620869346")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Closed, null, null,
+            "9620869346", "9620869346")]
+        [InlineData(NotificationStatus.Closed, NotificationStatus.Closed, null, null,
+            "9620869346", "9620869346")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", null,
+            "9620869346", "9620869346")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", "2",
+            "9620869346", "9620869346")]
+        public async Task NotificationsWithDuplicateNhsNumbers_CorrectlyFindsDuplicates(
+            NotificationStatus status1, NotificationStatus status2, string groupName1, string groupName2,
+            string nhsNumber1, string nhsNumber2)
+        {
+            // Arrange
+            var group1 = new NotificationGroup();
+            var group2 = new NotificationGroup();
+            await _context.NotificationGroup.AddRangeAsync(group1, group2);
+
+            var notification1 = new Notification
+            {
+                NotificationStatus = status1,
+                NotificationDate = DateTime.Now,
+                Group = groupName1 == "1" ? group1 : groupName1 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    NhsNumber = nhsNumber1,
+                }
+            };
+            var notification2 = new Notification
+            {
+                NotificationStatus = status2,
+                NotificationDate = DateTime.Now,
+                Group = groupName2 == "1" ? group1 : groupName2 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    NhsNumber = nhsNumber2,
+                }
+            };
+
+            await _context.AddRangeAsync(notification1, notification2);
+            await _context.SaveChangesAsync();
+
+            var repo = new DataQualityRepository(_context);
+
+            // Act
+            var notificationIds = await repo.GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
+
+            // Assert
+            AssertDuplicatePairIsFound(notificationIds, notification1.NotificationId, notification2.NotificationId);
+        }
+
+        [Theory]
+        [InlineData(NotificationStatus.Deleted, NotificationStatus.Notified, null, null,
+            "9620869346", "9620869346")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Denotified, null, null,
+            "9620869346", "9620869346")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Draft, null, null,
+            "9620869346", "9620869346")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "0000000000", "9620869346")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            null, null)]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", "1",
+            "9620869346", "9620869346")]
+        public async Task NotificationsWithDuplicateNhsNumbers_CorrectlyIgnoresNonDuplicates(
+            NotificationStatus status1, NotificationStatus status2, string groupName1, string groupName2,
+            string nhsNumber1, string nhsNumber2)
+        {
+            // Arrange
+            var group1 = new NotificationGroup();
+            var group2 = new NotificationGroup();
+            await _context.NotificationGroup.AddRangeAsync(group1, group2);
+
+            var notification1 = new Notification
+            {
+                NotificationStatus = status1,
+                NotificationDate = DateTime.Now,
+                Group = groupName1 == "1" ? group1 : groupName1 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    NhsNumber = nhsNumber1,
+                }
+            };
+            var notification2 = new Notification
+            {
+                NotificationStatus = status2,
+                NotificationDate = DateTime.Now,
+                Group = groupName2 == "1" ? group1 : groupName2 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    NhsNumber = nhsNumber2,
+                }
+            };
+
+            await _context.AddRangeAsync(notification1, notification2);
+            await _context.SaveChangesAsync();
+
+            var repo = new DataQualityRepository(_context);
+
+            // Act
+            var notificationIds = await repo.GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
+
+            // Assert
+            Assert.Empty(notificationIds);
+        }
+
+        [Theory]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Closed, null, null,
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Closed, NotificationStatus.Closed, null, null,
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", null,
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", "2",
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "John", "Smith", "Smith", "John", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Closed, null, null,
+            "John", "Smith", "Smith", "John", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Closed, NotificationStatus.Closed, null, null,
+            "John", "Smith", "Smith", "John", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", null,
+            "John", "Smith", "Smith", "John", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", "2",
+            "John", "Smith", "Smith", "John", "2020-01-01", "2020-01-01")]
+        public async Task NotificationsWithDuplicateNamesAndDobs_CorrectlyFindsDuplicates(
+            NotificationStatus status1, NotificationStatus status2, string groupName1, string groupName2,
+            string givenName1, string givenName2, string familyName1, string familyName2, string dob1, string dob2)
+        {
+            // Arrange
+            var group1 = new NotificationGroup();
+            var group2 = new NotificationGroup();
+            await _context.NotificationGroup.AddRangeAsync(group1, group2);
+
+            var notification1 = new Notification
+            {
+                NotificationStatus = status1,
+                NotificationDate = DateTime.Now,
+                Group = groupName1 == "1" ? group1 : groupName1 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    GivenName = givenName1,
+                    FamilyName = familyName1,
+                    Dob = dob1 == null ? null : (DateTime?)DateTime.Parse(dob1)
+                }
+            };
+            var notification2 = new Notification
+            {
+                NotificationStatus = status2,
+                NotificationDate = DateTime.Now,
+                Group = groupName2 == "1" ? group1 : groupName2 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    GivenName = givenName2,
+                    FamilyName = familyName2,
+                    Dob = dob1 == null ? null : (DateTime?)DateTime.Parse(dob2)
+                }
+            };
+
+            await _context.AddRangeAsync(notification1, notification2);
+            await _context.SaveChangesAsync();
+
+            var repo = new DataQualityRepository(_context);
+
+            // Act
+            var notificationIds = await repo.GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
+
+            // Assert
+            AssertDuplicatePairIsFound(notificationIds, notification1.NotificationId, notification2.NotificationId);
+        }
+
+        [Theory]
+        [InlineData(NotificationStatus.Deleted, NotificationStatus.Notified, null, null,
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Denotified, null, null,
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Draft, null, null,
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "John", "John", "Smith", "Smith", "1990-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "John", "John", "Smith", "Smith", null, null)]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "John", "John", "Johnson", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "John", "John", null, null, "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            "John", "James", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, null, null,
+            null, null, "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        [InlineData(NotificationStatus.Notified, NotificationStatus.Notified, "1", "1",
+            "John", "John", "Smith", "Smith", "2020-01-01", "2020-01-01")]
+        public async Task NotificationsWithDuplicateNamesAndDobs_CorrectlyIgnoresNonDuplicates(
+            NotificationStatus status1, NotificationStatus status2, string groupName1, string groupName2,
+            string givenName1, string givenName2, string familyName1, string familyName2, string dob1, string dob2)
+        {
+            // Arrange
+            var group1 = new NotificationGroup();
+            var group2 = new NotificationGroup();
+            await _context.NotificationGroup.AddRangeAsync(group1, group2);
+
+            var notification1 = new Notification
+            {
+                NotificationStatus = status1,
+                NotificationDate = DateTime.Now,
+                Group = groupName1 == "1" ? group1 : groupName1 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    GivenName = givenName1,
+                    FamilyName = familyName1,
+                    Dob = dob1 == null ? null : (DateTime?)DateTime.Parse(dob1)
+                }
+            };
+            var notification2 = new Notification
+            {
+                NotificationStatus = status2,
+                NotificationDate = DateTime.Now,
+                Group = groupName2 == "1" ? group1 : groupName2 == "2" ? group2 : null,
+                PatientDetails = new PatientDetails
+                {
+                    GivenName = givenName2,
+                    FamilyName = familyName2,
+                    Dob = dob1 == null ? null : (DateTime?)DateTime.Parse(dob2)
+                }
+            };
+
+            await _context.AddRangeAsync(notification1, notification2);
+            await _context.SaveChangesAsync();
+
+            var repo = new DataQualityRepository(_context);
+
+            // Act
+            var notificationIds = await repo.GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
+
+            // Assert
+            Assert.Empty(notificationIds);
+        }
+
+        private static void AssertDuplicatePairIsFound(IList<NotificationAndDuplicateIds> notificationIds,
+            int notificationId1, int notificationId2)
+        {
+            Assert.Contains(notificationIds, pair =>
+                pair.NotificationId == notificationId1
+                && pair.DuplicateId == notificationId2);
+            Assert.Contains(notificationIds, pair =>
+                pair.NotificationId == notificationId2
+                && pair.DuplicateId == notificationId1);
+            Assert.Equal(2, notificationIds.Count);
+        }
+
         private static Notification NotificationEligibleForCountryOfBirthDqAlert(string name)
         {
             return new Notification
@@ -76,6 +328,13 @@ namespace ntbs_service_unit_tests.DataAccess
                 },
                 Alerts = new List<Alert>()
             };
+        }
+
+        public void Dispose()
+        {
+            _context.Notification.RemoveRange(_context.Notification);
+            _context.NotificationGroup.RemoveRange(_context.NotificationGroup);
+            _context.SaveChanges();
         }
     }
 }

--- a/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryTests.cs
+++ b/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryTests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
 using ntbs_service.DataAccess;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
@@ -15,63 +14,51 @@ namespace ntbs_service_unit_tests.DataAccess
     // This suite attempts to test EF queries, close to the context. It draws on this article for the setup inspiration
     // (albeit without the extensive multi-provider support):
     // https://docs.microsoft.com/en-us/ef/core/miscellaneous/testing/testing-sample
-    public class DataQualityRepositoryTests
+    public class DataQualityRepositoryTests : IClassFixture<DataQualityRepositoryFixture>
     {
+        private readonly NtbsContext _context;
+
         private const string NoAlertsName = "A";
         private const string BirthCountryAlertName = "B";
         private const string ClinicalDatesAlertName = "C";
 
-        public DataQualityRepositoryTests()
+        public DataQualityRepositoryTests(DataQualityRepositoryFixture dataQualityRepositoryFixture)
         {
-            ContextOptions = new DbContextOptionsBuilder<NtbsContext>()
-                .UseInMemoryDatabase(nameof(DataQualityRepositoryTests))
-                .Options;
+            _context = dataQualityRepositoryFixture.Context;
         }
-
-        private DbContextOptions<NtbsContext> ContextOptions { get; }
 
         [Fact]
         public async Task FiltersOutNotificationsWithTheAlertTypeAlreadyPresent()
         {
             // ARRANGE
-            using (var context = new NtbsContext(ContextOptions))
-            {
-                await context.Database.EnsureDeletedAsync();
-                await context.Database.EnsureCreatedAsync();
+            // We will use the birth country alert as a proxy for testing the common path ways of the
+            // data quality repository
+            // All seeded notifications will be eligible for this alert
 
-                // We will use the birth country alert as a proxy for testing the common path ways of the
-                // data quality repository
-                // All seeded notifications will be eligible for this alert
+            var notification1 = NotificationEligibleForCountryOfBirthDqAlert(NoAlertsName);
 
-                var notification1 = NotificationEligibleForCountryOfBirthDqAlert(NoAlertsName);
+            var notification2 = NotificationEligibleForCountryOfBirthDqAlert(BirthCountryAlertName);
+            notification2.Alerts = new List<Alert> { new DataQualityBirthCountryAlert() };
 
-                var notification2 = NotificationEligibleForCountryOfBirthDqAlert(BirthCountryAlertName);
-                notification2.Alerts = new List<Alert> { new DataQualityBirthCountryAlert() };
+            var notification3 = NotificationEligibleForCountryOfBirthDqAlert(ClinicalDatesAlertName);
+            notification3.Alerts = new List<Alert> { new DataQualityClinicalDatesAlert() };
 
-                var notification3 = NotificationEligibleForCountryOfBirthDqAlert(ClinicalDatesAlertName);
-                notification3.Alerts = new List<Alert> { new DataQualityClinicalDatesAlert() };
+            await _context.AddRangeAsync(notification1, notification2, notification3);
+            await _context.SaveChangesAsync();
 
-                await context.AddRangeAsync(notification1, notification2, notification3);
+            var repo = new DataQualityRepository(_context);
 
-                await context.SaveChangesAsync();
-            }
+            // ACT
+            // Get all possible ones
+            var notifications = await repo.GetNotificationsEligibleForDqBirthCountryAlertsAsync(100, 0);
 
-            using (var context = new NtbsContext(ContextOptions))
-            {
-                var repo = new DataQualityRepository(context);
-
-                // ACT
-                // Get all possible ones
-                var notifications = await repo.GetNotificationsEligibleForDqBirthCountryAlertsAsync(100, 0);
-
-                // ASSERT
-                // Out of the 3 eligible notifications, 1 already has the alert
-                Assert.True(notifications.Any(n => n.PatientDetails.FamilyName == NoAlertsName),
-                    "Eligible notification with no other alerts not selected");
-                Assert.True(notifications.Any(n => n.PatientDetails.FamilyName == ClinicalDatesAlertName),
-                    "Eligible notification with only other alerts types not selected");
-                Assert.Equal(2, notifications.Count);
-            }
+            // ASSERT
+            // Out of the 3 eligible notifications, 1 already has the alert
+            Assert.True(notifications.Any(n => n.PatientDetails.FamilyName == NoAlertsName),
+                "Eligible notification with no other alerts not selected");
+            Assert.True(notifications.Any(n => n.PatientDetails.FamilyName == ClinicalDatesAlertName),
+                "Eligible notification with only other alerts types not selected");
+            Assert.Equal(2, notifications.Count);
         }
 
         private static Notification NotificationEligibleForCountryOfBirthDqAlert(string name)

--- a/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
+++ b/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Audit.EntityFramework.Core" Version="17.0.7" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
     <PackageReference Include="MockQueryable.Moq" Version="5.0.1" />


### PR DESCRIPTION
## Description
The duplicate matching step that is failing on load-test is the one checking for duplicate NHS numbers, and the data in question is the nicely seeded random set of NHS numbers, ~40k of them, and is an ideal simulation of running this job on live.

This old query was defined using Entity Framework, and takes at least 12 minutes (and then we run out of tempdb space….) to run on 40k records. This is a bad query, in particular the WHERE clause is a complicated mess, in particular it does a poor job of translating comparators given the different ways NULLs are compared in C# and SQL. This messy query bamboozles the query optimiser, causing it to choose a hopelessly slow, bad plan (it appears to take the cartesian product of `(Notification, Patients) × (Notification, Patients)` and then filter, which for 40k notifications requires 1.6e+9 records, or 10 GB of swap space…)

I hand-wrote the query with a more legible WHERE clause and it ran in a small fraction of a second, using a nice neat little query plan which uses JOINs to implement the matching of NHS numbers. We’ve already switched to using a raw-SQL approach for the other check (based on names and dates of birth), so I've used it for this one as well.

## Checklist:
- [x] Automated tests are passing locally.