### PR TITLE
NTBS-2533 improve contact tracing import

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorContactTracingTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorContactTracingTest.cs
@@ -1,0 +1,574 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Validations;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataMigration
+{
+    public partial class ImportValidatorTest
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_AdultsIdentified(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                AdultsIdentified = valueEntered,
+                AdultsScreened = 3,
+                AdultsActiveTB = 3,
+                AdultsLatentTB = 3,
+                AdultsStartedTreatment = 3,
+                AdultsFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                AdultsIdentified = valueEntered,
+                AdultsScreened = null,
+                AdultsActiveTB = null,
+                AdultsLatentTB = null,
+                AdultsStartedTreatment = null,
+                AdultsFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            // Validation errors
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingAdultsScreened,
+                ValidationMessages.ContactTracingAdultsActiveTB,
+                ValidationMessages.ContactTracingAdultsLatentTB,
+                ValidationMessages.ContactTracingAdultsStartedTreatment,
+                ValidationMessages.ContactTracingAdultsFinishedTreatment
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_ChildrenIdentified(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = valueEntered,
+                ChildrenScreened = 3,
+                ChildrenActiveTB = 3,
+                ChildrenLatentTB = 3,
+                ChildrenStartedTreatment = 3,
+                ChildrenFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = valueEntered,
+                ChildrenScreened = null,
+                ChildrenActiveTB = null,
+                ChildrenLatentTB = null,
+                ChildrenStartedTreatment = null,
+                ChildrenFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            // Validation errors
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingChildrenScreened,
+                ValidationMessages.ContactTracingChildrenActiveTB,
+                ValidationMessages.ContactTracingChildrenLatentTB,
+                ValidationMessages.ContactTracingChildrenStartedTreatment,
+                ValidationMessages.ContactTracingChildrenFinishedTreatment
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_AdultsScreened(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = valueEntered,
+                AdultsActiveTB = 3,
+                AdultsLatentTB = 3,
+                AdultsStartedTreatment = 3,
+                AdultsFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = valueEntered,
+                AdultsActiveTB = null,
+                AdultsLatentTB = null,
+                AdultsStartedTreatment = null,
+                AdultsFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            // Validation errors
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingAdultsActiveTB,
+                ValidationMessages.ContactTracingAdultsLatentTB,
+                ValidationMessages.ContactTracingAdultsStartedTreatment,
+                ValidationMessages.ContactTracingAdultsFinishedTreatment
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_ChildrenScreened(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = valueEntered,
+                ChildrenActiveTB = 3,
+                ChildrenLatentTB = 3,
+                ChildrenStartedTreatment = 3,
+                ChildrenFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = valueEntered,
+                ChildrenActiveTB = null,
+                ChildrenLatentTB = null,
+                ChildrenStartedTreatment = null,
+                ChildrenFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            // Validation errors
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingChildrenActiveTB,
+                ValidationMessages.ContactTracingChildrenLatentTB,
+                ValidationMessages.ContactTracingChildrenStartedTreatment,
+                ValidationMessages.ContactTracingChildrenFinishedTreatment
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_AdultsLatentTB(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = 3,
+                AdultsActiveTB = 1,
+                AdultsLatentTB = valueEntered,
+                AdultsStartedTreatment = 3,
+                AdultsFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = 3,
+                AdultsActiveTB = 1,
+                AdultsLatentTB = valueEntered,
+                AdultsStartedTreatment = null,
+                AdultsFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingAdultsStartedTreatment,
+                ValidationMessages.ContactTracingAdultsFinishedTreatment
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_ChildrenLatentTB(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = 3,
+                ChildrenActiveTB = 1,
+                ChildrenLatentTB = valueEntered,
+                ChildrenStartedTreatment = 3,
+                ChildrenFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = 3,
+                ChildrenActiveTB = 1,
+                ChildrenLatentTB = valueEntered,
+                ChildrenStartedTreatment = null,
+                ChildrenFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingChildrenStartedTreatment,
+                ValidationMessages.ContactTracingChildrenFinishedTreatment
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_AdultsStartedTreatment(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = 3,
+                AdultsActiveTB = 1,
+                AdultsLatentTB = 1,
+                AdultsStartedTreatment = valueEntered,
+                AdultsFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = 3,
+                AdultsActiveTB = 1,
+                AdultsLatentTB = 1,
+                AdultsStartedTreatment = valueEntered,
+                AdultsFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[] { ValidationMessages.ContactTracingAdultsFinishedTreatment });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData(1)]
+        public async Task ImportValidatorCleansContactTracingValuesBasedOn_ChildrenStartedTreatment(int? valueEntered)
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = 3,
+                ChildrenActiveTB = 1,
+                ChildrenLatentTB = 1,
+                ChildrenStartedTreatment = valueEntered,
+                ChildrenFinishedTreatment = 3,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = 3,
+                ChildrenActiveTB = 1,
+                ChildrenLatentTB = 1,
+                ChildrenStartedTreatment = valueEntered,
+                ChildrenFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[] { ValidationMessages.ContactTracingChildrenFinishedTreatment });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Fact]
+        public async Task ImportValidatorCleansContactTracingValues_WhenTooManyOfEachAdultsCaseType()
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = 3,
+                AdultsActiveTB = 2,
+                AdultsLatentTB = 2,
+                AdultsStartedTreatment = 1,
+                AdultsFinishedTreatment = 1,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 3,
+                AdultsScreened = 3,
+                AdultsActiveTB = null,
+                AdultsLatentTB = null,
+                AdultsStartedTreatment = null,
+                AdultsFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            // Validation errors
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingAdultsActiveTB,
+                ValidationMessages.ContactTracingAdultsLatentTB,
+                ValidationMessages.ContactTracingAdultsStartedTreatment,
+                ValidationMessages.ContactTracingAdultsFinishedTreatment,
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Fact]
+        public async Task ImportValidatorCleansContactTracingValues_WhenTooManyOfEachChildrenCaseType()
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = 3,
+                ChildrenActiveTB = 2,
+                ChildrenLatentTB = 2,
+                ChildrenStartedTreatment = 1,
+                ChildrenFinishedTreatment = 1,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            var expectedContactTracing = new ContactTracing
+            {
+                ChildrenIdentified = 3,
+                ChildrenScreened = 3,
+                ChildrenActiveTB = null,
+                ChildrenLatentTB = null,
+                ChildrenStartedTreatment = null,
+                ChildrenFinishedTreatment = null,
+            };
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, new[]
+            {
+                ValidationMessages.ContactTracingChildrenActiveTB,
+                ValidationMessages.ContactTracingChildrenLatentTB,
+                ValidationMessages.ContactTracingChildrenStartedTreatment,
+                ValidationMessages.ContactTracingChildrenFinishedTreatment,
+            });
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        [Fact]
+        public async Task ImportValidator_PreservesValidContactTracingValues()
+        {
+            // Arrange
+            var actualNotification = CreateBasicNotification();
+            actualNotification.ContactTracing = new ContactTracing
+            {
+                AdultsIdentified = 5,
+                AdultsScreened = 5,
+                AdultsActiveTB = 0,
+                AdultsLatentTB = 5,
+                AdultsStartedTreatment = 5,
+                AdultsFinishedTreatment = 5,
+
+                ChildrenIdentified = 5,
+                ChildrenScreened = 4,
+                ChildrenActiveTB = 1,
+                ChildrenLatentTB = 3,
+                ChildrenStartedTreatment = 2,
+                ChildrenFinishedTreatment = 1,
+            };
+            var oldContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+            var expectedContactTracing = CloneContactTracing(actualNotification.ContactTracing);
+
+            // Act
+            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, actualNotification);
+
+            // Assert
+            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
+            Assert.Empty(errorMessages);
+
+            AssertWarningsGiven(actualNotification, Enumerable.Empty<string>());
+
+            AssertContractTracingObjectsMatch(actualNotification.ContactTracing, expectedContactTracing,
+                oldContactTracing, actualNotification.ClinicalDetails.Notes);
+        }
+
+        private void AssertWarningsGiven(Notification notification, IEnumerable<string> warnings)
+        {
+            foreach (var warning in warnings)
+            {
+                _importLoggerMock.Verify(s => s.LogNotificationWarning(null, RunId, notification.LegacyId, warning));
+            }
+            _importLoggerMock.VerifyNoOtherCalls();
+        }
+
+        private static void AssertContractTracingObjectsMatch(ContactTracing actual, ContactTracing expected,
+            ContactTracing old, string actualClinicalNotes)
+        {
+            actualClinicalNotes = actualClinicalNotes ?? "";
+
+            var propertyNames = new[]
+            {
+                nameof(ContactTracing.AdultsIdentified), nameof(ContactTracing.ChildrenIdentified),
+                nameof(ContactTracing.AdultsScreened), nameof(ContactTracing.ChildrenScreened),
+                nameof(ContactTracing.AdultsActiveTB), nameof(ContactTracing.ChildrenActiveTB),
+                nameof(ContactTracing.AdultsLatentTB), nameof(ContactTracing.ChildrenLatentTB),
+                nameof(ContactTracing.AdultsStartedTreatment), nameof(ContactTracing.ChildrenStartedTreatment),
+                nameof(ContactTracing.AdultsFinishedTreatment), nameof(ContactTracing.ChildrenFinishedTreatment)
+            };
+
+            foreach (var propertyName in propertyNames)
+            {
+                AssertContactTracingPropertyMatches(actual, expected, old, actualClinicalNotes, propertyName);
+            }
+        }
+
+        private static void AssertContactTracingPropertyMatches(ContactTracing actualContactTracing,
+            ContactTracing expectedContactTracing, ContactTracing oldContactTracing, string actualClinicalNotes,
+            string propertyName)
+        {
+            var property = typeof(ContactTracing).GetProperty(propertyName);
+
+            var actualValue = (int?) property?.GetValue(actualContactTracing);
+            var expectedValue = (int?) property?.GetValue(expectedContactTracing);
+            var oldValue = (int?) property?.GetValue(oldContactTracing);
+
+            Assert.Equal(expectedValue, actualValue);
+            if (oldValue == expectedValue)
+            {
+                Assert.DoesNotContain(propertyName, actualClinicalNotes);
+            }
+            else
+            {
+                Assert.Contains($"{propertyName}: {oldValue}", actualClinicalNotes);
+            }
+        }
+
+        private static ContactTracing CloneContactTracing(ContactTracing original) =>
+            new ContactTracing
+            {
+                AdultsIdentified = original.AdultsIdentified,
+                AdultsScreened = original.AdultsScreened,
+                AdultsActiveTB = original.AdultsActiveTB,
+                AdultsLatentTB = original.AdultsLatentTB,
+                AdultsStartedTreatment = original.AdultsStartedTreatment,
+                AdultsFinishedTreatment = original.AdultsFinishedTreatment,
+                ChildrenIdentified = original.ChildrenIdentified,
+                ChildrenScreened = original.ChildrenScreened,
+                ChildrenActiveTB = original.ChildrenActiveTB,
+                ChildrenLatentTB = original.ChildrenLatentTB,
+                ChildrenStartedTreatment = original.ChildrenStartedTreatment,
+                ChildrenFinishedTreatment = original.ChildrenFinishedTreatment
+            };
+    }
+}

