### PR TITLE
NTBS-2495: Change padlock functionality 

### DIFF
--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -307,8 +307,13 @@ namespace ntbs_service.DataAccess
                         Sex = n.PatientDetails.SexLabel,
                         NotificationStatus = n.NotificationStatus,
                         DrugResistance = n.DrugResistanceProfile.DrugResistanceProfileString,
-                        TreatmentEvents = n.TreatmentEvents
+                        TreatmentEvents = n.TreatmentEvents,
+                        PreviousTbServiceCodes = n.PreviousTbServices.Select(service => service.TbServiceCode),
+                        PreviousPhecCodes = n.PreviousTbServices.Select(service => service.PhecCode),
+                        LinkedNotificationPhecCodes = n.Group.Notifications.Select(no => no.HospitalDetails.TBService.PHECCode),
+                        LinkedNotificationTbServiceCodes = n.Group.Notifications.Select(no => no.HospitalDetails.TBServiceCode)
                     })
+                .AsSingleQuery()
                 .AsNoTracking()
                 .ToListAsync())
                 .Select(n => new NotificationBannerModel(n, showLink: true));

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -313,6 +313,7 @@ namespace ntbs_service.DataAccess
                         LinkedNotificationPhecCodes = n.Group.Notifications.Select(no => no.HospitalDetails.TBService.PHECCode),
                         LinkedNotificationTbServiceCodes = n.Group.Notifications.Select(no => no.HospitalDetails.TBServiceCode)
                     })
+                // Do not use query splitting as EFCore doesn't allow query splitting with a collection in the select
                 .AsSingleQuery()
                 .AsNoTracking()
                 .ToListAsync())

--- a/ntbs-service/Helpers/NotificationExtensionMethods.cs
+++ b/ntbs-service/Helpers/NotificationExtensionMethods.cs
@@ -21,7 +21,7 @@ namespace ntbs_service.Helpers
                     var fullAccess = permissionLevel == PermissionLevel.Edit;
                     return new NotificationBannerModel(
                         n,
-                        showPadlock: !fullAccess,
+                        showPadlock: permissionLevel == PermissionLevel.None,
                         showLink: fullAccess || n.NotificationStatus != NotificationStatus.Draft);
                 })
                 .Select(n => n.Result);

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -12,6 +12,8 @@ namespace ntbs_service.Models
     [NotMapped]
     public class NotificationBannerModel
     {
+        public static string NTBS_SOURCE = "ntbs";
+
         public string NotificationId;
         public DateTime? SortByDate;
         public string NotificationDate;
@@ -72,7 +74,7 @@ namespace ntbs_service.Models
                 notification.Group?.Notifications.Select(no => no.HospitalDetails.TBService.PHECCode);
             LinkedNotificationTbServiceCodes =
                 notification.Group?.Notifications.Select(no => no.HospitalDetails.TBServiceCode);
-            Source = "ntbs";
+            Source = NTBS_SOURCE;
             ShowLink = showLink;
             ShowPadlock = showPadlock;
             RedirectPath = RouteHelper.GetNotificationPath(notification.NotificationId, NotificationSubPaths.Overview);
@@ -105,7 +107,7 @@ namespace ntbs_service.Models
             PreviousPhecCodes = notification.PreviousPhecCodes;
             LinkedNotificationTbServiceCodes = notification.LinkedNotificationTbServiceCodes;
             LinkedNotificationPhecCodes = notification.LinkedNotificationPhecCodes;
-            Source = "ntbs";
+            Source = NTBS_SOURCE;
             ShowLink = showLink;
             ShowPadlock = showPadlock;
             RedirectPath = RouteHelper.GetNotificationPath(notification.NotificationId, NotificationSubPaths.Overview);

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -43,9 +43,9 @@ namespace ntbs_service.Models
         public IEnumerable<string> LinkedNotificationTbServiceCodes { get; set; }
         public IEnumerable<string> LinkedNotificationPhecCodes { get; set; }
 
-        // Access level is treated as a bool for either able to edit or not. This differs from the standard PermissionLevel
-        // implemented across the codebase due to there being no visual difference between no permission level and readonly
-        // permission on notification banner models
+        // Access level is treated as a bool for either able to view or not. This differs from the standard PermissionLevel
+        // implemented across the codebase due to there being no visual difference between full edit permissions
+        // and readonly permissions on notification banner models
         public NotificationBannerModel(Notification notification, bool showPadlock = false, bool showLink = false)
         {
             NotificationId = notification.NotificationId.ToString();

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -36,6 +36,10 @@ namespace ntbs_service.Models
         public bool ShowPadlock;
         public string RedirectPath;
         public int? CaseManagerId;
+        public IEnumerable<string> PreviousTbServiceCodes { get; set; }
+        public IEnumerable<string> PreviousPhecCodes { get; set; }
+        public IEnumerable<string> LinkedNotificationTbServiceCodes { get; set; }
+        public IEnumerable<string> LinkedNotificationPhecCodes { get; set; }
 
         // Access level is treated as a bool for either able to edit or not. This differs from the standard PermissionLevel
         // implemented across the codebase due to there being no visual difference between no permission level and readonly
@@ -62,6 +66,12 @@ namespace ntbs_service.Models
             NotificationDate = notification.FormattedNotificationDate;
             DrugResistance = notification.DrugResistanceProfile.DrugResistanceProfileString;
             TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents);
+            PreviousTbServiceCodes = notification.PreviousTbServices.Select(service => service.TbServiceCode);
+            PreviousPhecCodes = notification.PreviousTbServices.Select(service => service.PhecCode);
+            LinkedNotificationPhecCodes =
+                notification.Group?.Notifications.Select(no => no.HospitalDetails.TBService.PHECCode);
+            LinkedNotificationTbServiceCodes =
+                notification.Group?.Notifications.Select(no => no.HospitalDetails.TBServiceCode);
             Source = "ntbs";
             ShowLink = showLink;
             ShowPadlock = showPadlock;
@@ -91,6 +101,10 @@ namespace ntbs_service.Models
             NotificationDate = notification.NotificationDate.ConvertToString();
             DrugResistance = notification.DrugResistance;
             TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents);
