### PR TITLE
NTBS-1559 remove local details after transfer

### DIFF
--- a/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/ActionTransferPageTests.cs
@@ -40,11 +40,13 @@ namespace ntbs_integration_tests.TransferPage
                 {
                     NotificationId = Utilities.NOTIFICATION_WITH_TRANSFER_REQUEST_TO_ACCEPT,
                     NotificationStatus = NotificationStatus.Notified,
-                    HospitalDetails = new HospitalDetails()
+                    HospitalDetails = new HospitalDetails
                     {
                         TBServiceCode = Utilities.TBSERVICE_ROYAL_FREE_LONDON_TB_SERVICE_ID,
-                        CaseManagerId = Utilities.CASEMANAGER_ABINGDON_ID
-                    }
+                        CaseManagerId = Utilities.CASEMANAGER_ABINGDON_ID,
+                        Consultant = "Dr John Dorian"
+                    },
+                    PatientDetails = new PatientDetails { LocalPatientId = "Patient Number 1234" }
                 }
             };
         }
@@ -115,6 +117,10 @@ namespace ntbs_integration_tests.TransferPage
             Assert.Contains("Abingdon Community Hospital", overviewPage.QuerySelector("#banner-tb-service").TextContent);
             Assert.Contains("Abingdon Permitted", overviewPage.QuerySelector("#banner-case-manager").TextContent);
             Assert.Contains("ABINGDON COMMUNITY HOSPITAL", overviewPage.QuerySelector("#overview-hospital-details-hospital-name").TextContent);
+            Assert.Empty(
+                overviewPage.QuerySelector("#overview-patient-details-local-patient-id").TextContent.Replace(" ", ""));
+            Assert.Empty(overviewPage.QuerySelector("#overview-hospital-details-consultant").TextContent.Replace(" ", ""));
+
             Assert.Null(overviewPage.QuerySelector("#alert-20003"));
         }
 

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -148,10 +148,16 @@ namespace ntbs_service.Pages.Alerts
             Notification.HospitalDetails.TBServiceCode = TransferAlert.TbServiceCode;
             Notification.HospitalDetails.HospitalId = TargetHospitalId;
             Notification.HospitalDetails.CaseManagerId = TargetCaseManagerId;
+
+            // Drop consultant and local patient ID because these are almost certainly going to be different at the new
+            // TB service, as per NTBS-1559
+            Notification.HospitalDetails.Consultant = null;
+            Notification.PatientDetails.LocalPatientId = null;
             // We want to save all these changes in the same transaction so that we make sure the time between the first
             // and last audit logs are within the timeframe for them to be grouped together on the changes page. We
             // experienced an issue where the audits from an acceptance were over this threshold and our app didn't
             // know how to handle the group. See NTBS-2457
+            Service.UpdatePatientDetailsWithoutSave(Notification, Notification.PatientDetails);
             Service.UpdateHospitalDetailsWithoutSave(Notification, Notification.HospitalDetails);
             _treatmentEventRepository.AddWithoutSave(transferOutEvent);
             _treatmentEventRepository.AddWithoutSave(transferInEvent);

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -18,6 +18,7 @@ namespace ntbs_service.Services
     public interface INotificationService
     {
         Task UpdatePatientDetailsAsync(Notification notification, PatientDetails patientDetails);
+        void UpdatePatientDetailsWithoutSave(Notification notification, PatientDetails patientDetails);
         Task UpdatePatientFlagsAsync(PatientDetails patientDetails);
         Task UpdateClinicalDetailsAsync(Notification notification, ClinicalDetails timeline);
         Task UpdateTestDataAsync(Notification notification, TestData testData);
@@ -84,6 +85,11 @@ namespace ntbs_service.Services
 
             await _notificationRepository.SaveChangesAsync();
             await _alertService.AutoDismissAlertAsync<DataQualityBirthCountryAlert>(notification);
+        }
+
+        public void UpdatePatientDetailsWithoutSave(Notification notification, PatientDetails patient)
+        {
+            _context.SetValues(notification.PatientDetails, patient);
         }
 
         public async Task UpdatePatientFlagsAsync(PatientDetails patientDetails)

--- a/ntbs-ui-tests/Features/TransferNotification.feature
+++ b/ntbs-ui-tests/Features/TransferNotification.feature
@@ -3,7 +3,7 @@ Feature: Transfer notification
   Background: Create a transfer request
     Given I navigate to the app
     And I have logged in as BirminghamServiceUser