--- a/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/ImportValidatorTest.cs
@@ -16,7 +16,7 @@ namespace ntbs_service_unit_tests.DataMigration
     // happening on all parts of a notification that we expect it to happen on.
     // We aim to write much more in depth tests for services that are missing them, including validation,
     // with this test suite being the start of that process.
-    public class ImportValidatorTest
+    public partial class ImportValidatorTest
     {
         private readonly IImportValidator _importValidator;
         private readonly Mock<IReferenceDataRepository> _referenceDataRepositoryMock =
@@ -125,28 +125,6 @@ namespace ntbs_service_unit_tests.DataMigration
                 errorMessages);
             Assert.Contains(ValidationMessages.HasNoUnpasteurisedMilkConsumptionRecords,
                 errorMessages);
-        }
-
-        [Fact]
-        public async Task ImportValidatorCleansContactTracingValues()
-        {
-            // Arrange
-            var notification = CreateBasicNotification();
-
-            // These values would fail validation
-            notification.ContactTracing = new ContactTracing
-            {
-                AdultsIdentified = 1,
-                AdultsScreened = 3
-            };
-
-            // Act
-            var validationResults = await _importValidator.CleanAndValidateNotification(null, RunId, notification);
-
-            // Assert
-            var errorMessages = validationResults.Select(r => r.ErrorMessage).ToList();
-
-            Assert.Empty(errorMessages);
         }
 
         [Fact]

