### PR TITLE
NTBS-2530: NHS number validation allows spaces

### DIFF
--- a/ntbs-service-unit-tests/Models/NhsNumberValidatingTest.cs
+++ b/ntbs-service-unit-tests/Models/NhsNumberValidatingTest.cs
@@ -39,7 +39,8 @@ namespace ntbs_service_unit_tests.Models
                 {
                     "0000000000",
                     "1111111111",
-                    "9999999999"
+                    "9999999999",
+                    "111 111 1111"
                 }
                 .Select(number => new object[] { number });
         }
@@ -75,7 +76,8 @@ namespace ntbs_service_unit_tests.Models
             {
                 "4123456789",
                 "5234567890",
-                "6345678901"
+                "6345678901",
+                "683 844 1857"
             }
             .Select(number => new object[] { number });
         }
@@ -93,7 +95,9 @@ namespace ntbs_service_unit_tests.Models
             {
                 "6511195635",
                 "8881441519",
-                "5864552852"
+                "5864552852",
+                "251 244 6433",
+                "683 8 4 4 085 7"
             }
             .Select(number => new object[] { number });
         }

--- a/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
@@ -193,6 +193,7 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdateImmunosuppressionDetails_LeavesValuesUnchangedWhenStatusIsYes()
         {
+            // Arrange
             var reference = new ImmunosuppressionDetails
             {
                 Status = Status.Yes,
@@ -211,8 +212,10 @@ namespace ntbs_service_unit_tests.Services
             };
             var notification = new Notification();
 
+            // Act
             await _notificationService.UpdateImmunosuppresionDetailsAsync(notification, input);
 
+            // Assert
             Assert.Equal(reference.Status, input.Status);
             Assert.Equal(reference.HasBioTherapy, input.HasBioTherapy);
             Assert.Equal(reference.HasTransplantation, input.HasTransplantation);
@@ -226,6 +229,7 @@ namespace ntbs_service_unit_tests.Services
         [InlineData((int)Status.Unknown)]
         public async Task UpdateImmunosuppressionDetails_StripsAllButStatusWhenStatusIsNotYes(int status)
         {
+            // Arrange
             var parsedStatus = (Status)status;
             var reference = new ImmunosuppressionDetails
             {
@@ -245,8 +249,10 @@ namespace ntbs_service_unit_tests.Services
             };
             var notification = new Notification();
 
+            // Act
             await _notificationService.UpdateImmunosuppresionDetailsAsync(notification, input);
 
+            // Assert
             Assert.Equal(reference.Status, input.Status);
             Assert.NotEqual(reference.HasBioTherapy, input.HasBioTherapy);
             Assert.Null(input.HasBioTherapy);
@@ -264,6 +270,7 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdateImmunosuppressionDetails_StripsOtherDescriptionWhenHasOtherIsFalse()
         {
+            // Arrange
             var reference = new ImmunosuppressionDetails
             {
                 Status = Status.Yes,
@@ -278,8 +285,10 @@ namespace ntbs_service_unit_tests.Services
             };
             var notification = new Notification();
 
+            // Act
             await _notificationService.UpdateImmunosuppresionDetailsAsync(notification, input);
 
+            // Assert
             Assert.Equal(reference.Status, input.Status);
             Assert.Equal(reference.HasOther, input.HasOther);
             Assert.NotEqual(reference.OtherDescription, input.OtherDescription);
@@ -292,22 +301,25 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdatePatientDetails_FormatsNhsNumber()
         {
-            var reference = new PatientDetails { NhsNumber = "12345" };
+            // Arrange
+            var expectedNhsNumber = "12345" ;
             var input = new PatientDetails { NhsNumber = "12 345" };
             var notification = new Notification();
 
+            // Act
             await _notificationService.UpdatePatientDetailsAsync(notification, input);
 
-            Assert.Equal(reference.NhsNumber, input.NhsNumber);
-
-            _mockContext.Verify(context => context.SetValues(notification.PatientDetails, input));
-            _mockAlertService.Verify(x => x.AutoDismissAlertAsync<DataQualityBirthCountryAlert>(It.IsAny<Notification>()), Times.Once);
+            // Assert
+            _mockContext.Verify(context => context.SetValues(
+                notification.PatientDetails,
+                It.Is<PatientDetails>(pd => pd.NhsNumber == expectedNhsNumber)));
             VerifyUpdateDatabaseCalled();
         }
 
         [Fact]
         public async Task UpdatePatientFlags_StripsNhsNumberIfNotKnownAsync()
         {
+            // Arrange
             var reference = new PatientDetails { NhsNumberNotKnown = true, NhsNumber = "12345" };
             var input = new PatientDetails
             {
@@ -315,8 +327,10 @@ namespace ntbs_service_unit_tests.Services
                 NhsNumber = reference.NhsNumber
             };
 
+            // Act
             await _notificationService.UpdatePatientFlagsAsync(input);
 
+            // Assert
             Assert.Equal(reference.NhsNumberNotKnown, input.NhsNumberNotKnown);
             Assert.NotEqual(reference.NhsNumber, input.NhsNumber);
             Assert.Null(input.NhsNumber);
@@ -325,6 +339,7 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdatePatientFlags_DoesNotStripNhsNumberIfKnown()
         {
+            // Arrange
             var reference = new PatientDetails { NhsNumberNotKnown = false, NhsNumber = "12345" };
             var input = new PatientDetails
             {
@@ -332,8 +347,10 @@ namespace ntbs_service_unit_tests.Services
                 NhsNumber = reference.NhsNumber
             };
 
+            // Act
             await _notificationService.UpdatePatientFlagsAsync(input);
 
+            // Assert
             Assert.Equal(reference.NhsNumberNotKnown, input.NhsNumberNotKnown);
             Assert.Equal(reference.NhsNumber, input.NhsNumber);
         }
@@ -341,11 +358,14 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdatePatientFlags_StripsPostcodeIfNoFixedAbode()
         {
+            // Arrange
             var reference = new PatientDetails { NoFixedAbode = true, Postcode = "12345" };
             var input = new PatientDetails { NoFixedAbode = reference.NoFixedAbode, Postcode = reference.Postcode };
 
+            // Act
             await _notificationService.UpdatePatientFlagsAsync(input);
 
+            // Assert
             Assert.Equal(reference.NoFixedAbode, input.NoFixedAbode);
             Assert.NotEqual(reference.Postcode, input.Postcode);
             Assert.Null(input.Postcode);
@@ -354,11 +374,14 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdatePatientFlags_DoesNotStripPostcodeIfFixedAbode()
         {
+            // Arrange
             var reference = new PatientDetails { NoFixedAbode = false, Postcode = "12345" };
             var input = new PatientDetails { NoFixedAbode = reference.NoFixedAbode, Postcode = reference.Postcode };
 
+            // Act
             await _notificationService.UpdatePatientFlagsAsync(input);
 
+            // Assert
             Assert.Equal(reference.NoFixedAbode, input.NoFixedAbode);
             Assert.Equal(reference.Postcode, input.Postcode);
         }
@@ -375,8 +398,10 @@ namespace ntbs_service_unit_tests.Services
             _mockReferenceDataRepository.Setup(rep => rep.GetOccupationByIdAsync(input.OccupationId.Value))
                 .Returns(Task.FromResult(new Occupation { HasFreeTextField = false }));
 
+            // Act
             await _notificationService.UpdatePatientFlagsAsync(input);
 
+            // Assert
             Assert.Equal(reference.OccupationId, input.OccupationId);
             Assert.NotEqual(reference.OccupationOther, input.OccupationOther);
             Assert.Null(input.OccupationOther);
@@ -385,6 +410,7 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdatePatientFlags_DoesNotStripOccupationFreeTextIfFreeTextForOccupation()
         {
+            // Arrange
             var reference = new PatientDetails { OccupationId = 1, OccupationOther = "12345" };
             var input = new PatientDetails
             {
@@ -394,14 +420,17 @@ namespace ntbs_service_unit_tests.Services
             _mockReferenceDataRepository.Setup(rep => rep.GetOccupationByIdAsync(input.OccupationId.Value))
                 .Returns(Task.FromResult(new Occupation { HasFreeTextField = true }));
 
+            // Act
             await _notificationService.UpdatePatientFlagsAsync(input);
 
+            // Assert
             Assert.Equal(reference.OccupationId, input.OccupationId);
             Assert.Equal(reference.OccupationOther, input.OccupationOther);
         }
 
         private void VerifyUpdateDatabaseCalled()
         {
+            // Arrange
             _mockNotificationRepository.Verify(mock =>
                 mock.SaveChangesAsync(It.IsAny<NotificationAuditType>(), It.IsAny<string>()));
         }
@@ -442,6 +471,7 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdateNotificationClustersAsync_DoesNotThrowIfNotificationExists()
         {
+            // Arrange
             const int existingNotification = 1;
             _mockNotificationRepository
                 .Setup(r => r.GetNotificationAsync(existingNotification))
@@ -461,11 +491,13 @@ namespace ntbs_service_unit_tests.Services
         [Fact]
         public async Task UpdateNotificationClustersAsync_ThrowsIfNotificationDoesNotExist()
         {
+            // Arrange
             const int notExistingNotification = 1;
             _mockNotificationRepository
                 .Setup(r => r.GetNotificationAsync(notExistingNotification))
                 .Returns(Task.FromResult<Notification>(null));
 
+            // Assert
             await Assert.ThrowsAnyAsync<DataException>(() =>
                 _notificationService.UpdateNotificationClustersAsync(
                     new List<NotificationClusterValue>

--- a/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/NotificationServiceTest.cs
@@ -290,6 +290,22 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Fact]
+        public async Task UpdatePatientDetails_FormatsNhsNumber()
+        {
+            var reference = new PatientDetails { NhsNumber = "12345" };
+            var input = new PatientDetails { NhsNumber = "12 345" };
+            var notification = new Notification();
+
+            await _notificationService.UpdatePatientDetailsAsync(notification, input);
+
+            Assert.Equal(reference.NhsNumber, input.NhsNumber);
+
+            _mockContext.Verify(context => context.SetValues(notification.PatientDetails, input));
+            _mockAlertService.Verify(x => x.AutoDismissAlertAsync<DataQualityBirthCountryAlert>(It.IsAny<Notification>()), Times.Once);
+            VerifyUpdateDatabaseCalled();
+        }
+
+        [Fact]
         public async Task UpdatePatientFlags_StripsNhsNumberIfNotKnownAsync()
         {
             var reference = new PatientDetails { NhsNumberNotKnown = true, NhsNumber = "12345" };

--- a/ntbs-service/Helpers/NotificationHelper.cs
+++ b/ntbs-service/Helpers/NotificationHelper.cs
@@ -43,5 +43,10 @@ namespace ntbs_service.Helpers
                 ? TreatmentEventType.TreatmentStart
                 : TreatmentEventType.DiagnosisMade;
         }
+
+        public static string FormatNhsNumber(string rawNhsNumber)
+        {
+            return rawNhsNumber.Replace(" ", "");
+        }
     }
 }

--- a/ntbs-service/Models/Validations/NhsNumberValidationAttribute.cs
+++ b/ntbs-service/Models/Validations/NhsNumberValidationAttribute.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
+using ntbs_service.Helpers;
 
 namespace ntbs_service.Models.Validations
 {
@@ -13,7 +14,7 @@ namespace ntbs_service.Models.Validations
             {
                 return null;
             }
-            var nhsNumber = value.ToString();
+            var nhsNumber = NotificationHelper.FormatNhsNumber(value.ToString());
             var match = Regex.Match(nhsNumber, "^[0-9]+$");
             if (!match.Success)
             {

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -80,6 +80,7 @@ namespace ntbs_service.Services
         public async Task UpdatePatientDetailsAsync(Notification notification, PatientDetails patient)
         {
             await UpdatePatientFlagsAsync(patient);
+            FormatNhsNumber(patient);
             _context.SetValues(notification.PatientDetails, patient);
 
             await _notificationRepository.SaveChangesAsync();
@@ -109,6 +110,11 @@ namespace ntbs_service.Services
             {
                 patient.YearOfUkEntry = null;
             }
+        }
+
+        private static void FormatNhsNumber(PatientDetails patient)
+        {
+            patient.NhsNumber = NotificationHelper.FormatNhsNumber(patient.NhsNumber);
         }
 
         private async Task UpdateOccupation(PatientDetails patient)


### PR DESCRIPTION
## Description
NHS number validation allows spaces, and before the NHS number is saved format it without spaces.
Both call a helper, just incase in the future we allow other formatting of them.
Added tests for the update, and for the validation.

## Checklist:
- [x] Automated tests are passing locally.
