### PR TITLE
NTBS-2563 Refactor filters for treatment outcome alerts

### DIFF
--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -132,14 +132,14 @@ namespace ntbs_service.DataAccess
             int count,
             int offset) =>
             GetMultipleNotificationsEligibleForDataQualityTreatmentOutcomeAlerts<DataQualityTreatmentOutcome12>(
-                DataQualityTreatmentOutcome12.NotificationInQualifyingDateRangeExpression,
+                DataQualityTreatmentOutcome12.NotificationInQualifyingRangeExpression,
                 DataQualityTreatmentOutcome12.NotificationInRangeQualifies,
                 count,
                 offset);
 
         public Task<int> GetNotificationsEligibleForDqTreatmentOutcome12AlertsCountAsync() =>
             GetNotificationsEligibleForAlertsCount(DataQualityTreatmentOutcome12
-                .NotificationInQualifyingDateRangeExpression);
+                .NotificationInQualifyingRangeExpression);
 
         #endregion
 
@@ -149,14 +149,14 @@ namespace ntbs_service.DataAccess
             int count,
             int offset) =>
             GetMultipleNotificationsEligibleForDataQualityTreatmentOutcomeAlerts<DataQualityTreatmentOutcome24>(
-                DataQualityTreatmentOutcome24.NotificationInQualifyingDateRangeExpression,
+                DataQualityTreatmentOutcome24.NotificationInQualifyingRangeExpression,
                 DataQualityTreatmentOutcome24.NotificationInRangeQualifies,
                 count,
                 offset);
 
         public Task<int> GetNotificationsEligibleForDqTreatmentOutcome24AlertsCountAsync() =>
             GetNotificationsEligibleForAlertsCount(DataQualityTreatmentOutcome24
-                .NotificationInQualifyingDateRangeExpression);
+                .NotificationInQualifyingRangeExpression);
 
         #endregion
 
@@ -166,14 +166,14 @@ namespace ntbs_service.DataAccess
             int count,
             int offset) =>
             GetMultipleNotificationsEligibleForDataQualityTreatmentOutcomeAlerts<DataQualityTreatmentOutcome36>(
-                DataQualityTreatmentOutcome36.NotificationInQualifyingDateRangeExpression,
+                DataQualityTreatmentOutcome36.NotificationInQualifyingRangeExpression,
                 DataQualityTreatmentOutcome36.NotificationInRangeQualifies,
                 count,
                 offset);
 
         public Task<int> GetNotificationsEligibleForDqTreatmentOutcome36AlertsCountAsync() =>
             GetNotificationsEligibleForAlertsCount(DataQualityTreatmentOutcome36
-                .NotificationInQualifyingDateRangeExpression);
+                .NotificationInQualifyingRangeExpression);
 
         #endregion
 

