### PR TITLE
NTBS-2571: Fix alert case manager and tb service names

### DIFF
--- a/ntbs-service-unit-tests/DataAccess/AlertRepositoryTests.cs
+++ b/ntbs-service-unit-tests/DataAccess/AlertRepositoryTests.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using ntbs_service.DataAccess;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Entities.Alerts;
+using ntbs_service.Models.Enums;
+using ntbs_service.Models.ReferenceEntities;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataAccess
+{
+    public class AlertRepositoryTests : IClassFixture<RepositoryFixture<AlertRepository>>, IDisposable
+    {
+        private readonly NtbsContext _context;
+        private readonly AlertRepository _alertRepo;
+
+        public AlertRepositoryTests(RepositoryFixture<AlertRepository> alertRepositoryFixture)
+        {
+            _context = alertRepositoryFixture.Context;
+            _alertRepo = new AlertRepository(_context);
+        }
+
+        private readonly User _caseManager = new User {DisplayName = "Pharoah Sanders", Username = "ps@fake-nhs.co"};
+        private readonly TBService _tbService = new TBService {Code = "TB-TEST-001", Name = "Test Service 001"};
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public async void CorrectlyMapsTransferAlertToDisplayAlert(bool hasCaseManager, bool hasTbService)
+        {
+            // Arrange
+            var notification = await GivenNotificationWithCaseManagerAndTbService
+                (hasCaseManager ? _caseManager : null, hasTbService ? _tbService : null);
+            await _context.Alert.AddAsync(new TransferAlert()
+            {
+                CaseManagerId = notification.HospitalDetails.CaseManagerId,
+                TbServiceCode = notification.HospitalDetails.TBServiceCode,
+                CreationDate = new DateTime(2004,2,2),
+                NotificationId = notification.NotificationId,
+                AlertType = AlertType.TransferRequest
+            });
+            _context.SaveChanges();
+
+            // Act
+            var result = (await _alertRepo.GetOpenAlertsForNotificationAsync(notification.NotificationId)).Single();
+
+            // Assert
+            Assert.Equal(hasCaseManager ? _caseManager.DisplayName : null, result.CaseManagerName);
+            Assert.Equal(hasTbService ? _tbService.Code : null, result.TbServiceCode);
+            Assert.Equal(hasTbService ? _tbService.Name : null, result.TbServiceName);
+            Assert.Equal(new DateTime(2004,2,2), result.CreationDate);
+            Assert.Equal(notification.NotificationId, result.NotificationId);
+            Assert.Equal(AlertType.TransferRequest, result.AlertType);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async void CorrectlyMapsUserOnNonTransferAlertToDisplayAlert(bool hasCaseManager, bool caseManagerIsActive)
+        {
+            // Arrange
+            var caseManager = hasCaseManager
+                ? new User {DisplayName = "Pharoah Sanders", Username = "ps@fake-nhs.co", IsActive = caseManagerIsActive}
+                : null;
+            var notification = await GivenNotificationWithCaseManagerAndTbService(caseManager, _tbService);
+
+            await _context.Alert.AddAsync(new DataQualityTreatmentOutcome12()
+            {
+                CreationDate = new DateTime(2004,2,2),
+                NotificationId = notification.NotificationId,
+                AlertType = AlertType.DataQualityTreatmentOutcome12
+            });
+            _context.SaveChanges();
+
+            // Act
+            var result = (await _alertRepo.GetOpenAlertsForNotificationAsync(notification.NotificationId)).Single();
+
+            // Assert
+            Assert.Equal(caseManagerIsActive && hasCaseManager ? caseManager.DisplayName : null, result.CaseManagerName);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async void CorrectlyMapsTBServiceOnNonTransferAlertToDisplayAlert(bool hasTbService)
+        {
+            // Arrange
+            var notification = await GivenNotificationWithCaseManagerAndTbService(_caseManager, hasTbService ? _tbService : null);
+
+            await _context.Alert.AddAsync(new DataQualityTreatmentOutcome12()
+            {
+                CreationDate = new DateTime(2004,2,2),
+                NotificationId = notification.NotificationId,
+                AlertType = AlertType.DataQualityTreatmentOutcome12
+            });
+            _context.SaveChanges();
+
+            // Act
+            var result = (await _alertRepo.GetOpenAlertsForNotificationAsync(notification.NotificationId)).Single();
+
+            // Assert
+            Assert.Equal(hasTbService ? _tbService.Code : null, result.TbServiceCode);
+            Assert.Equal(hasTbService ? _tbService.Name : null, result.TbServiceName);
+        }
+
+        private async Task<Notification> GivenNotificationWithCaseManagerAndTbService(User caseManager, TBService tbService)
+        {
+            var notification = await _context.Notification.AddAsync(new Notification {NotificationId = 6655,
+                HospitalDetails = new HospitalDetails
+                {
+                    CaseManager = caseManager,
+                    TBService = tbService
+                }
+            });
+            await _context.SaveChangesAsync();
+            return notification.Entity;
+        }
+
+        public void Dispose()
+        {
+            _context.Alert.RemoveRange(_context.Alert);
+            _context.Notification.RemoveRange(_context.Notification);
+            _context.TbService.RemoveRange(_context.TbService);
+            _context.User.RemoveRange(_context.User);
+            _context.SaveChanges();
+        }
+    }
+}

--- a/ntbs-service-unit-tests/DataAccess/AlertRepositoryTests.cs
+++ b/ntbs-service-unit-tests/DataAccess/AlertRepositoryTests.cs
@@ -25,11 +25,16 @@ namespace ntbs_service_unit_tests.DataAccess
         private readonly TBService _tbService = new TBService {Code = "TB-TEST-001", Name = "Test Service 001"};
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(false, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public async void CorrectlyMapsTransferAlertToDisplayAlert(bool hasCaseManager, bool hasTbService)
+        [InlineData(true, true, "Pharoah Sanders", "Test Service 001", "TB-TEST-001")]
+        [InlineData(false, true, null, "Test Service 001", "TB-TEST-001")]
+        [InlineData(true, false, "Pharoah Sanders", null, null)]
+        [InlineData(false, false, null, null, null)]
+        public async void CorrectlyMapsTransferAlertToDisplayAlert(
+            bool hasCaseManager,
+            bool hasTbService,
+            string expectedCaseManagerName,
+            string expectedTbServiceName,
+            string expectedTbServiceCode)
         {
             // Arrange
             var notification = await GivenNotificationWithCaseManagerAndTbService
@@ -48,20 +53,20 @@ namespace ntbs_service_unit_tests.DataAccess
             var result = (await _alertRepo.GetOpenAlertsForNotificationAsync(notification.NotificationId)).Single();
 
             // Assert
-            Assert.Equal(hasCaseManager ? _caseManager.DisplayName : null, result.CaseManagerName);
-            Assert.Equal(hasTbService ? _tbService.Code : null, result.TbServiceCode);
-            Assert.Equal(hasTbService ? _tbService.Name : null, result.TbServiceName);
+            Assert.Equal(expectedCaseManagerName, result.CaseManagerName);
+            Assert.Equal(expectedTbServiceCode, result.TbServiceCode);
+            Assert.Equal(expectedTbServiceName, result.TbServiceName);
             Assert.Equal(new DateTime(2004,2,2), result.CreationDate);
             Assert.Equal(notification.NotificationId, result.NotificationId);
             Assert.Equal(AlertType.TransferRequest, result.AlertType);
         }
 
         [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public async void CorrectlyMapsUserOnNonTransferAlertToDisplayAlert(bool hasCaseManager, bool caseManagerIsActive)
+        [InlineData(true, true, "Pharoah Sanders")]
+        [InlineData(true, false, null)]
+        [InlineData(false, false, null)]
+        public async void CorrectlyMapsUserOnNonTransferAlertToDisplayAlert
+            (bool hasCaseManager, bool caseManagerIsActive, string expectedCaseManagerName)
         {
             // Arrange
             var caseManager = hasCaseManager
@@ -81,13 +86,16 @@ namespace ntbs_service_unit_tests.DataAccess
             var result = (await _alertRepo.GetOpenAlertsForNotificationAsync(notification.NotificationId)).Single();
 
             // Assert
-            Assert.Equal(caseManagerIsActive && hasCaseManager ? caseManager.DisplayName : null, result.CaseManagerName);
+            Assert.Equal(expectedCaseManagerName, result.CaseManagerName);
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async void CorrectlyMapsTBServiceOnNonTransferAlertToDisplayAlert(bool hasTbService)
+        [InlineData(true, "Test Service 001", "TB-TEST-001")]
+        [InlineData(false, null, null)]
+        public async void CorrectlyMapsTBServiceOnNonTransferAlertToDisplayAlert(
+            bool hasTbService,
+            string expectedTbServiceName,
+            string expectedTbServiceCode)
         {
             // Arrange
             var notification = await GivenNotificationWithCaseManagerAndTbService(_caseManager, hasTbService ? _tbService : null);
@@ -104,8 +112,8 @@ namespace ntbs_service_unit_tests.DataAccess
             var result = (await _alertRepo.GetOpenAlertsForNotificationAsync(notification.NotificationId)).Single();
 
             // Assert
-            Assert.Equal(hasTbService ? _tbService.Code : null, result.TbServiceCode);
-            Assert.Equal(hasTbService ? _tbService.Name : null, result.TbServiceName);
+            Assert.Equal(expectedTbServiceCode, result.TbServiceCode);
+            Assert.Equal(expectedTbServiceName, result.TbServiceName);
         }
 
         private async Task<Notification> GivenNotificationWithCaseManagerAndTbService(User caseManager, TBService tbService)

--- a/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryTests.cs
+++ b/ntbs-service-unit-tests/DataAccess/DataQualityRepositoryTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace ntbs_service_unit_tests.DataAccess
 {
-    public class DataQualityRepositoryTests : IClassFixture<DataQualityRepositoryFixture>, IDisposable
+    public class DataQualityRepositoryTests : IClassFixture<RepositoryFixture<DataQualityRepository>>, IDisposable
     {
         private readonly NtbsContext _context;
 
@@ -20,7 +20,7 @@ namespace ntbs_service_unit_tests.DataAccess
         private const string BirthCountryAlertName = "B";
         private const string ClinicalDatesAlertName = "C";
 
-        public DataQualityRepositoryTests(DataQualityRepositoryFixture dataQualityRepositoryFixture)
+        public DataQualityRepositoryTests(RepositoryFixture<DataQualityRepository> dataQualityRepositoryFixture)
         {
             _context = dataQualityRepositoryFixture.Context;
         }

--- a/ntbs-service-unit-tests/DataAccess/RepositoryFixture.cs
+++ b/ntbs-service-unit-tests/DataAccess/RepositoryFixture.cs
@@ -6,14 +6,14 @@ using Xunit;
 namespace ntbs_service_unit_tests.DataAccess
 {
     // ReSharper disable once ClassNeverInstantiated.Global
-    public class DataQualityRepositoryFixture : IAsyncLifetime
+    public class RepositoryFixture<T> : IAsyncLifetime
     {
         public NtbsContext Context;
 
         public async Task InitializeAsync()
         {
             var contextOptions = new DbContextOptionsBuilder<NtbsContext>()
-                .UseSqlite($"Filename={nameof(DataQualityRepositoryTests)}.db")
+                .UseSqlite($"Filename={typeof(T)}.db")
                 .Options;
 
             Context = new NtbsContext(contextOptions);

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -139,11 +139,10 @@ namespace ntbs_service.DataAccess
                             : alert.Notification.HospitalDetails.TBServiceCode,
                         TbServiceName = alert is TransferAlert
                             ? ((TransferAlert)alert).TbService.Name
-                            : alert.Notification.HospitalDetails.TBService != null
-                                ? alert.Notification.HospitalDetails.TBService.Name : null,
+                            : alert.Notification.HospitalDetails.TBService.Name,
                         CaseManagerName = alert is TransferAlert
                             ? ((TransferAlert)alert).CaseManager.DisplayName
-                            : alert.Notification.HospitalDetails.CaseManager != null && alert.Notification.HospitalDetails.CaseManager.IsActive
+                            : alert.Notification.HospitalDetails.CaseManager.IsActive
                                 ? alert.Notification.HospitalDetails.CaseManager.DisplayName : null,
                         AlertType = alert.AlertType,
                         Action = alert.Action,

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -139,10 +139,12 @@ namespace ntbs_service.DataAccess
                             : alert.Notification.HospitalDetails.TBServiceCode,
                         TbServiceName = alert is TransferAlert
                             ? ((TransferAlert)alert).TbService.Name
-                            : alert.Notification.HospitalDetails.TBServiceName,
+                            : alert.Notification.HospitalDetails.TBService != null
+                                ? alert.Notification.HospitalDetails.TBService.Name : null,
                         CaseManagerName = alert is TransferAlert
                             ? ((TransferAlert)alert).CaseManager.DisplayName
-                            : alert.Notification.HospitalDetails.CaseManagerName,
+                            : alert.Notification.HospitalDetails.CaseManager != null && alert.Notification.HospitalDetails.CaseManager.IsActive
+                                ? alert.Notification.HospitalDetails.CaseManager.DisplayName : null,
                         AlertType = alert.AlertType,
                         Action = alert.Action,
                         ActionLink = alert.ActionLink,


### PR DESCRIPTION
## Description
When we were projecting the alerts to AlertWithTbServiceForDisplay we were actually never getting the TB service's name/code or the case manager's name - as it was trying to pull them from HospitalDetailsDisplay. Now we actually go to the entity we want the name/code from. I've added tests so this isn't reintroduced.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