+            PreviousTbServiceCodes = notification.PreviousTbServiceCodes;
+            PreviousPhecCodes = notification.PreviousPhecCodes;
+            LinkedNotificationTbServiceCodes = notification.LinkedNotificationTbServiceCodes;
+            LinkedNotificationPhecCodes = notification.LinkedNotificationPhecCodes;
             Source = "ntbs";
             ShowLink = showLink;
             ShowPadlock = showPadlock;

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -12,7 +12,7 @@ namespace ntbs_service.Models
     [NotMapped]
     public class NotificationBannerModel
     {
-        public static string NTBS_SOURCE = "ntbs";
+        public static string NtbsSource = "NTBS";
 
         public string NotificationId;
         public DateTime? SortByDate;
@@ -74,7 +74,7 @@ namespace ntbs_service.Models
                 notification.Group?.Notifications.Select(no => no.HospitalDetails.TBService.PHECCode);
             LinkedNotificationTbServiceCodes =
                 notification.Group?.Notifications.Select(no => no.HospitalDetails.TBServiceCode);
-            Source = NTBS_SOURCE;
+            Source = NtbsSource;
             ShowLink = showLink;
             ShowPadlock = showPadlock;
             RedirectPath = RouteHelper.GetNotificationPath(notification.NotificationId, NotificationSubPaths.Overview);
@@ -107,7 +107,7 @@ namespace ntbs_service.Models
             PreviousPhecCodes = notification.PreviousPhecCodes;
             LinkedNotificationTbServiceCodes = notification.LinkedNotificationTbServiceCodes;
             LinkedNotificationPhecCodes = notification.LinkedNotificationPhecCodes;
-            Source = NTBS_SOURCE;
+            Source = NtbsSource;
             ShowLink = showLink;
             ShowPadlock = showPadlock;
             RedirectPath = RouteHelper.GetNotificationPath(notification.NotificationId, NotificationSubPaths.Overview);

--- a/ntbs-service/Models/Projections/NotificationForBannerModel.cs
+++ b/ntbs-service/Models/Projections/NotificationForBannerModel.cs
@@ -27,5 +27,10 @@ namespace ntbs_service.Models.Projections
         public NotificationStatus NotificationStatus { get; set; }
 
         public ICollection<TreatmentEvent> TreatmentEvents { get; set; }
+
+        public IEnumerable<string> PreviousTbServiceCodes { get; set; }
+        public IEnumerable<string> PreviousPhecCodes { get; set; }
+        public IEnumerable<string> LinkedNotificationTbServiceCodes { get; set; }
+        public IEnumerable<string> LinkedNotificationPhecCodes { get; set; }
     }
 }

