### PR TITLE
NTBS-2533 Tweak notes text from contact tracing

### DIFF
--- a/ntbs-service/DataMigration/ImportValidator.cs
+++ b/ntbs-service/DataMigration/ImportValidator.cs
@@ -169,9 +169,15 @@ namespace ntbs_service.DataMigration
                 "The following contact tracing values were invalid and were removed from the notification:\n"
                 + string.Join(", ", lostData);
 
-            notification.ClinicalDetails.Notes = string.IsNullOrWhiteSpace(notification.ClinicalDetails.Notes)
-                ? contactTracingNotes
-                : notification.ClinicalDetails.Notes + ".\n" + contactTracingNotes;
+            if (string.IsNullOrWhiteSpace(notification.ClinicalDetails.Notes))
+            {
+                notification.ClinicalDetails.Notes = contactTracingNotes;
+            }
+            else
+            {
+                notification.ClinicalDetails.Notes += notification.ClinicalDetails.Notes.Last() == '.' ? "" : ".";
+                notification.ClinicalDetails.Notes += "\n" + contactTracingNotes;
+            }
         }
 
         private static void CleanValidationProperty(string propertyName, Notification notification,


### PR DESCRIPTION
## Description
Tweak notes text from contact tracing, to not append a full stop if the current last character is one.

## Checklist:
- [x] Automated tests are passing locally.