--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -51,6 +50,46 @@ namespace ntbs_service.DataMigration
         {
             TrimAndCleanStringProperties(notification);
 
+            await CleanTestData(notification, context, runId);
+
+            await CleanContactTracingData(notification, context, runId);
+        }
+
+        private static void TrimAndCleanStringProperties(object entity)
+        {
+            // Clean strings properties of this object
+            entity?.GetType()
+                .GetProperties()
+                .Where(prop => prop.PropertyType == typeof(string)
+                               && prop.CanWrite
+                               && (Attribute.IsDefined(prop, typeof(RegularExpressionAttribute))
+                                   || Attribute.IsDefined(prop, typeof(MaxLengthAttribute))))
+                .ForEach(prop => prop.SetValue(entity, TrimAndCleanString((string)prop.GetValue(entity))));
+
+            // Clean strings properties of this object's entity children
+            entity?
+                .GetType()
+                .GetProperties()
+                .Where(prop => Attribute.IsDefined(prop, typeof(ValidationChildAttribute)))
+                .ForEach(prop => TrimAndCleanStringProperties(prop.GetValue(entity)));
+
+            // Clean strings properties of this object's enumerable children
+            entity?
+                .GetType()
+                .GetProperties()
+                .Where(prop => Attribute.IsDefined(prop, typeof(ValidationChildEnumerableAttribute)))
+                .Select(prop => prop.GetValue(entity))
+                .Where(enumerable => enumerable != null)
+                .OfType<IEnumerable<object>>()
+                // Flatten
+                .SelectMany(element => element)
+                .ForEach(TrimAndCleanStringProperties);
+        }
+
+        private static string TrimAndCleanString(string s) => s?.Trim().Replace("\t", " ");
+
+        private async Task CleanTestData(Notification notification, PerformContext context, int runId)
+        {
             var missingDateResults = notification.TestData.ManualTestResults
                 .Where(result => !result.TestDate.HasValue)
                 .ToList();
@@ -89,48 +128,90 @@ namespace ntbs_service.DataMigration
             {
                 notification.TestData.HasTestCarriedOut = false;
             }
+        }
 
