### PR TITLE
NTBS-2553: No longer import case manager twice during migration

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/NotificationImportServiceTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationImportServiceTest.cs
@@ -240,8 +240,6 @@ namespace ntbs_service_unit_tests.DataMigration
 
         private void VerifyInitialImportServicesAreCalled(Notification notification, Times times)
         {
-            _caseManagerImportService.Verify(s =>
-                s.ImportOrUpdateUserFromNotification(notification, _performContext, _runId), times);
             _importValidator
                 .Verify(s => s.CleanAndValidateNotification(_performContext, _runId, notification), times);
         }

--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Hangfire.Server;
 using Moq;
 using ntbs_service.DataAccess;
 using ntbs_service.DataMigration;
@@ -54,7 +55,7 @@ namespace ntbs_service_unit_tests.DataMigration
         public NotificationMapperTest()
         {
             _caseManagerImportService
-                .Setup(serv => serv.ImportOrUpdateLegacyUser(It.IsAny<string>(), It.IsAny<string>()))
+                .Setup(serv => serv.ImportOrUpdateLegacyUser(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<PerformContext>(), It.IsAny<int>()))
                 .Returns(() => Task.CompletedTask);
             _referenceDataRepositoryMock.Setup(repo => repo.GetUserByUsernameAsync(It.IsAny<string>()))
                 .Returns((string username) => Task.FromResult(_usernameToUserDict[username]));

--- a/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
@@ -61,7 +61,7 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             // Act
-            var mappedEvent = await _treatmentEventMapper.AsTransferEvent(migrationTransferEvent);
+            var mappedEvent = await _treatmentEventMapper.AsTransferEvent(migrationTransferEvent, null, 1);
 
             // Assert
             Assert.Equal(DateTime.Parse("12/12/2012"), mappedEvent.EventDate);
@@ -88,7 +88,7 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             // Act
-            var mappedEvent = await _treatmentEventMapper.AsOutcomeEvent(migrationTransferEvent);
+            var mappedEvent = await _treatmentEventMapper.AsOutcomeEvent(migrationTransferEvent, null, 1);
 
             // Assert
             Assert.Equal(DateTime.Parse("12/12/2012"), mappedEvent.EventDate);
@@ -115,7 +115,7 @@ namespace ntbs_service_unit_tests.DataMigration
             };
 
             // Act
-            var mappedEvent = await _treatmentEventMapper.AsOutcomeEvent(migrationTransferEvent);
+            var mappedEvent = await _treatmentEventMapper.AsOutcomeEvent(migrationTransferEvent, null, 1);
 
             // Assert
             Assert.Equal(DateTime.Parse("12/12/2012"), mappedEvent.EventDate);

--- a/ntbs-service/DataMigration/NotificationImportService.cs
+++ b/ntbs-service/DataMigration/NotificationImportService.cs
@@ -186,7 +186,6 @@ namespace ntbs_service.DataMigration
             var isAnyNotificationInvalid = false;
             foreach (var notification in notifications)
             {
-                await _caseManagerImportService.ImportOrUpdateUserFromNotification(notification, context, runId);
                 var linkedNotificationId = notification.LegacyId;
                 _logger.LogInformation(context, runId, $"Validating notification with Id={linkedNotificationId}");
 

--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -161,12 +161,12 @@ namespace ntbs_service.DataMigration
                 var notificationTransferEvents = new List<TreatmentEvent>();
                 foreach (var transfer in transferEvents.Where(sc => sc.OldNotificationId == id))
                 {
-                    notificationTransferEvents.Add(await _treatmentEventMapper.AsTransferEvent(transfer));
+                    notificationTransferEvents.Add(await _treatmentEventMapper.AsTransferEvent(transfer, context, runId));
                 }
                 var notificationOutcomeEvents = new List<TreatmentEvent>();
                 foreach (var outcome in outcomeEvents.Where(sc => sc.OldNotificationId == id))
                 {
-                    notificationOutcomeEvents.Add(await _treatmentEventMapper.AsOutcomeEvent(outcome));
+                    notificationOutcomeEvents.Add(await _treatmentEventMapper.AsOutcomeEvent(outcome, context, runId));
                 }
                 var notificationMBovisAnimalExposures = mbovisAnimalExposures
                     .Where(sc => sc.OldNotificationId == id)
@@ -348,7 +348,7 @@ namespace ntbs_service.DataMigration
             notification.ComorbidityDetails = ExtractComorbidityDetails(rawNotification);
             notification.ImmunosuppressionDetails = ExtractImmunosuppressionDetails(rawNotification);
             notification.SocialRiskFactors = ExtractSocialRiskFactors(rawNotification);
-            notification.HospitalDetails = await ExtractHospitalDetailsAsync(rawNotification);
+            notification.HospitalDetails = await ExtractHospitalDetailsAsync(rawNotification, context, runId);
             notification.ContactTracing = ExtractContactTracingDetails(rawNotification);
             notification.PreviousTbHistory = ExtractPreviousTbHistory(rawNotification);
             notification.MDRDetails = ExtractMdrDetailsAsync(rawNotification);
@@ -356,7 +356,7 @@ namespace ntbs_service.DataMigration
             return notification;
         }
 
-        private async Task<HospitalDetails> ExtractHospitalDetailsAsync(MigrationDbNotification rawNotification)
+        private async Task<HospitalDetails> ExtractHospitalDetailsAsync(MigrationDbNotification rawNotification, PerformContext context, int runId)
         {
             var details = new HospitalDetails
             {
@@ -383,7 +383,7 @@ namespace ntbs_service.DataMigration
 
             if (!string.IsNullOrEmpty(rawNotification.CaseManager))
             {
-                await _caseManagerImportService.ImportOrUpdateLegacyUser(rawNotification.CaseManager, details.TBServiceCode);
+                await _caseManagerImportService.ImportOrUpdateLegacyUser(rawNotification.CaseManager, details.TBServiceCode, context, runId);
                 details.CaseManagerId = (await _referenceDataRepository.GetUserByUsernameAsync(rawNotification.CaseManager)).Id;
             }
 


### PR DESCRIPTION
## Description
While I was investigating 2553 I realised that during the import of a notification we were importing/updating the case manager of the notification twice. I think this was added when we switched to using a user ID - as we needed the ID to add to the hospital details we were importing the case manager in the mapper, but we never removed the call to the import later on in the notification importer/validator step. 

## Checklist:
- [x] Automated tests are passing locally.
