### PR TITLE
NTBS-2573 Fix validation bug on lab results page

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -94,6 +94,8 @@ namespace ntbs_integration_tests.Helpers
 
         public const int NOTIFICATION_WITH_PREVIOUS_TB_SERVICE_OF_ABINGDON = 10400;
 
+        public const int UNUSED_NOTIFICATION_ID = 999999;
+
         public const int ALERT_ID = 20001;
         public const int TRANSFER_ALERT_ID = 20002;
         public const int TRANSFER_ALERT_ID_TO_ACCEPT = 20003;

--- a/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
+++ b/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
@@ -1,12 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using ntbs_integration_tests.Helpers;
 using ntbs_integration_tests.TestServices;
 using ntbs_service;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
+using ntbs_service.Models.Validations;
 using ntbs_service.Services;
 using Xunit;
 using IndexModel = ntbs_service.Pages.LabResults.IndexModel;
@@ -16,6 +20,8 @@ namespace ntbs_integration_tests.LabResultsPage
     public class LabResultsPageTests : TestRunnerBase
     {
         public LabResultsPageTests(NtbsWebApplicationFactory<Startup> factory) : base(factory) { }
+
+        const string PageRoute = "/LabResults";
 
         public static IList<Notification> GetSeedingNotifications()
         {
@@ -44,7 +50,17 @@ namespace ntbs_integration_tests.LabResultsPage
                 new Notification
                 {
                     NotificationId = Utilities.SPECIMEN_MATCHING_MANUAL_MATCH_NOTIFICATION_ID,
-                    NotificationStatus = NotificationStatus.Notified
+                    NotificationStatus = NotificationStatus.Notified,
+                    NotificationDate = DateTime.Parse("2021-01-01"),
+                    PatientDetails = new PatientDetails
+                    {
+                        NhsNumber = "9535981730",
+                        FamilyName = "Bloggs", GivenName = "Joe"
+                    },
+                    HospitalDetails = new HospitalDetails
+                    {
+                        TBServiceCode = Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID
+                    }
                 }
             };
         }
@@ -66,7 +82,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 };
 
                 //Act
-                var response = await client.GetAsync("/LabResults");
+                var response = await client.GetAsync(PageRoute);
                 var document = await GetDocumentAsync(response);
 
                 // Assert
@@ -96,7 +112,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 .CreateClientWithoutRedirects())
             {
                 //Act
-                var response = await client.GetAsync("/LabResults");
+                var response = await client.GetAsync(PageRoute);
                 var document = await GetDocumentAsync(response);
 
                 // Assert
@@ -124,7 +140,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 };
 
                 //Act
-                var response = await client.GetAsync("/LabResults");
+                var response = await client.GetAsync(PageRoute);
                 var document = await GetDocumentAsync(response);
 
                 // Assert
@@ -161,7 +177,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 };
 
                 //Act
-                var response = await client.GetAsync("/LabResults");
+                var response = await client.GetAsync(PageRoute);
                 var document = await GetDocumentAsync(response);
 
                 // Assert
@@ -191,8 +207,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 // Arrange
                 var specimenNumber = MockSpecimenService.MockUnmatchedSpecimenForTbService.ReferenceLaboratoryNumber;
 
-                const string url = "/LabResults";
-                var response = await client.GetAsync(url);
+                var response = await client.GetAsync(PageRoute);
                 var document = await GetDocumentAsync(response);
 
                 var formData = new Dictionary<string, string>
@@ -203,10 +218,10 @@ namespace ntbs_integration_tests.LabResultsPage
                 };
 
                 // Act
-                var postResponse = await client.SendPostFormWithData(document, formData, url);
+                var postResponse = await client.SendPostFormWithData(document, formData, PageRoute);
 
                 // Assert
-                await AssertAndFollowRedirect(postResponse, url);
+                await AssertAndFollowRedirect(postResponse, PageRoute);
 
                 // As session/tempData aren't functional by default with webApplicationFactory, and configuring this
                 // wasn't deemed a good use of time, cannot confirm that the flash message is shown here.
@@ -227,8 +242,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 var specimenNumber = expectedUnmatchedSpecimen.ReferenceLaboratoryNumber;
                 const int manualMatchNotificationId = Utilities.SPECIMEN_MATCHING_MANUAL_MATCH_NOTIFICATION_ID;
 
-                const string url = "/LabResults";
-                var response = await client.GetAsync(url);
+                var response = await client.GetAsync(PageRoute);
                 var document = await GetDocumentAsync(response);
 
                 var formData = new Dictionary<string, string>
@@ -240,10 +254,10 @@ namespace ntbs_integration_tests.LabResultsPage
                 };
 
                 // Act
