### PR TITLE
NTBS-2674 Update webpack settings to be consistent with new css-loader

### DIFF
--- a/ntbs-service/webpack.common.js
+++ b/ntbs-service/webpack.common.js
@@ -5,7 +5,7 @@ module.exports = {
   entry: { 'main': './wwwroot/source/app.ts'},
   output: {
     path: path.resolve(__dirname, 'wwwroot/dist'),
-    publicPath: 'dist/',
+    publicPath: '/dist/',
     filename: 'bundle.js'
   },
   plugins: [
@@ -46,13 +46,7 @@ module.exports = {
       },
       {
         test: /\.(png|woff|woff2|eot|ttf|svg)$/,
-        use: {
-            loader: 'url-loader',
-            options: {
-              limit: 10000, // bytes
-              publicPath: './'
-            }
-        }
+        type: "asset"
       }
     ]
   },


### PR DESCRIPTION
I've checked locally that the issue loading the fonts is fixed. We should do a bit of regression testing on `int` to make sure this hasn't broken anything else.