### PR TITLE
NTBS-1420: Add TB service search during transfer

### DIFF
--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml
@@ -29,7 +29,7 @@
                         <span nhs-span-type="ErrorMessage" id="tb-service-error" has-error="@hasTbServiceCodeError"
                               ref="errorField" asp-validation-for="TransferRequest.TbServiceCode"></span>
                         <autocomplete-select ref="filterContainer" v-on:mounted="filteringMounted" v-on:input-changed="filteringChanged"
-                                             placeholder="Select TB service" filter="true" inline-template>
+                                             placeholder="Select TB service" emit-change-on="select" inline-template>
                             <select ref="selectField" nhs-select-type="@tbServiceCodeSelectErrorState" asp-for="TransferRequest.TbServiceCode"
                                 asp-items="Model.TbServices">
                                 <option value=""></option>

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml
@@ -15,21 +15,8 @@
     <form method="post" autocomplete="off">
         <h2> You are about to transfer this notification </h2>
         <div>
-            <cascading-dropdown filter-first-handler-path="FilteredTbServiceListsByPhecCode" 
-                filter-second-handler-path="FilteredCaseManagersListByTbServiceCode"
-                v-bind:hidden-first-dropdown-with-no-js="true"
-                :filtering-refs="['tbServices', 'caseManagers']" inline-template>
+            <filtered-dropdown filter-handler-path="FilteredCaseManagersListByTbServiceCode" :filtering-refs="['caseManagers']" inline-template>
                 <div>