--- a/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
+++ b/ntbs-service/Pages/LegacyNotifications/Index.cshtml.cs
@@ -90,7 +90,7 @@ namespace ntbs_service.Pages.LegacyNotifications
             }
 
             NotificationBannerModel.ShowLink = false;
-            NotificationBannerModel.ShowPadlock = !await _authorizationService.CanEditBannerModelAsync(User, NotificationBannerModel);
+            NotificationBannerModel.ShowPadlock = !await _authorizationService.CanViewBannerModelAsync(User, NotificationBannerModel);
             return Page();
         }
     }

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -55,7 +55,7 @@ namespace ntbs_service.Pages.Notifications
             var (permissionLevel, reason) = await _authorizationService.GetPermissionLevelAsync(User, Notification);
             PermissionLevel = permissionLevel;
             PermissionReason = reason;
-            NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel != PermissionLevel.Edit);
+            NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel == PermissionLevel.None);
         }
 
         protected async Task<bool> TryGetLinkedNotificationsAsync()

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -8,7 +8,6 @@ using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
-using ntbs_service.Models.Projections;
 using ntbs_service.Pages;
 
 namespace ntbs_service.Services
@@ -74,7 +73,7 @@ namespace ntbs_service.Services
         {
             async Task SetPadlockAndLinkForBannerAsync(ClaimsPrincipal u, NotificationBannerModel bannerModel)
             {
-                bannerModel.ShowPadlock = bannerModel.Source == NotificationBannerModel.NTBS_SOURCE && !(await CanViewBannerModelAsync(u, bannerModel));
+                bannerModel.ShowPadlock = bannerModel.Source == NotificationBannerModel.NtbsSource && !(await CanViewBannerModelAsync(u, bannerModel));
                 bannerModel.ShowLink = !UserIsReadOnlyAndNotificationIsDraftOrLegacy(u, bannerModel);
             }
 
@@ -134,13 +133,13 @@ namespace ntbs_service.Services
             }
 
             return _userPermissionsFilter.Type == UserType.NationalTeam
-                   || UserBelongsToTbServiceOfNotification(notificationBannerModel.TbServiceCode)
-                   || UserBelongsToPhecFromNotification(notificationBannerModel.TbServicePHECCode)
-                   || UserBelongsToPhecFromNotification(notificationBannerModel.LocationPHECCode)
-                   || notificationBannerModel.LinkedNotificationPhecCodes.Any(UserBelongsToPhecFromNotification)
-                   || notificationBannerModel.LinkedNotificationTbServiceCodes.Any(UserBelongsToTbServiceOfNotification)
-                   || notificationBannerModel.PreviousTbServiceCodes.Any(UserBelongsToTbServiceOfNotification)
-                   || notificationBannerModel.PreviousPhecCodes.Any(UserBelongsToPhecFromNotification);
+                   || UserBelongsToTbService(notificationBannerModel.TbServiceCode)
+                   || UserBelongsToPhec(notificationBannerModel.TbServicePHECCode)
+                   || UserBelongsToPhec(notificationBannerModel.LocationPHECCode)
+                   || notificationBannerModel.LinkedNotificationPhecCodes.Any(UserBelongsToPhec)
+                   || notificationBannerModel.LinkedNotificationTbServiceCodes.Any(UserBelongsToTbService)
+                   || notificationBannerModel.PreviousTbServiceCodes.Any(UserBelongsToTbService)
+                   || notificationBannerModel.PreviousPhecCodes.Any(UserBelongsToPhec);
         }
 
         private bool UserHasDirectRelationToLinkedNotification(Notification notification)