-    And I am on seeded 'MINIMAL_DETAILS' notification overview page
+    And I am on seeded 'MAXIMUM_DETAILS' notification overview page
     Then I can see the value 'Birmingham & Solihull' for the field 'tb-service' in the 'HospitalDetails' overview section
 
     When I expand manage notification section
@@ -46,6 +46,8 @@ Feature: Transfer notification
 
     Then I should see the Notification
     Then I can see the value 'LCHC (Leeds Community Healthcare NHS Trust)' for the field 'tb-service' in the 'HospitalDetails' overview section
+    Then I can see no value for the field 'local-patient-id' in the 'PatientDetails' overview section
+    Then I can see no value for the field 'consultant' in the 'HospitalDetails' overview section
 
   Scenario: Decline transfer of notification between services
     When I log out
@@ -65,6 +67,8 @@ Feature: Transfer notification
     Given I have logged in as BirminghamServiceUser
 
     When I navigate to the url of the current notification
+    Then I can see the value '3455' for the field 'local-patient-id' in the 'PatientDetails' overview section
+    Then I can see the value 'Dr Frank Lotchewski' for the field 'consultant' in the 'HospitalDetails' overview section
     When I take action on the alert with title Transfer rejected
 
     Then I should be on the TransferDeclined page

--- a/ntbs-ui-tests/Helpers/Utilities.cs
+++ b/ntbs-ui-tests/Helpers/Utilities.cs
@@ -16,11 +16,11 @@ namespace ntbs_ui_tests.Helpers
                 throw new ArgumentException($"Unexpected notification name {notificationName} given");
             }
             baseNotification.CreationDate = DateTime.Now;
-            baseNotification.HospitalDetails = new HospitalDetails
-            {
-                TBServiceCode = userConfig.TbServiceCode,
-                CaseManagerId = userConfig.UserId
-            };
+
+            baseNotification.HospitalDetails ??= new HospitalDetails();
+            baseNotification.HospitalDetails.TBServiceCode = userConfig.TbServiceCode;
+            baseNotification.HospitalDetails.CaseManagerId = userConfig.UserId;
+
             return baseNotification;
         }
 
@@ -74,7 +74,7 @@ namespace ntbs_ui_tests.Helpers
                             BCGVaccinationState = Status.Yes, BCGVaccinationYear = 1990,
                             DiagnosisDate = new DateTime(2011, 3, 23), DotStatus = DotStatus.DotReceived,
                             StartedTreatment = false, EnhancedCaseManagementLevel = 2,
-                            EnhancedCaseManagementStatus = Status.Yes, FirstPresentationDate = new DateTime(2010, 12, 25), 
+                            EnhancedCaseManagementStatus = Status.Yes, FirstPresentationDate = new DateTime(2010, 12, 25),
                             HomeVisitCarriedOut = Status.No, HealthcareDescription = "Been giving lots of paracetamol",
                             HealthcareSetting = HealthcareSetting.GP, HIVTestState = HIVTestStatus.OfferedButRefused,
                             IsSymptomatic = true, IsDotOffered = Status.Unknown,

--- a/ntbs-ui-tests/Steps/AssertSteps.cs
+++ b/ntbs-ui-tests/Steps/AssertSteps.cs
@@ -227,6 +227,19 @@ namespace ntbs_ui_tests.Steps
             });
         }
 
+
+        [Then(@"I can see no value for the field '(.*)' in the '(.*)' overview section")]
+        public void ThenICanNoValueForFieldInTheOverviewSection(string field, string section)
+        {
+            WithErrorLogging(() =>
+            {
+                var sectionId = HtmlElementHelper.GetSectionIdFromSection(section);
+                var htmlId = $"{sectionId}-{field}";
+                Assert.Empty(HtmlElementHelper.FindElementById(Browser, htmlId).Text.Replace(" ", ""));
+            });
+        }
+
+
         [Then(@"The notification should be denotified")]
         public void ThenCurrentNotificationShouldBeDenotified()
         {


### PR DESCRIPTION
## Description
* Remove local patient ID and consultant name when a case is transferred from one TB service to another.
* Tweak integration tests to cover this.
* Add UI test checks for dropping details on accepted transfer (and keeping on rejected transfer). 
    * Fix a small UI test bug that was overwriting seed `HospitalDetails` on setting case manager and TB service.

## Checklist:
- [x] Automated tests are passing locally (including UI tests)