### PR TITLE
NTBS-2650: Add display-only denotified treatment event

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -299,6 +299,7 @@ namespace ntbs_integration_tests.Helpers
                     NotificationStatus = NotificationStatus.Denotified,
                     DenotificationDetails = new DenotificationDetails
                     {
+                        DateOfDenotification = new DateTime(2020, 12, 25),
                         Reason = DenotificationReason.Other,
                         OtherDescription = "a great reason"
                     },

--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -316,6 +316,12 @@ namespace ntbs_integration_tests.Helpers
                     ClinicalDetails = new ClinicalDetails
                     {
                         TreatmentRegimen = TreatmentRegimen.MdrTreatment
+                    },
+                    TreatmentEvents = new List<TreatmentEvent> { new TreatmentEvent
+                        {
+                            TreatmentEventId = 4444,
+                            TreatmentEventType = TreatmentEventType.DiagnosisMade, EventDate = new DateTime(2011, 2, 1)
+                        }
                     }
                 },
                 new Notification

--- a/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/DenotifyPageTests.cs
@@ -21,13 +21,39 @@ namespace ntbs_integration_tests.NotificationPages
         {
             return new List<Notification>()
             {
-                new Notification(){ NotificationId = Utilities.DENOTIFY_WITH_DESCRIPTION, NotificationStatus = NotificationStatus.Notified },
-                new Notification(){ NotificationId = Utilities.DENOTIFY_NO_DESCRIPTION, NotificationStatus = NotificationStatus.Notified },
+                new Notification()
+                {
+                    NotificationId = Utilities.DENOTIFY_WITH_DESCRIPTION,
+                    NotificationStatus = NotificationStatus.Notified,
+                    TreatmentEvents = new List<TreatmentEvent> { new TreatmentEvent
+                        {
+                            TreatmentEventId = 4040,
+                            TreatmentEventType = TreatmentEventType.DiagnosisMade, EventDate = new DateTime(2011, 2, 1)
+                        }
+                    }
+                },
+                new Notification()
+                {
+                    NotificationId = Utilities.DENOTIFY_NO_DESCRIPTION,
+                    NotificationStatus = NotificationStatus.Notified,
+                    TreatmentEvents = new List<TreatmentEvent> { new TreatmentEvent
+                        {
+                            TreatmentEventId = 4041,
+                            TreatmentEventType = TreatmentEventType.DiagnosisMade, EventDate = new DateTime(2011, 2, 1)
+                        }
+                    }
+                },
                 new Notification()
                 {
                     NotificationId = Utilities.NOTIFIED_ID_WITH_NOTIFICATION_DATE,
                     NotificationStatus = NotificationStatus.Notified,
-                    NotificationDate = new DateTime(2011, 1, 1)
+                    NotificationDate = new DateTime(2011, 1, 1),
+                    TreatmentEvents = new List<TreatmentEvent> { new TreatmentEvent
+                        {
+                            TreatmentEventId = 4042,
+                            TreatmentEventType = TreatmentEventType.DiagnosisMade, EventDate = new DateTime(2011, 2, 1)
+                        }
+                    }
                 }
             };
         }

--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -295,6 +295,17 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
+        public async Task OverviewPageShowsDenotificationEvent_ForDenotifiedRecord()
+        {
+            // Arrange
+            var url = GetCurrentPathForId(Utilities.DENOTIFIED_ID);
+            var document = await GetDocumentForUrlAsync(url);
+            var eventText = document.QuerySelector("#overview-episodes").TextContent;
+            Assert.Contains("25 Dec 2020", eventText);
+            Assert.Contains("Denotification", eventText);
+        }
+
+        [Fact]
         public async Task OverviewPageDoesNotShowDenotificationDetails_ForNotifiedRecord()
         {
             // Arrange

--- a/ntbs-service/Helpers/EpisodesExtensionMethods.cs
+++ b/ntbs-service/Helpers/EpisodesExtensionMethods.cs
@@ -67,9 +67,10 @@ namespace ntbs_service.Helpers
 
         public static bool IsEpisodeEndingTreatmentEvent(this TreatmentEvent treatmentEvent)
         {
-            return (treatmentEvent.TreatmentOutcome != null
-                    && EpisodeEndingOutcomeTypes.Contains(treatmentEvent.TreatmentOutcome.TreatmentOutcomeType))
-                   || treatmentEvent.TreatmentEventType == TreatmentEventType.TransferOut;
+            return treatmentEvent.TreatmentEventType == TreatmentEventType.Denotification
+                   || treatmentEvent.TreatmentEventType == TreatmentEventType.TransferOut
+                   || (treatmentEvent.TreatmentOutcome != null
+                       && EpisodeEndingOutcomeTypes.Contains(treatmentEvent.TreatmentOutcome.TreatmentOutcomeType));
         }
 
         public static IEnumerable<TreatmentEvent> OrderForEpisodes(this IEnumerable<TreatmentEvent> treatmentEvents)

--- a/ntbs-service/Helpers/EpisodesExtensionMethods.cs
+++ b/ntbs-service/Helpers/EpisodesExtensionMethods.cs
@@ -103,6 +103,8 @@ namespace ntbs_service.Helpers
                             return 5;
                         case TreatmentEventType.TreatmentOutcome:
                             return 6;
+                        case TreatmentEventType.Denotification:
+                            return 7;
                         default:
                             throw new ArgumentOutOfRangeException();
                     }

