### PR TITLE
NTBS-2596 Add stale element retry to wait for select element

### DIFF
--- a/ntbs-integration-tests/Helpers/TestUser.cs
+++ b/ntbs-integration-tests/Helpers/TestUser.cs
@@ -149,7 +149,7 @@ namespace ntbs_integration_tests.Helpers
             "ReadOnly@ntbs.phe.com",
             "ReadOnly UserGroup",
             UserType.NhsUser,
-            new[] { "App.Auth.NIS.NTBS.Read_Only_User" },
+            new[] { "App.Auth.NIS.NTBS.Read_Only" },
             isReadOnly: true);
     }
 }

--- a/ntbs-service/appsettings.CI.json
+++ b/ntbs-service/appsettings.CI.json
@@ -6,7 +6,7 @@
   "AdOptions": {
     "BaseUserGroup": "App.Auth.NIS.NTBS",
     "AdminUserGroup": "App.Auth.NIS.NTBS.Admin",
-    "ReadOnlyUserGroup": "App.Auth.NIS.NTBS.Read_Only_User",
+    "ReadOnlyUserGroup": "App.Auth.NIS.NTBS.Read_Only",
     "NationalTeamAdGroup": "App.Auth.NIS.NTBS.NTS",
     "ServiceGroupAdPrefix": "App.Auth.NIS.NTBS.Service",
     "DevGroup": "App.Auth.NIS.NTBS.NTS",

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -2,7 +2,7 @@
   "AdOptions": {
     "BaseUserGroup": "App.Auth.NIS.NTBS",
     "AdminUserGroup": "App.Auth.NIS.NTBS.Admin",
-    "ReadOnlyUserGroup": "App.Auth.NIS.NTBS.Read_Only_User",
+    "ReadOnlyUserGroup": "App.Auth.NIS.NTBS.Read_Only",
     "NationalTeamAdGroup": "App.Auth.NIS.NTBS.NTS",
     "ServiceGroupAdPrefix": "App.Auth.NIS.NTBS.Service",
     "DevGroup": "App.Auth.NIS.NTBS.NTS",

--- a/ntbs-ui-tests/Helpers/WebDriverExtensions.cs
+++ b/ntbs-ui-tests/Helpers/WebDriverExtensions.cs
@@ -7,6 +7,21 @@ namespace ntbs_ui_tests.Helpers
 {
     internal static class WebDriverExtensions
     {
+        public static void WaitUntilElementIsClickableWithRetry(this IWebDriver webDriver, By by, TimeSpan timeout)
+        {
+            try
+            {
+                webDriver.WaitUntilElementIsClickable(by, timeout);
+            }
+            catch (StaleElementReferenceException)
+            {
+                // In scenarios where the dropdown we're selecting from has just been reloaded (e.g. because of the result
+                // of an API call) the options can become stale between finding the dropdown and selecting a value. In this
+                // case we can select the value by just trying again.
+                webDriver.WaitUntilElementIsClickable(by, timeout);
+            }
+        }
+
         public static void WaitUntilElementIsClickable(this IWebDriver webDriver, By by, TimeSpan timeout)
         {
             var wait = new WebDriverWait(webDriver, timeout);

--- a/ntbs-ui-tests/Steps/ActSteps.cs
+++ b/ntbs-ui-tests/Steps/ActSteps.cs
@@ -275,7 +275,7 @@ namespace ntbs_ui_tests.Steps
                     : $"//select[@id='{dropdownId}']/option[normalize-space(text())='{text}']";
                 // In some scenarios the select does not become visible/active until an API call (triggered by previous input) has returned.
                 // Consequently we add a wait here for the element we want to select to be clickable.
-                Browser.WaitUntilElementIsClickable(By.XPath(xPath), Settings.ImplicitWait);
+                Browser.WaitUntilElementIsClickableWithRetry(By.XPath(xPath), Settings.ImplicitWait);
                 SelectElementFromDropdownWithRetry(xPath);
             });
         }


### PR DESCRIPTION
## Description
Fix a flake that I was reproducing consistently locally, that was also the cause of the "Edit notification test results fields" failure [here](https://github.com/publichealthengland/ntbs_Beta/runs/3165821469?check_suite_focus=true). The `WaitUntilElementIsClickable`, a Selenium function sometimes throws `StaleElementExceptions`. My fix is to catch the first one of these and try waiting again, following the pattern used elsewhere to tolerate the exceptions

Of the four recent failures:
* [Run 182](https://github.com/publichealthengland/ntbs_Beta/runs/3165821469?check_suite_focus=true) the issue described above and fixed in this PR
* [Run 183](https://github.com/publichealthengland/ntbs_Beta/runs/3176013222?check_suite_focus=true) Azure login fell over for over 30s (slightly surprising but not much that could have been done here asides from a test-suite retry)
* [Run 184](https://github.com/publichealthengland/ntbs_Beta/runs/3186060943?check_suite_focus=true) Two issues:
    * The page didn't change after we pressed save (after a treatment event), and we waited 30s for it to show up... Probably the app just being slow
    * A `StaleElementException` that came out of `AssertSteps.ThenICanSeeTheWarningForId`. We could cover all of this with retries, but I'm not sure if its worth it at this stage
* [Run 185](https://github.com/publichealthengland/ntbs_Beta/runs/3196159971?check_suite_focus=true) NHS number regression catch


Also, make the read only user group consistent across all of our tests (this was breaking the read only test locally for me).

## Checklist
* [x] Unit and integration tests pass locally
* [x] UI tests pass locally
* [x] UI tests pass on [GitHub Action](https://github.com/publichealthengland/ntbs_Beta/runs/3251505316?check_suite_focus=true)