-                var postResponse = await client.SendPostFormWithData(document, formData, url);
+                var postResponse = await client.SendPostFormWithData(document, formData, PageRoute);
 
                 // Assert
-                await AssertAndFollowRedirect(postResponse, url);
+                await AssertAndFollowRedirect(postResponse, PageRoute);
 
                 // As session/tempData aren't functional by default with webApplicationFactory, and configuring this
                 // wasn't deemed a good use of time, cannot confirm that the flash message is shown here.
@@ -264,8 +278,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 var specimenNumber = expectedUnmatchedSpecimen.ReferenceLaboratoryNumber;
                 const int manualMatchNotificationId = 999145;
 
-                const string url = "/LabResults/";
-                var response = await client.GetAsync(url);
+                var response = await client.GetAsync(PageRoute);
                 var document = await GetDocumentAsync(response);
 
                 var formData = new Dictionary<string, string>
@@ -277,7 +290,7 @@ namespace ntbs_integration_tests.LabResultsPage
                 };
 
                 // Act
-                var result = await client.SendPostFormWithData(document, formData, url);
+                var result = await client.SendPostFormWithData(document, formData, PageRoute);
                 var resultDocument = await GetDocumentAsync(result);
 
                 // Assert
@@ -299,11 +312,119 @@ namespace ntbs_integration_tests.LabResultsPage
                 .CreateClientWithoutRedirects())
             {
                 // Act
-                var response = await client.GetAsync("/LabResults");
+                var response = await client.GetAsync(PageRoute);
 
                 // Assert
-                response.AssertRedirectTo("/Account/AccessDenied");
+                response.AssertRedirectTo(RouteHelper.AccessDeniedPath);
             }
         }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public async Task GetPotentialMatchData_ReturnsEmptyJson_WhenIdEmpty(string submittedId)
+        {
+            // Act
+            var response = await Client.GetAsync(GetPotentialMatchUrl(submittedId));
+
+            // Assert
+            var resultString = await response.Content.ReadAsStringAsync();
+            var results = JsonConvert.DeserializeObject<Dictionary<string, string>>(resultString);
+
+            Assert.NotNull(results);
+            Assert.Empty(results);
+        }
+
+        [Theory]
+        [InlineData("-1")]
+        [InlineData("Banana")]
+        [InlineData("abcde12345")]
+        public async Task GetPotentialMatchData_ReturnsError_WhenIdInvalid(string submittedId)
+        {
+            // Act
+            var response = await Client.GetAsync(GetPotentialMatchUrl(submittedId));
+
+            // Assert
+            var resultString = await response.Content.ReadAsStringAsync();
+            var results = JsonConvert.DeserializeObject<Dictionary<string, string>>(resultString);
+
+            Assert.NotNull(results);
+            Assert.Collection(results, pair =>
+            {
+                Assert.Equal("errorMessage", pair.Key);
+                Assert.Equal(string.Format(ValidationMessages.NumberFormat, "Notification Id"), pair.Value);
+            });
+        }
+
+        [Theory]
+        [InlineData(Utilities.DRAFT_ID)]
+        [InlineData(Utilities.DENOTIFIED_ID)]
+        [InlineData(Utilities.UNUSED_NOTIFICATION_ID)]
+        public async Task GetPotentialMatchData_ReturnsError_WhenIdDoesNotExist(int submittedId)
+        {
+            // Act
+            var response = await Client.GetAsync(GetPotentialMatchUrl(submittedId.ToString()));
+
+            // Assert
+            var resultString = await response.Content.ReadAsStringAsync();
+            var results = JsonConvert.DeserializeObject<Dictionary<string, string>>(resultString);
+
+            Assert.NotNull(results);
+            Assert.Collection(results, pair =>
+            {
+                Assert.Equal("errorMessage", pair.Key);
+                Assert.Equal(ValidationMessages.LabResultNotificationDoesNotExist, pair.Value);
+            });
+        }
+
+        [Fact]
+        public async Task GetPotentialMatchData_ReturnsError_WhenUserDoesNotHaveAccess()
+        {
+            // Arrange
+            var submittedId = Utilities.SPECIMEN_MATCHING_MANUAL_MATCH_NOTIFICATION_ID.ToString();
+
+            using (var client = Factory.WithUserAuth(TestUser.GatesheadCaseManager)
+                .CreateClientWithoutRedirects())
+            {
+                // Act
+                var response = await client.GetAsync(GetPotentialMatchUrl(submittedId));
+
+                // Assert
+                var resultString = await response.Content.ReadAsStringAsync();
+                var results = JsonConvert.DeserializeObject<Dictionary<string, string>>(resultString);
+
+                Assert.NotNull(results);
+                Assert.Collection(results, pair =>
+                {
+                    Assert.Equal("errorMessage", pair.Key);
+                    Assert.Equal(ValidationMessages.LabResultNotificationMatchNoPermission, pair.Value);
+                });
+            }
+        }
+
+        [Fact]
+        public async Task GetPotentialMatchData_ReturnsPartial_WhenNotificationIdExists()
+        {
+            // Arrange
+            var submittedId = Utilities.SPECIMEN_MATCHING_MANUAL_MATCH_NOTIFICATION_ID.ToString();
+
+            // Act
+            var response = await Client.GetAsync(GetPotentialMatchUrl(submittedId.ToString()));
+            var document = await GetDocumentAsync(response);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.NotNull(document.Body);
+
+            var documentHtml = document.Body.InnerHtml;
+            Assert.Contains(Utilities.SPECIMEN_MATCHING_MANUAL_MATCH_NOTIFICATION_ID.ToString(), documentHtml);
+            Assert.Contains("01 Jan 2021", documentHtml);
+            Assert.Contains("953 598 1730", documentHtml);
+            Assert.Contains("BLOGGS, Joe", documentHtml);
+        }
+
+        private static string GetPotentialMatchUrl(string id) =>
+            $"{PageRoute}/PotentialMatchData?manualNotificationId={id}";
     }
 }