--- a/ntbs-service/Models/Enums/TreatmentEventType.cs
+++ b/ntbs-service/Models/Enums/TreatmentEventType.cs
@@ -16,5 +16,7 @@ namespace ntbs_service.Models.Enums
         TreatmentStart,
         [Display(Name = "Diagnosis made")]
         DiagnosisMade,
+        [Display(Name = "Denotification")]
+        Denotification
     }
 }

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -105,15 +105,8 @@ namespace ntbs_service.Pages.Notifications
                     EventDate = Notification.DenotificationDetails.DateOfDenotification,
                     TreatmentEventType = TreatmentEventType.Denotification
                 };
-                if (TreatmentPeriods.Any())
-                {
-                    TreatmentPeriods.Last().TreatmentEvents.Add(denotificationEvent);
-                    TreatmentPeriods.Last().TreatmentEvents.OrderForEpisodes();
-                }
-                else
-                {
-                    TreatmentPeriods.Add(TreatmentPeriod.CreateTreatmentPeriod(1, denotificationEvent));
-                }
+                TreatmentPeriods.Last().TreatmentEvents.Add(denotificationEvent);
+                TreatmentPeriods.Last().TreatmentEvents.OrderForEpisodes();
             }
         }
 

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using ntbs_service.DataAccess;
@@ -70,6 +71,7 @@ namespace ntbs_service.Pages.Notifications
             CultureAndResistance = await _cultureAndResistanceService.GetCultureAndResistanceDetailsAsync(NotificationId);
             TreatmentPeriods = Notification.TreatmentEvents.GroupEpisodesIntoPeriods();
 
+            AddDenotificationEventIfDenotified();
             CalculateTreatmentOutcomes();
             return Page();
         }
@@ -90,6 +92,28 @@ namespace ntbs_service.Pages.Notifications
             {
                 Should36MonthOutcomeBeDisplayed = true;
                 OutcomeAt36Months = TreatmentOutcomesHelper.GetTreatmentOutcomeAtXYears(Notification, 3);
+            }
+        }
+
+        // We only want to add a 'pseudo-event' which is displayed but isn't actually tied to the notification/outcomes
+        private void AddDenotificationEventIfDenotified()
+        {
+            if (Notification.NotificationStatus == NotificationStatus.Denotified)
+            {
+                var denotificationEvent = new TreatmentEvent
+                {
+                    EventDate = Notification.DenotificationDetails.DateOfDenotification,
+                    TreatmentEventType = TreatmentEventType.Denotification
+                };
+                if (TreatmentPeriods.Any())
+                {
+                    TreatmentPeriods.Last().TreatmentEvents.Add(denotificationEvent);
+                    TreatmentPeriods.Last().TreatmentEvents.OrderForEpisodes();
+                }
+                else
+                {
+                    TreatmentPeriods.Add(TreatmentPeriod.CreateTreatmentPeriod(1, denotificationEvent));
+                }
             }
         }
 

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -51,7 +51,7 @@
                     @(period.IsTransfer ? "Transfer" :  $"Treatment period {period.PeriodNumber}")
                 </h4>
 
-                @if (period.TreatmentEvents.Last().TreatmentEventType == TreatmentEventType.Denotification || period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
+                @if (period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
                 {
                     <span id="@sectionId-@period.PeriodNumber-dates">@period.TreatmentEvents.First().FormattedEventDate to @period.TreatmentEvents.Last().FormattedEventDate</span>
                 }

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -51,7 +51,7 @@
                     @(period.IsTransfer ? "Transfer" :  $"Treatment period {period.PeriodNumber}")
                 </h4>
 
-                @if (period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
+                @if (period.TreatmentEvents.Last().TreatmentEventType == TreatmentEventType.Denotification || period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
                 {
                     <span id="@sectionId-@period.PeriodNumber-dates">@period.TreatmentEvents.First().FormattedEventDate to @period.TreatmentEvents.Last().FormattedEventDate</span>
                 }


### PR DESCRIPTION
## Description
Add a display-only denotification event if the notification is denotified. This will be used for the period's end date if it's the last event, but will not be used for any outcome calculations. This event is appended to the last period and then ordered by date (and a custom ordering, where denotification is last).

## Checklist:
- [x] Automated tests are passing locally.