-            if (ValidateObject(notification.ContactTracing).Any())
+        private async Task CleanContactTracingData(Notification notification, PerformContext context, int runId)
+        {
+            if (!ValidateObject(notification.ContactTracing).Any())
             {
-                const string message = "invalid contact tracing figures. " +
-                                       "The notification will be imported without contact tracing data.";
+                // If there are no issues in the contact tracing
+                return;
+            }
+
+            var messages = new List<string>();
+            var lostData = new List<string>();
+
+            // The order we clean properties is important, because if we overwrite one value (eg. AdultsScreened) with
+            // null then we also need to overwrite the values that are necessarily lower than it (eg. AdultsActiveTB)
+
+            CleanValidationProperty(nameof(ContactTracing.AdultsScreened), notification, messages, lostData);
+            CleanValidationProperty(nameof(ContactTracing.ChildrenScreened), notification, messages, lostData);
+
+            // Because Active + Latent <= Screened, these have to be cleaned together
+            CleanValidationPropertyPair(nameof(ContactTracing.AdultsActiveTB), nameof(ContactTracing.AdultsLatentTB),
+                notification, messages, lostData);
+            CleanValidationPropertyPair(nameof(ContactTracing.ChildrenActiveTB),
+                nameof(ContactTracing.ChildrenLatentTB), notification, messages, lostData);
+
+
+            CleanValidationProperty(nameof(ContactTracing.AdultsStartedTreatment), notification, messages, lostData);
+            CleanValidationProperty(nameof(ContactTracing.ChildrenStartedTreatment), notification, messages, lostData);
+
+            CleanValidationProperty(nameof(ContactTracing.AdultsFinishedTreatment), notification, messages, lostData);
+            CleanValidationProperty(nameof(ContactTracing.ChildrenFinishedTreatment), notification, messages, lostData);
+
+            foreach (var message in messages)
+            {
                 await _logger.LogNotificationWarning(context, runId, notification.LegacyId, message);
-                notification.ContactTracing = new ContactTracing();
+            }
+
+            notification.ClinicalDetails.Notes +=
+                "The following contact tracing values were invalid and were removed from the notification\n"
+                + string.Join(", ", lostData);
+        }
+
+        private static void CleanValidationProperty(string propertyName, Notification notification,
+            List<string> messages, List<string> lostData)
+        {
+            var property = typeof(ContactTracing).GetProperty(propertyName);
+            var propertyValue = property?.GetValue(notification.ContactTracing);
+
+            var validationResults =
+                ValidateProperty(notification.ContactTracing, propertyValue, propertyName).ToList();
+            if (validationResults.Any())
+            {
+                property?.SetValue(notification.ContactTracing, null);
+                messages.AddRange(validationResults.Select(result => result.ErrorMessage));
+                lostData.Add($"{propertyName}: {propertyValue}");
             }
         }
 
