### PR TITLE
NTBS-2335: Change did not start treatment to started treatment

### DIFF
--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -75,7 +75,7 @@ namespace ntbs_integration_tests.NotificationPages
                 ["FormattedDiagnosisDate.Day"] = "1",
                 ["FormattedDiagnosisDate.Month"] = "1",
                 ["FormattedDiagnosisDate.Year"] = "2050",
-                ["ClinicalDetails.DidNotStartTreatment"] = "false",
+                ["ClinicalDetails.StartedTreatment"] = "true",
                 ["FormattedTreatmentDate.Day"] = "1",
                 ["ClinicalDetails.Notes"] = new string('i', 1002),
             };
@@ -379,7 +379,7 @@ namespace ntbs_integration_tests.NotificationPages
                 ["FormattedTreatmentDate.Day"] = "1",
                 ["FormattedTreatmentDate.Month"] = "1",
                 ["FormattedTreatmentDate.Year"] = "2012",
-                ["ClinicalDetails.DidNotStartTreatment"] = "true",
+                ["ClinicalDetails.StartedTreatment"] = "false",
                 ["ClinicalDetails.IsPostMortem"] = "false",
                 ["FormattedSymptomDate.Day"] = "10",
                 ["FormattedSymptomDate.Month"] = "10",

--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -492,7 +492,7 @@ namespace ntbs_service.DataMigration
                 FirstPresentationDate = notification.FirstPresentationDate,
                 TBServicePresentationDate = notification.TbServicePresentationDate,
                 DiagnosisDate = notification.DiagnosisDate ?? notification.StartOfTreatmentDate ?? notification.NotificationDate,
-                DidNotStartTreatment = Converter.GetNullableBoolValue(notification.DidNotStartTreatment),
+                StartedTreatment = !Converter.GetNullableBoolValue(notification.DidNotStartTreatment),
                 TreatmentStartDate = notification.StartOfTreatmentDate,
                 MDRTreatmentStartDate = notification.MDRTreatmentStartDate,
                 IsSymptomatic = Converter.GetNullableBoolValue(notification.IsSymptomatic),

--- a/ntbs-service/Migrations/20210802135016_ChangeDidNotStartTreatmentToStartedTreatment.Designer.cs
+++ b/ntbs-service/Migrations/20210802135016_ChangeDidNotStartTreatmentToStartedTreatment.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20210802135016_ChangeDidNotStartTreatmentToStartedTreatment")]
+    partial class ChangeDidNotStartTreatmentToStartedTreatment
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20210802135016_ChangeDidNotStartTreatmentToStartedTreatment.cs
+++ b/ntbs-service/Migrations/20210802135016_ChangeDidNotStartTreatmentToStartedTreatment.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class ChangeDidNotStartTreatmentToStartedTreatment : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "DidNotStartTreatment",
+                table: "ClinicalDetails",
+                newName: "StartedTreatment");
+
+            migrationBuilder.Sql(
+                @"UPDATE [ClinicalDetails] SET StartedTreatment = ~StartedTreatment");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "StartedTreatment",
+                table: "ClinicalDetails",
+                newName: "DidNotStartTreatment");
+
+            migrationBuilder.Sql(
+                @"UPDATE [ClinicalDetails] SET DidNotStartTreatment = ~DidNotStartTreatment");
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -52,7 +52,7 @@ namespace ntbs_service.Models.Entities
         public DateTime? StartingDate => TreatmentStartDate ?? DiagnosisDate;
 
         [Display(Name = "Has the patient started treatment?")]
-        public bool? DidNotStartTreatment { get; set; }
+        public bool? StartedTreatment { get; set; }
 
         [Display(Name = "Was the TB diagnosis made at post-mortem?")]
         public bool? IsPostMortem { get; set; }

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -206,7 +206,7 @@ namespace ntbs_service.Pages.Notifications.Edit
                 ModelState.Remove("ClinicalDetails.SymptomStartDate");
             }
 
