### PR TITLE
NTBS-2529 Create all alerts with current timestamp

### DIFF
--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using ntbs_service.DataAccess;
@@ -229,7 +228,7 @@ namespace ntbs_service.Services
 
         private async Task PopulateAndAddAlertAsync(Alert alert)
         {
-            alert.CreationDate = DateTime.Today;
+            alert.CreationDate = DateTime.Now;
             await _alertRepository.AddAlertAsync(alert);
         }
     }


### PR DESCRIPTION
Previously, some alerts were created with a date only, while others included the date and time. Here we make the behaviour consistent - all alerts should be added with the time included.

## Checklist:
- [x] Automated tests are passing locally.