-        private static void TrimAndCleanStringProperties(object entity)
+        private static void CleanValidationPropertyPair(string propertyName1, string propertyName2,
+            Notification notification, List<string> messages, List<string> lostData)
         {
-            // Clean strings properties of this object
-            entity?.GetType()
-                .GetProperties()
-                .Where(prop => prop.PropertyType == typeof(string)
-                               && prop.CanWrite
-                               && (Attribute.IsDefined(prop, typeof(RegularExpressionAttribute))
-                                   || Attribute.IsDefined(prop, typeof(MaxLengthAttribute))))
-                .ForEach(prop => prop.SetValue(entity, TrimAndCleanString((string)prop.GetValue(entity))));
+            var property1 = typeof(ContactTracing).GetProperty(propertyName1);
+            var propertyValue1 = property1?.GetValue(notification.ContactTracing);
 
-            // Clean strings properties of this object's entity children
-            entity?
-                .GetType()
-                .GetProperties()
-                .Where(prop => Attribute.IsDefined(prop, typeof(ValidationChildAttribute)))
-                .ForEach(prop => TrimAndCleanStringProperties(prop.GetValue(entity)));
+            var property2 = typeof(ContactTracing).GetProperty(propertyName2);
+            var propertyValue2 = property2?.GetValue(notification.ContactTracing);
 
-            // Clean strings properties of this object's enumerable children
-            entity?
-                .GetType()
-                .GetProperties()
-                .Where(prop => Attribute.IsDefined(prop, typeof(ValidationChildEnumerableAttribute)))
-                .Select(prop => prop.GetValue(entity))
-                .Where(enumerable => enumerable != null)
-                .OfType<IEnumerable<object>>()
-                // Flatten
-                .SelectMany(element => element)
-                .ForEach(TrimAndCleanStringProperties);
+            var validationResults1 =
+                ValidateProperty(notification.ContactTracing, propertyValue1, propertyName1).ToList();
+            var validationResults2 =
+                ValidateProperty(notification.ContactTracing, propertyValue2, propertyName2).ToList();
+
+            if (validationResults1.Any() || validationResults2.Any())
+            {
+                property1?.SetValue(notification.ContactTracing, null);
+                property2?.SetValue(notification.ContactTracing, null);
+
+                messages.AddRange(validationResults1.Select(result => result.ErrorMessage));
+                messages.AddRange(validationResults2.Select(result => result.ErrorMessage));
+
+                if (propertyValue1 != null) lostData.Add($"{propertyName1}: {propertyValue1}");
+                if (propertyValue2 != null) lostData.Add($"{propertyName2}: {propertyValue2}");
+            }
         }
