### PR TITLE
NTBS-2652 Fix GetUserDisplayName null ref exception

### DIFF
--- a/ntbs-service/Services/UserService.cs
+++ b/ntbs-service/Services/UserService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Castle.Core.Internal;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 using ntbs_service.DataAccess;
@@ -117,9 +118,9 @@ namespace ntbs_service.Services
 
         public string GetUserDisplayName(ClaimsPrincipal user)
         {
-            var displayName = NameFormattingHelper.FormatDisplayName(user.Identity.Name);
+            var displayName = NameFormattingHelper.FormatDisplayName(user.Identity?.Name);
 
-            if (displayName.Contains("@"))
+            if (displayName.IsNullOrEmpty() || displayName.Contains("@"))
             {
                 var nameClaim = user.Claims.FirstOrDefault(c => c.Type == "name");
                 if (nameClaim != null)


### PR DESCRIPTION
## Description
* Fix a null reference exception in `UserService`.
* Whilst I was here, I wrote a bunch of unit tests for the method in question.

I was not able to reproduce the error. It seems to have occurred when a user logged in without any details about them in Azure AD, and the header `null` ref'ed when trying to display their name. This means the user probably was shown our "Service unavailable" error 500 page, instead of the access denied page they should have got. Rider was able to point out the source of the `null` reference exception on the line in question so I just fixed it.

## Questions
Just one question: currently it's still possible to get a `null` out of `UserService.GetUserDisplayName`, which is used by the header partial to make this text:
![image](https://user-images.githubusercontent.com/3650110/130644612-6975a756-92de-4c1b-b40a-315d94916091.png)
And if the user does get in somehow without a name (even to just view the access denied page), this will just be displayed as a down arrow. Do we want some kind of default text here, like "Unknown user" or something? 
Also similar question for the this-user contact details page:
![image](https://user-images.githubusercontent.com/3650110/130645080-63d6c1a6-7de9-4681-ae2d-b3577f17debf.png)

## Checklist:
- [x] Automated tests are passing locally.