--- a/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome12.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome12.cs
@@ -9,16 +9,16 @@ namespace ntbs_service.Models.Entities.Alerts
     // ReSharper disable once ClassNeverInstantiated.Global - actually instantiated in DataQualityAlertsJob
     public class DataQualityTreatmentOutcome12 : Alert
     {
-        public static readonly Expression<Func<Notification, bool>> NotificationInQualifyingDateRangeExpression =
+        public static readonly Expression<Func<Notification, bool>> NotificationInQualifyingRangeExpression =
             // This corresponds to n.ClinicalDetails.StartingDate but we can't use it directly as LINQ->SQL gives up
-            n => (n.ClinicalDetails.TreatmentStartDate ?? n.ClinicalDetails.DiagnosisDate) < DateTime.Today.AddYears(-1);
+            n => (n.ClinicalDetails.TreatmentStartDate ?? n.ClinicalDetails.DiagnosisDate) < DateTime.Today.AddYears(-1)
+                 && n.NotificationStatus == NotificationStatus.Notified;
 
         public static readonly Func<Notification, bool> NotificationInRangeQualifies =
             n => TreatmentOutcomesHelper.IsTreatmentOutcomeMissingAtXYears(n, 1);
 
         public static readonly Func<Notification, bool> NotificationQualifies =
-            n => n.NotificationStatus == NotificationStatus.Notified
-                 && NotificationInQualifyingDateRangeExpression.Compile()(n)
+            n => NotificationInQualifyingRangeExpression.Compile()(n)
                  && NotificationInRangeQualifies(n);
 
         public override string Action => "Please provide an outcome with appropriate date";

--- a/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome24.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome24.cs
@@ -9,16 +9,16 @@ namespace ntbs_service.Models.Entities.Alerts
     // ReSharper disable once ClassNeverInstantiated.Global - actually instantiated in DataQualityAlertsJob
     public class DataQualityTreatmentOutcome24 : Alert
     {
-        public static readonly Expression<Func<Notification, bool>> NotificationInQualifyingDateRangeExpression =
+        public static readonly Expression<Func<Notification, bool>> NotificationInQualifyingRangeExpression =
             // This corresponds to n.ClinicalDetails.StartingDate but we can't use it directly as LINQ->SQL gives up
-            n => (n.ClinicalDetails.TreatmentStartDate ?? n.ClinicalDetails.DiagnosisDate) < DateTime.Today.AddYears(-2);
+            n => (n.ClinicalDetails.TreatmentStartDate ?? n.ClinicalDetails.DiagnosisDate) < DateTime.Today.AddYears(-2)
+                 && n.NotificationStatus == NotificationStatus.Notified;
 
         public static readonly Func<Notification, bool> NotificationInRangeQualifies =
             n => TreatmentOutcomesHelper.IsTreatmentOutcomeMissingAtXYears(n, 2);
 
         public static readonly Func<Notification, bool> NotificationQualifies =
-            n => n.NotificationStatus == NotificationStatus.Notified
-                 && NotificationInQualifyingDateRangeExpression.Compile()(n)
+            n => NotificationInQualifyingRangeExpression.Compile()(n)
                  && NotificationInRangeQualifies(n);
 
         public override string Action => "Please provide an outcome with appropriate date";

--- a/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome36.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityTreatmentOutcome36.cs
@@ -9,16 +9,16 @@ namespace ntbs_service.Models.Entities.Alerts
     // ReSharper disable once ClassNeverInstantiated.Global - actually instantiated in DataQualityAlertsJob
     public class DataQualityTreatmentOutcome36 : Alert
     {
-        public static readonly Expression<Func<Notification, bool>> NotificationInQualifyingDateRangeExpression =
+        public static readonly Expression<Func<Notification, bool>> NotificationInQualifyingRangeExpression =
             // This corresponds to n.ClinicalDetails.StartingDate but we can't use it directly as LINQ->SQL gives up
-            n => (n.ClinicalDetails.TreatmentStartDate ?? n.ClinicalDetails.DiagnosisDate) < DateTime.Today.AddYears(-3);
+            n => (n.ClinicalDetails.TreatmentStartDate ?? n.ClinicalDetails.DiagnosisDate) < DateTime.Today.AddYears(-3)
+                 && n.NotificationStatus == NotificationStatus.Notified;
 
         public static readonly Func<Notification, bool> NotificationInRangeQualifies =
             n => TreatmentOutcomesHelper.IsTreatmentOutcomeMissingAtXYears(n, 3);
 
         public static readonly Func<Notification, bool> NotificationQualifies =
-            n => n.NotificationStatus == NotificationStatus.Notified
-                 && NotificationInQualifyingDateRangeExpression.Compile()(n)
+            n => NotificationInQualifyingRangeExpression.Compile()(n)
                  && NotificationInRangeQualifies(n);
 
         public override string Action => "Please provide an outcome with appropriate date";


### PR DESCRIPTION
## Description
Another round of improving the performance of the `data-quality-alerts` job.

Filter by notification status as well as date range for the first pass of filtering for treatment outcome DQ alerts. The more complex treatment outcome analysis is done in memory for each possibly eligible notification, so the more precisely we define that set the less notifications the job has to consider each night.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.