-            if (ClinicalDetails.StartedTreatment != true)
+            if (ClinicalDetails.StartedTreatment == false)
             {
                 ClinicalDetails.TreatmentStartDate = null;
                 FormattedTreatmentDate = ClinicalDetails.TreatmentStartDate.ConvertToFormattedDate();

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -206,7 +206,7 @@ namespace ntbs_service.Pages.Notifications.Edit
                 ModelState.Remove("ClinicalDetails.SymptomStartDate");
             }
 
-            if (ClinicalDetails.DidNotStartTreatment == true)
+            if (ClinicalDetails.StartedTreatment != true)
             {
                 ClinicalDetails.TreatmentStartDate = null;
                 FormattedTreatmentDate = ClinicalDetails.TreatmentStartDate.ConvertToFormattedDate();

--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
@@ -286,11 +286,11 @@
         <nhs-form-group nhs-form-group-type="Standard" id="ClinicalDetails-TreatmentStartDate">
             <nhs-fieldset>
                 <nhs-fieldset-legend nhs-legend-size="Standard">
-                    @Html.DisplayNameFor(m => m.Notification.ClinicalDetails.DidNotStartTreatment)
+                    @Html.DisplayNameFor(m => m.Notification.ClinicalDetails.StartedTreatment)
                 </nhs-fieldset-legend>
                 <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                     <div class="nhsuk-radios__item">
-                        <input asp-for="ClinicalDetails.DidNotStartTreatment" id="treatment-yes" class="nhsuk-radios__input" type="radio" value="false" data-aria-controls="conditional-treatment-conditional">
+                        <input asp-for="ClinicalDetails.StartedTreatment" id="treatment-yes" class="nhsuk-radios__input" type="radio" value="true" data-aria-controls="conditional-treatment-conditional">
                         <label class="nhsuk-label nhsuk-radios__label" for="treatment-yes">
                             Yes
                         </label>
@@ -336,7 +336,7 @@
                         </validate-date>
                     </div>
                     <div class="nhsuk-radios__item">
-                        <input asp-for="ClinicalDetails.DidNotStartTreatment" id="treatment-no" class="nhsuk-radios__input" type="radio" value="true">
+                        <input asp-for="ClinicalDetails.StartedTreatment" id="treatment-no" class="nhsuk-radios__input" type="radio" value="false">
                         <label class="nhsuk-label nhsuk-radios__label" for="treatment-no">
                             No
                         </label>

--- a/ntbs-ui-tests/Helpers/Utilities.cs
+++ b/ntbs-ui-tests/Helpers/Utilities.cs
@@ -73,7 +73,7 @@ namespace ntbs_ui_tests.Helpers
                         {
                             BCGVaccinationState = Status.Yes, BCGVaccinationYear = 1990,
                             DiagnosisDate = new DateTime(2011, 3, 23), DotStatus = DotStatus.DotReceived,
-                            DidNotStartTreatment = true, EnhancedCaseManagementLevel = 2,
+                            StartedTreatment = false, EnhancedCaseManagementLevel = 2,
                             EnhancedCaseManagementStatus = Status.Yes, FirstPresentationDate = new DateTime(2010, 12, 25), 
                             HomeVisitCarriedOut = Status.No, HealthcareDescription = "Been giving lots of paracetamol",
                             HealthcareSetting = HealthcareSetting.GP, HIVTestState = HIVTestStatus.OfferedButRefused,


### PR DESCRIPTION
## Description
Changed the DidNotStartTreatment column to StartedTreatment.
In the migration I have inverted the boolean column, I will also need to go update DACPACs and make a change in reporting.

## Checklist:
- [x] Automated tests are passing locally.
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [x] EF migrations created and committed. Snapshot committed
- [x] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Specimen matching database DACPAC updated
- [x] Reporting database ingestion considered (uspGenerateReusableNotification)