--- a/ntbs-service/Pages/LabResults/Index.cshtml.cs
+++ b/ntbs-service/Pages/LabResults/Index.cshtml.cs
@@ -117,6 +117,11 @@ namespace ntbs_service.Pages.LabResults
                 return new JsonResult(new { errorMessage });
             }
 
+            if (string.IsNullOrWhiteSpace(manualNotificationId))
+            {
+                return new JsonResult(new {});
+            }
+
             var parsedManualNotificationId = int.Parse(manualNotificationId);
             var notification = await _notificationRepository.GetNotifiedNotificationAsync(parsedManualNotificationId);
             if (notification == null)
@@ -237,8 +242,7 @@ namespace ntbs_service.Pages.LabResults
                 NotificationId = notification.NotificationId,
                 NotificationDate = notification.NotificationDate,
                 NtbsAddress = notification.PatientDetails.Address,
-                NtbsName =
-                    $"{notification.PatientDetails.FamilyName.ToUpper()}, {notification.PatientDetails.GivenName}",
+                NtbsName = notification.PatientDetails.FullName,
                 NtbsPostcode = notification.PatientDetails.Postcode,
                 NtbsBirthDate = notification.PatientDetails.Dob,
                 NtbsNhsNumber = notification.PatientDetails.FormattedNhsNumber,

--- a/ntbs-service/wwwroot/source/Components/FetchSpecimenPotentialMatch.ts
+++ b/ntbs-service/wwwroot/source/Components/FetchSpecimenPotentialMatch.ts
@@ -12,7 +12,7 @@ const FetchSpecimenPotentialMatch = Vue.extend({
         update: function (userInput: string) {
             this.clearPotentialMatchHtml();
             this.clearErrorMessage();
-            
+
             clearTimeout(this.timeout);
             this.timeout = setTimeout(() => {
                 this.fetchPotentialMatchData(userInput)
@@ -29,11 +29,12 @@ const FetchSpecimenPotentialMatch = Vue.extend({
 
             axios.request(requestConfig)
                 .then((response: any) => {
-                    if (typeof response.data === "object") {
-                        this.showErrorMessage(response.data.errorMessage);
-                    } else {
+                    if (typeof response.data !== "object") {
                         this.updatePotentialMatchHtml(response.data);
+                    } else if (response.data.errorMessage !== undefined) {
+                        this.showErrorMessage(response.data.errorMessage);
                     }
+                    // If no NotificationID was specified, leave it in the cleared state
                 });
         },
         showErrorMessage: function (errorMessage: string) {
@@ -50,8 +51,6 @@ const FetchSpecimenPotentialMatch = Vue.extend({
         },
         updatePotentialMatchHtml(divHtml: string) {
             this.$refs["matchDetails"].innerHTML = divHtml;
-            console.log('UpdatingPotentialDiv');
-            console.log(divHtml);
         },
         clearPotentialMatchHtml() {
             this.$refs["matchDetails"].innerHTML = "";


### PR DESCRIPTION
## Description
When fetching a notification ID for a manual match, if it is null or empty just clear the notification details, and notification ID validation errors, instead of 500'ing.

Add a new field to the response JSON, to say that there was no notification ID in the request.

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing - not done yet, I wanted to get this up for review first
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))