-                    <nhs-form-group nhs-form-group-type="Standard" ref="firstFilterContainer" classes="hidden">
-                        <label nhs-label-type="Standard" for="PhecCode">
-                            PHEC
-                        </label>
-                        <select id="PhecCode" ref="selectField" nhs-select-type="@SelectType.Standard"
-                                asp-items="Model.Phecs" v-on:change="firstFilteringChanged">
-                            <option value="" selected>Please select</option>
-                        </select>
-                    </nhs-form-group>
-
                     @{
                         var hasTbServiceCodeError = !Model.ValidationService.IsValid("TransferRequest.TbServiceCode");
                         var tbServiceCodeGroupState = hasTbServiceCodeError ? Error : Standard;
@@ -40,11 +27,14 @@
                             @Html.DisplayNameFor(model => model.TransferRequest.TbServiceCode)
                         </label>
                         <span nhs-span-type="ErrorMessage" id="tb-service-error" has-error="@hasTbServiceCodeError"
-                                ref="errorField" asp-validation-for="TransferRequest.TbServiceCode"></span>
-                        <select ref="selectField" nhs-select-type="@tbServiceCodeSelectErrorState" asp-for="TransferRequest.TbServiceCode"
-                                asp-items="Model.TbServices" v-on:change="secondFilteringChanged">
-                            <option value="" selected>Please select</option>
-                        </select>
+                              ref="errorField" asp-validation-for="TransferRequest.TbServiceCode"></span>
+                        <autocomplete-select ref="filterContainer" v-on:mounted="filteringMounted" v-on:input-changed="filteringChanged"
+                                             placeholder="Select TB service" filter="true" inline-template>
+                            <select ref="selectField" nhs-select-type="@tbServiceCodeSelectErrorState" asp-for="TransferRequest.TbServiceCode"
+                                asp-items="Model.TbServices">
+                                <option value=""></option>
+                            </select>
+                        </autocomplete-select>
                     </nhs-form-group>
                     @{
                         var hasCaseManagerError = !Model.ValidationService.IsValid("TransferRequest.CaseManagerId");
@@ -63,7 +53,7 @@
                         </select>
                     </nhs-form-group>
                 </div>
-            </cascading-dropdown>
+            </filtered-dropdown>
         </div>
 
         @{

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml
@@ -124,7 +124,7 @@
                 Add optional note to display to receiving case manager
             </label>
             <span id="optional-note-error" nhs-span-type="ErrorMessage" asp-validation-for="TransferRequest.TransferRequestNote" has-error="@hasRequestNoteError"></span>
-            <input asp-for="TransferRequest.TransferRequestNote" nhs-input-type="Standard" is-error-input="@hasRequestNoteError" aria-describedby="note-error" />
+            <input asp-for="TransferRequest.TransferRequestNote" nhs-input-type="Standard" is-error-input="@hasRequestNoteError" aria-describedby="optional-note-error" />
         </nhs-form-group>
 
         <div class="flex-container">

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisAnimalExposure.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisAnimalExposure.cshtml
@@ -67,8 +67,8 @@
                                 has-error="@hasCountryError">
                             </span>
                             <div ref="selectField" class="@countrySelectErrorClass">
-                                <autocomplete-select v-on:validate-input="validate" placeholder="Please select" validate="true" inline-template>
-                                    <select asp-for="MBovisAnimalExposure.CountryId" asp-items="Model.Countries" ref="selectElement">
+                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" validate="true" inline-template>
+                                    <select asp-for="MBovisAnimalExposure.CountryId" asp-items="Model.Countries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisAnimalExposure.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisAnimalExposure.cshtml
@@ -67,7 +67,7 @@
                                 has-error="@hasCountryError">
                             </span>
                             <div ref="selectField" class="@countrySelectErrorClass">
-                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" validate="true" inline-template>
+                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" emit-change-on="blur" inline-template>
                                     <select asp-for="MBovisAnimalExposure.CountryId" asp-items="Model.Countries" ref="selectField">
                                         <option value=""></option>
                                     </select>

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisOccupationExposure.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisOccupationExposure.cshtml
@@ -68,8 +68,8 @@
                                 has-error="@hasCountryError">
                             </span>
                             <div ref="selectField" class="@countrySelectErrorClass">
-                                <autocomplete-select v-on:validate-input="validate" placeholder="Please select" validate="true" inline-template>
-                                    <select asp-for="MBovisOccupationExposure.CountryId" asp-items="Model.Countries" ref="selectElement">
+                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" validate="true" inline-template>
+                                    <select asp-for="MBovisOccupationExposure.CountryId" asp-items="Model.Countries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisOccupationExposure.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisOccupationExposure.cshtml
@@ -68,7 +68,7 @@
                                 has-error="@hasCountryError">
                             </span>
                             <div ref="selectField" class="@countrySelectErrorClass">
-                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" validate="true" inline-template>
+                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" emit-change-on="blur" inline-template>
                                     <select asp-for="MBovisOccupationExposure.CountryId" asp-items="Model.Countries" ref="selectField">
                                         <option value=""></option>
                                     </select>

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisUnpasteurisedMilkConsumption.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisUnpasteurisedMilkConsumption.cshtml
@@ -67,8 +67,8 @@
                                 has-error="@hasCountryError">
                             </span>
                             <div ref="selectField" class="@countrySelectErrorClass">
-                                <autocomplete-select v-on:validate-input="validate" placeholder="Please select" validate="true" inline-template>
-                                    <select asp-for="MBovisUnpasteurisedMilkConsumption.CountryId" asp-items="Model.Countries" ref="selectElement">
+                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" validate="true" inline-template>
+                                    <select asp-for="MBovisUnpasteurisedMilkConsumption.CountryId" asp-items="Model.Countries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/Items/_MBovisUnpasteurisedMilkConsumption.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_MBovisUnpasteurisedMilkConsumption.cshtml
@@ -67,7 +67,7 @@
                                 has-error="@hasCountryError">
                             </span>
                             <div ref="selectField" class="@countrySelectErrorClass">
-                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" validate="true" inline-template>
+                                <autocomplete-select v-on:input-changed="validate" placeholder="Please select" emit-change-on="blur" inline-template>
                                     <select asp-for="MBovisUnpasteurisedMilkConsumption.CountryId" asp-items="Model.Countries" ref="selectField">
                                         <option value=""></option>
                                     </select>

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
@@ -72,7 +72,7 @@
                                         ref="errorField" asp-validation-for="MDRDetails.CountryId" has-error="@hasCountryError">
                                     </span>
                                     <div ref="selectField" data-aria-controls="notified-to-phe-conditional" class=@countrySelectErrorClass>
-                                        <autocomplete-select v-on:input-changed="validate" placeholder="Select Country" validate="true" inline-template>
+                                        <autocomplete-select v-on:input-changed="validate" placeholder="Select Country" emit-change-on="blur" inline-template>
                                             <select asp-for="MDRDetails.CountryId" asp-items="Model.Countries" ref="selectField">
                                                 <option value=""></option>
                                             </select>

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
@@ -72,8 +72,8 @@
                                         ref="errorField" asp-validation-for="MDRDetails.CountryId" has-error="@hasCountryError">
                                     </span>
                                     <div ref="selectField" data-aria-controls="notified-to-phe-conditional" class=@countrySelectErrorClass>
-                                        <autocomplete-select v-on:validate-input="validate" placeholder="Select Country" validate="true" inline-template>
-                                            <select asp-for="MDRDetails.CountryId" asp-items="Model.Countries" ref="selectElement">
+                                        <autocomplete-select v-on:input-changed="validate" placeholder="Select Country" validate="true" inline-template>
+                                            <select asp-for="MDRDetails.CountryId" asp-items="Model.Countries" ref="selectField">
                                                 <option value=""></option>
                                             </select>
                                         </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
@@ -253,8 +253,8 @@
                     <span nhs-span-type="ErrorMessage" id="birth-country-error"
                           ref="errorField" asp-validation-for="PatientDetails.CountryId" has-error="@hasCountryError"></span>
                     <div ref="selectField" data-aria-controls="year-of-entry-conditional" class=@countrySelectErrorClass>
-                        <autocomplete-select v-on:validate-input="validate" placeholder="Select a Birth Country" validate="true" inline-template>
-                            <select asp-for="PatientDetails.CountryId" asp-items="Model.Countries" ref="selectElement">
+                        <autocomplete-select v-on:input-changed="validate" placeholder="Select a Birth Country" validate="true" inline-template>
+                            <select asp-for="PatientDetails.CountryId" asp-items="Model.Countries" ref="selectField">
                                 <option value=""></option>
                             </select>
                         </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml
@@ -253,7 +253,7 @@
                     <span nhs-span-type="ErrorMessage" id="birth-country-error"
                           ref="errorField" asp-validation-for="PatientDetails.CountryId" has-error="@hasCountryError"></span>
                     <div ref="selectField" data-aria-controls="year-of-entry-conditional" class=@countrySelectErrorClass>
-                        <autocomplete-select v-on:input-changed="validate" placeholder="Select a Birth Country" validate="true" inline-template>
+                        <autocomplete-select v-on:input-changed="validate" placeholder="Select a Birth Country" emit-change-on="blur" inline-template>
                             <select asp-for="PatientDetails.CountryId" asp-items="Model.Countries" ref="selectField">
                                 <option value=""></option>
                             </select>

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
@@ -85,7 +85,7 @@
                                         <span nhs-span-type="ErrorMessage" id="birth-country-error"
                                               ref="errorField" asp-validation-for="PreviousTbHistory.PreviousTreatmentCountryId" has-error="@hasCountryError">
                                         </span>
-                                        <autocomplete-select v-on:input-changed="validate" placeholder="Select country of treatment" validate="true" inline-template>
+                                        <autocomplete-select v-on:input-changed="validate" placeholder="Select country of treatment" emit-change-on="blur" inline-template>
                                             <select asp-for="PreviousTbHistory.PreviousTreatmentCountryId"
                                                     asp-items="Model.Countries" 
                                                     ref="selectField">

--- a/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/PreviousHistory.cshtml
@@ -85,10 +85,10 @@
                                         <span nhs-span-type="ErrorMessage" id="birth-country-error"
                                               ref="errorField" asp-validation-for="PreviousTbHistory.PreviousTreatmentCountryId" has-error="@hasCountryError">
                                         </span>
-                                        <autocomplete-select v-on:validate-input="validate" placeholder="Select country of treatment" validate="true" inline-template>
+                                        <autocomplete-select v-on:input-changed="validate" placeholder="Select country of treatment" validate="true" inline-template>
                                             <select asp-for="PreviousTbHistory.PreviousTreatmentCountryId"
                                                     asp-items="Model.Countries" 
-                                                    ref="selectElement">
+                                                    ref="selectField">
                                                 <option value=""></option>
                                             </select>
                                         </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
@@ -54,7 +54,7 @@
                                   id="travel-country1Id-error" ref="country1IdErrorRef" has-error="@hasCountry1IdError"></span>
                             <div ref="country1Id" aria-describedby="travel-country1Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
-                                    <select asp-for="TravelDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
+                                    <select asp-for="TravelDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>
@@ -87,7 +87,7 @@
                                   id="travel-country2Id-error" ref="country2IdErrorRef" has-error="@hasCountry2IdError"></span>
                             <div ref="country2Id" aria-describedby="travel-country2Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
-                                    <select asp-for="TravelDetails.Country2Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
+                                    <select asp-for="TravelDetails.Country2Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>
@@ -120,7 +120,7 @@
                                   id="travel-country3Id-error" ref="country3IdErrorRef" has-error="@hasCountry3IdError"></span>
                             <div ref="country3Id" aria-describedby="travel-country3Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
-                                    <select asp-for="TravelDetails.Country3Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
+                                    <select asp-for="TravelDetails.Country3Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_TravelDetailsPartial.cshtml
@@ -53,7 +53,7 @@
                             <span asp-validation-for="TravelDetails.Country1Id" nhs-span-type="ErrorMessage"
                                   id="travel-country1Id-error" ref="country1IdErrorRef" has-error="@hasCountry1IdError"></span>
                             <div ref="country1Id" aria-describedby="travel-country1Id-error">
-                                <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
+                                <autocomplete-select placeholder="@selectDropdownPlaceholder" emit-change-on="blur" inline-template>
                                     <select asp-for="TravelDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
@@ -86,7 +86,7 @@
                             <span asp-validation-for="TravelDetails.Country2Id" nhs-span-type="ErrorMessage"
                                   id="travel-country2Id-error" ref="country2IdErrorRef" has-error="@hasCountry2IdError"></span>
                             <div ref="country2Id" aria-describedby="travel-country2Id-error">
-                                <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
+                                <autocomplete-select placeholder="@selectDropdownPlaceholder" emit-change-on="blur" inline-template>
                                     <select asp-for="TravelDetails.Country2Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
@@ -119,7 +119,7 @@
                             <span asp-validation-for="TravelDetails.Country3Id" nhs-span-type="ErrorMessage"
                                   id="travel-country3Id-error" ref="country3IdErrorRef" has-error="@hasCountry3IdError"></span>
                             <div ref="country3Id" aria-describedby="travel-country3Id-error">
-                                <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
+                                <autocomplete-select placeholder="@selectDropdownPlaceholder" emit-change-on="blur" inline-template>
                                     <select asp-for="TravelDetails.Country3Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>

--- a/ntbs-service/Pages/Notifications/Edit/_VisitorDetailsPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_VisitorDetailsPartial.cshtml
@@ -56,7 +56,7 @@
                                   id="visitor-country1Id-error" ref="country1IdErrorRef" has-error="@hasCountry1IdError"></span>
                             <div ref="country1Id" aria-describedby="visitor-country1Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
-                                    <select asp-for="VisitorDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
+                                    <select asp-for="VisitorDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>
@@ -89,7 +89,7 @@
                                   id="visitor-country2Id-error" ref="country2IdErrorRef" has-error="@hasCountry2IdError"></span>
                             <div ref="country2Id" aria-describedby="visitor-country2Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
-                                    <select asp-for="VisitorDetails.Country2Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
+                                    <select asp-for="VisitorDetails.Country2Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>
@@ -122,7 +122,7 @@
                                   id="visitor-country3Id-error" ref="country3IdErrorRef" has-error="@hasCountry3IdError"></span>
                             <div ref="country3Id" aria-describedby="visitor-country3Id-error">
                                 <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
-                                    <select asp-for="VisitorDetails.Country3Id" asp-items="Model.HighTbIncidenceCountries" ref="selectElement">
+                                    <select asp-for="VisitorDetails.Country3Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
                                 </autocomplete-select>

--- a/ntbs-service/Pages/Notifications/Edit/_VisitorDetailsPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_VisitorDetailsPartial.cshtml
@@ -55,7 +55,7 @@
                             <span asp-validation-for="VisitorDetails.Country1Id" nhs-span-type="ErrorMessage"
                                   id="visitor-country1Id-error" ref="country1IdErrorRef" has-error="@hasCountry1IdError"></span>
                             <div ref="country1Id" aria-describedby="visitor-country1Id-error">
-                                <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
+                                <autocomplete-select placeholder="@selectDropdownPlaceholder" emit-change-on="blur" inline-template>
                                     <select asp-for="VisitorDetails.Country1Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
@@ -88,7 +88,7 @@
                             <span asp-validation-for="VisitorDetails.Country2Id" nhs-span-type="ErrorMessage"
                                   id="visitor-country2Id-error" ref="country2IdErrorRef" has-error="@hasCountry2IdError"></span>
                             <div ref="country2Id" aria-describedby="visitor-country2Id-error">
-                                <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
+                                <autocomplete-select placeholder="@selectDropdownPlaceholder" emit-change-on="blur" inline-template>
                                     <select asp-for="VisitorDetails.Country2Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>
@@ -121,7 +121,7 @@
                             <span asp-validation-for="VisitorDetails.Country3Id" nhs-span-type="ErrorMessage"
                                   id="visitor-country3Id-error" ref="country3IdErrorRef" has-error="@hasCountry3IdError"></span>
                             <div ref="country3Id" aria-describedby="visitor-country3Id-error">
-                                <autocomplete-select placeholder="@selectDropdownPlaceholder" validate="true" inline-template>
+                                <autocomplete-select placeholder="@selectDropdownPlaceholder" emit-change-on="blur" inline-template>
                                     <select asp-for="VisitorDetails.Country3Id" asp-items="Model.HighTbIncidenceCountries" ref="selectField">
                                         <option value=""></option>
                                     </select>

--- a/ntbs-service/wwwroot/source/Components/AutocompleteSelect.ts
+++ b/ntbs-service/wwwroot/source/Components/AutocompleteSelect.ts
@@ -42,14 +42,14 @@ const AutocompleteSelect = Vue.extend({
         },
         onConfirm: function (value: any) {
             // this is called twice, when a user selects a value (value is defined) and when user clicks away from input (blur, value undefined)
-            if (!this.$props.emitChangeOn || (this.$props.emitChangeOn == "blur" && value != undefined)) {
+            if (!this.$props.emitChangeOn) {
                 return;
             }
-            if (value != undefined) {
-                this.setSelectValue(value);
-            }
-            else if (this.$props.emitChangeOn == "blur") {
+            if (this.$props.emitChangeOn === "blur" && value === undefined) {
                 this.setSelectValue(this.autocompleteElement.value);
+            }
+            else if (this.$props.emitChangeOn === "select" && value !== undefined) {
+                this.setSelectValue(value);
             }
         },
         setSelectValue: function (value: any) {


### PR DESCRIPTION
## Description
Removed the PHEC dropdown on transfers, as it was being used as a way to filter down the TB service list which is now searchable.
The cadcading-dropdown component is no longer needed as we don't need multiple filtering, so I'm just using the filtered-dropdown with an autocomplete-select. I've added a filtering property to this, as it means we can emit an event and filter when a choice is chosen instead of on blur, which is when validation happens.
Also I've changed the ref it's looking for for the select element so it lines up with filtered-dropdown - "selectField" instead of "selectElement".

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