-
-        private static string TrimAndCleanString(string s) => s?.Trim().Replace("\t", " ");
 
         private async Task<IEnumerable<ValidationResult>> GetValidationErrors(PerformContext context,
             int runId, Notification notification)
@@ -189,6 +270,17 @@ namespace ntbs_service.DataMigration
             var validationsResults = new List<ValidationResult>();
 
             Validator.TryValidateObject(objectToValidate, validationContext, validationsResults, true);
+
+            return validationsResults;
+        }
+
+        private static IEnumerable<ValidationResult> ValidateProperty(object objectToValidate, object propertyValue,
+            string propertyName)
+        {
+            var validationContext = new ValidationContext(objectToValidate, null, null) { MemberName = propertyName };
+            var validationsResults = new List<ValidationResult>();
+
+            Validator.TryValidateProperty(propertyValue, validationContext, validationsResults);
 
             return validationsResults;
         }

--- a/ntbs-service/Models/Entities/ContactTracing.cs
+++ b/ntbs-service/Models/Entities/ContactTracing.cs
@@ -33,7 +33,7 @@ namespace ntbs_service.Models.Entities
         [PositiveIntegerSmallerThanDifferenceOfValues("ChildrenScreened", "ChildrenActiveTB", ErrorMessage = ValidationMessages.ContactTracingChildrenLatentTB)]
         public int? ChildrenLatentTB { get; set; }
 
-        [PositiveIntegerSmallerThanValue("AdultsLatentTB", ErrorMessage = ValidationMessages.ContactTracingAdultStartedTreatment)]
+        [PositiveIntegerSmallerThanValue("AdultsLatentTB", ErrorMessage = ValidationMessages.ContactTracingAdultsStartedTreatment)]
         public int? AdultsStartedTreatment { get; set; }
 
         [PositiveIntegerSmallerThanValue("ChildrenLatentTB", ErrorMessage = ValidationMessages.ContactTracingChildrenStartedTreatment)]

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -72,7 +72,7 @@
         public const string ContactTracingChildrenLatentTB = "Children with latent TB must not be greater than number of children screened minus those with active TB";
         public const string ContactTracingAdultsActiveTB = "Adults with active TB  must not be greater than number of adults screened minus those with latent TB";
         public const string ContactTracingChildrenActiveTB = "Children with active TB must not be greater than equal to than number of children screened minus those with latent TB";
-        public const string ContactTracingAdultStartedTreatment = "Adults that have started treatment must not be greater than number of adults with latent TB";
+        public const string ContactTracingAdultsStartedTreatment = "Adults that have started treatment must not be greater than number of adults with latent TB";
         public const string ContactTracingChildrenStartedTreatment = "Children that have started treatment must not be greater than number of children with latent TB";
         public const string ContactTracingAdultsFinishedTreatment = "Adults that have finished treatment must not be greater than number of adults that started treatment";
         public const string ContactTracingChildrenFinishedTreatment = "Children that have finished treatment must not be greater than number of children that started treatment";


### PR DESCRIPTION
## Description
### Clean contact tracing data on import

Previously we would clean contact tracing data by checking whether it was entirely valid or not, and discarding it all if not. Now, try to preserve data from the outer rings of the Venn diagram (cases identified, screened etc.) even when inner rings (like  treatment info) are invalid.

For example, if there were 3 adult contacts identified, but 5 cases of adult latent TB identified after contact tracing: before we would just discard all info, and now we retain the 3 identified cases, but drop the invalid latent TB case count.

Add a set of tests for this new behaviour.

## Checklist:
- [x] Automated tests are passing locally.