### PR TITLE
NTBS-2581 User sync tweaks

### DIFF
--- a/ntbs-service/Jobs/UserSyncJob.cs
+++ b/ntbs-service/Jobs/UserSyncJob.cs
@@ -6,6 +6,12 @@ using Serilog;
 
 namespace ntbs_service.Jobs
 {
+    // Attempts here talks about retry attempts, so we retry up to four times after the initial failure, so there are
+    // five attempts total. The delay here means the first retry is after two minutes, and all subsequent retries after
+    // ten minutes.
+    // I have not found good docs for this, but the source code is easy enough to read:
+    // https://github.com/HangfireIO/Hangfire/blob/master/src/Hangfire.Core/AutomaticRetryAttribute.cs
+    [AutomaticRetry(Attempts = 4, DelaysInSeconds = new []{ 120, 600 })]
     public class UserSyncJob : HangfireJobContext
     {
         private readonly IAdImportService _adImportService;

--- a/ntbs-service/deployments/dev.yml
+++ b/ntbs-service/deployments/dev.yml
@@ -83,6 +83,8 @@ spec:
               value: "development"
             - name: EnvironmentDescription__EnvironmentName
               value: "phe-dev"
+            - name: ScheduledJobsConfig__UserSyncCron
+              value: "00 21 * * *"
       imagePullSecrets:
         - name: registery-password
         - name: default-dockercfg-bs7wj


### PR DESCRIPTION
## Description
 * Shift `phe-dev` user sync to 21:00: this is evenly spaced between UAT (19:00) and Live (23:00) though the job should only take a couple of seconds anyway.
 * Add automatic retries to User Sync job: allow up to 5 attempts per job, with the first attempt happening after two minutes of the failure, and all subsequent ones after 10 minutes.