@@ -153,7 +152,7 @@ namespace ntbs_service.Services
         {
             foreach (var previousTbService in notification.PreviousTbServices)
             {
-                if (UserBelongsToTbServiceOfNotification(previousTbService.TbServiceCode) || UserBelongsToPhecFromNotification(previousTbService.PhecCode))
+                if (UserBelongsToTbService(previousTbService.TbServiceCode) || UserBelongsToPhec(previousTbService.PhecCode))
                 {
                     return true;
                 }
@@ -163,15 +162,15 @@ namespace ntbs_service.Services
 
         private bool UserHasDirectRelationToNotification(Notification notification)
         {
-            return UserBelongsToTbServiceOfNotification(notification.HospitalDetails.TBServiceCode) || UserBelongsToPhecFromNotification(notification.HospitalDetails.TBService?.PHECCode);
+            return UserBelongsToTbService(notification.HospitalDetails.TBServiceCode) || UserBelongsToPhec(notification.HospitalDetails.TBService?.PHECCode);
         }
 
-        private bool UserBelongsToTbServiceOfNotification(string tbServiceCode)
+        private bool UserBelongsToTbService(string tbServiceCode)
         {
             return _userPermissionsFilter.Type == UserType.NhsUser && _userPermissionsFilter.IncludedTBServiceCodes.Contains(tbServiceCode);
         }
 
-        private bool UserBelongsToPhecFromNotification(string phecCode)
+        private bool UserBelongsToPhec(string phecCode)
         {
             return _userPermissionsFilter.Type == UserType.PheUser && _userPermissionsFilter.IncludedPHECCodes.Contains(phecCode);
         }
@@ -235,7 +234,7 @@ namespace ntbs_service.Services
         private bool UserIsReadOnlyAndNotificationIsDraftOrLegacy(ClaimsPrincipal user, NotificationBannerModel bannerModel)
         {
             return _userHelper.UserIsReadOnly(user) &&
-                   (bannerModel.NotificationStatus == NotificationStatus.Draft || bannerModel.Source != NotificationBannerModel.NTBS_SOURCE);
+                   (bannerModel.NotificationStatus == NotificationStatus.Draft || bannerModel.Source != NotificationBannerModel.NtbsSource);
         }
     }
 }

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -74,7 +74,7 @@ namespace ntbs_service.Services
         {
             async Task SetPadlockAndLinkForBannerAsync(ClaimsPrincipal u, NotificationBannerModel bannerModel)
             {
-                bannerModel.ShowPadlock = !(await CanViewBannerModelAsync(u, bannerModel));
+                bannerModel.ShowPadlock = bannerModel.Source == NotificationBannerModel.NTBS_SOURCE && !(await CanViewBannerModelAsync(u, bannerModel));
                 bannerModel.ShowLink = !UserIsReadOnlyAndNotificationIsDraftOrLegacy(u, bannerModel);
             }
 
@@ -235,7 +235,7 @@ namespace ntbs_service.Services
         private bool UserIsReadOnlyAndNotificationIsDraftOrLegacy(ClaimsPrincipal user, NotificationBannerModel bannerModel)
         {
             return _userHelper.UserIsReadOnly(user) &&
-                   (bannerModel.NotificationStatus == NotificationStatus.Draft || bannerModel.Source != "ntbs");
+                   (bannerModel.NotificationStatus == NotificationStatus.Draft || bannerModel.Source != NotificationBannerModel.NTBS_SOURCE);
         }
     }
 }

--- a/ntbs-service/Services/LegacySearchService.cs
+++ b/ntbs-service/Services/LegacySearchService.cs
@@ -175,7 +175,7 @@ namespace ntbs_service.Services
                 PreviousPhecCodes = new List<string>(),
                 LinkedNotificationPhecCodes = new List<string>(),
                 LinkedNotificationTbServiceCodes = new List<string>(),
-                ShowPadlock = true,
+                ShowPadlock = false,
                 ShowLink = true,
                 RedirectPath = RouteHelper.GetLegacyNotificationPath(result.PrimaryNotificationId)
             };

--- a/ntbs-service/Services/LegacySearchService.cs
+++ b/ntbs-service/Services/LegacySearchService.cs
@@ -171,6 +171,10 @@ namespace ntbs_service.Services
                 Postcode = (result.Postcode as string).FormatStringToPostcodeFormat(),
                 NhsNumber = (result.NhsNumber as string).FormatStringToNhsNumberFormat(),
                 DateOfBirth = (result.DateOfBirth as DateTime?).ConvertToString(),
+                PreviousTbServiceCodes = new List<string>(),
+                PreviousPhecCodes = new List<string>(),
+                LinkedNotificationPhecCodes = new List<string>(),
+                LinkedNotificationTbServiceCodes = new List<string>(),
                 ShowPadlock = true,
                 ShowLink = true,
                 RedirectPath = RouteHelper.GetLegacyNotificationPath(result.PrimaryNotificationId)


### PR DESCRIPTION
## Description
Only show a padlock if you have no read permissions for a notification. Never show a padlock on a legacy notification.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
