### PR TITLE
NTBS-2565 Make timezone cross-platform

### DIFF
--- a/ntbs-service/Jobs/HangfireJobScheduler.cs
+++ b/ntbs-service/Jobs/HangfireJobScheduler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Hangfire;
 using ntbs_service.Properties;
+using TimeZoneConverter;
 
 namespace ntbs_service.Jobs
 {
@@ -21,7 +22,10 @@ namespace ntbs_service.Jobs
 
         // The window in which our overnight jobs must run has become so narrow that we now need to adjust for local time
         // to be able to reliably fit them in before the start of the working day.
-        private static readonly TimeZoneInfo GmtStandardTime = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        // We're using TZConvert rather than TimeZoneInfo.FindSystemTimeZoneById because it is cross-platform. Note, however,
+        // that this will not be necessary in .NET 6, so when the project updates to .NET 6 we can remove the dependency.
+        // See https://devblogs.microsoft.com/dotnet/date-time-and-time-zone-enhancements-in-net-6/#time-zone-conversion-apis
+        private static readonly TimeZoneInfo GmtStandardTime = TZConvert.GetTimeZoneInfo("GMT Standard Time");
 
         public static void ScheduleRecurringJobs(ScheduledJobsConfig scheduledJobsConfig)
         {

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -44,6 +44,7 @@
     <PackageReference Include="Sentry.AspNetCore" Version="3.6.0" />
     <PackageReference Include="Sentry.Serilog" Version="3.6.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
+    <PackageReference Include="TimeZoneConverter" Version="3.5.0" />
     <PackageReference Include="ZNetCS.AspNetCore.Authentication.Basic" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
I've deployed this change to `int` this morning (from a feature branch) and it seems to be working - although really we need to let it run for a day to check that the jobs are happening at the right times.