### PR TITLE
NTBS-2520: Add links to legacy notifications on nhs number duplicate

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
@@ -34,13 +34,13 @@
                             {
                                 @:,
                             }
-                            if (!url.IsNullOrEmpty())
+                            if (!url.Contains("Legacy"))
                             {
                                 <a href="@url" target="_blank" title="Open notification overview for notification #@id">#@id</a>
                             }
                             else
                             {
-                                @id;
+                                <a href="@url" target="_blank" title="Open import page for notification @id">@id</a>
                             }
 
                             requiresPrependedComma = true;

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -129,7 +129,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
             var legacyIdDictionary = legacyNhsNumberMatches.ToDictionary(
                 match => $"{match.Source}: {match.OldNotificationId}",
-                match => "");
+                match => RouteHelper.GetLegacyNotificationPath(match.OldNotificationId));
 
             return filteredNtbsIdDictionary.Concat(legacyIdDictionary).ToDictionary(x => x.Key, x => x.Value);
         }
@@ -197,7 +197,7 @@ namespace ntbs_service.Pages.Notifications.Edit
         public async Task<JsonResult> OnPostNhsNumberDuplicates([FromBody]NhsNumberValidationModel validationData)
         {
             var group = await NotificationRepository.GetNotificationGroupAsync(validationData.NotificationId);
-            return new JsonResult(await GenerateDuplicateNhsNumberNotificationUrlsAsync(validationData.NhsNumber, group));
+            return new JsonResult(await GenerateDuplicateNhsNumberNotificationUrlsAsync(NotificationFieldFormattingHelper.FormatNhsNumberForModel(validationData.NhsNumber), group));
         }
     }
 }

--- a/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
+++ b/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
@@ -46,18 +46,18 @@ const NhsNumberDuplicateWarning = Vue.extend({
                         // New lines required to match output from .cshtml
                         warningContainer.appendChild(document.createTextNode("\r\n,\r\n"));
                     }
-                    if (url) {
-                        warningContainer.appendChild(this.createAnchorTag(id, url));
+                    if (url.includes("Legacy")) {
+                        warningContainer.appendChild(this.createAnchorLegacyTag(id, url));
                     }
                     else {
-                        warningContainer.appendChild(this.createSpanTag(id));
+                        warningContainer.appendChild(this.createAnchorNtbsTag(id, url));
                     }
                     requiresPrependedComma = true;
                 }
             }
             this.$refs["nhs-number-warning"].classList.remove("hidden");
         },
-        createAnchorTag: function (id: string, url: string) {
+        createAnchorNtbsTag: function (id: string, url: string) {
             const anchorTag = document.createElement("a");
             anchorTag.href = url;
             anchorTag.target = "_blank";
@@ -65,9 +65,12 @@ const NhsNumberDuplicateWarning = Vue.extend({
             anchorTag.title = `Open notification overview for notification #${id}`;
             return anchorTag;
         },
-        createSpanTag: function (id: string) {
-            const legacyTag = document.createElement("span");
+        createAnchorLegacyTag: function (id: string, url: string) {
+            const legacyTag = document.createElement("a");
+            legacyTag.href = url;
+            legacyTag.target = "_blank";
             legacyTag.innerHTML = id;
+            legacyTag.title = `Open import page for notification ${id}`;
             return legacyTag;
         }
     }


### PR DESCRIPTION
## Description
Fixed the duplicate check to format nhs number before checking - slipped through as the space-removing ticket and this were done at the same time.
Also added links to the legacy notification NHS number duplicate warnings.

## Checklist:
- [ ] Automated tests are passing locally.
