### PR TITLE
NTBS-2685: Take treatment event notes from migration database

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
@@ -72,6 +72,57 @@ namespace ntbs_service_unit_tests.DataMigration
         }
 
         [Fact]
+        public async Task MigrationTreatmentEventWithBoilerplateNoteMappedToNull()
+        {
+            // Arrange
+            GivenLegacyUserWithName("miles.davis@columbia.nhs.uk", "Miles", "Davis");
+            var migrationTransferEvent = new MigrationDbTransferEvent
+            {
+                EventDate = DateTime.Parse("12/12/2012"),
+                CaseManager = "miles.davis@columbia.nhs.uk",
+                HospitalId = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7B"),
+                TreatmentEventType = "TransferIn",
+                Notes = "Dear Mrs Lucy Carmen-Minoe, \n You have been identified as the new case manager for the case below.\n"
+                    + "Id: 134222 \n\n Patient: Harry Swingset  Case report date: 11/11/2009"
+            };
+
+            // Act
+            var mappedEvent = await _treatmentEventMapper.AsTransferEvent(migrationTransferEvent, null, 1);
+
+            // Assert
+            Assert.Equal(DateTime.Parse("12/12/2012"), mappedEvent.EventDate);
+            Assert.Equal(TreatmentEventType.TransferIn, mappedEvent.TreatmentEventType);
+            Assert.Null(mappedEvent.Note);
+        }
+
+        [Fact]
+        public async Task MigrationTreatmentEventWithCustomNoteMappedToWithoutBoilerplateParts()
+        {
+            // Arrange
+            GivenLegacyUserWithName("miles.davis@columbia.nhs.uk", "Miles", "Davis");
+            var migrationTransferEvent = new MigrationDbTransferEvent
+            {
+                EventDate = DateTime.Parse("12/12/2012"),
+                CaseManager = "miles.davis@columbia.nhs.uk",
+                HospitalId = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7B"),
+                TreatmentEventType = "TransferIn",
+                Notes = "Dear Mrs Lucy Carmen-Minoe, \n This patient was moved from XYX hospital in London. This is very important information.\n"
+                        + "Id: 134222 \n\n Patient: Harry Swingset  Case report date: 11/11/2009 \n Also they are allergic to mung beans"
+            };
+
+            // Act
+            var mappedEvent = await _treatmentEventMapper.AsTransferEvent(migrationTransferEvent, null, 1);
+
+            // Assert
+            Assert.Equal(DateTime.Parse("12/12/2012"), mappedEvent.EventDate);
+            Assert.Equal(TreatmentEventType.TransferIn, mappedEvent.TreatmentEventType);
+            Assert.Contains("This patient was moved from XYX hospital in London. This is very important information.", mappedEvent.Note);
+            Assert.Contains("Also they are allergic to mung beans", mappedEvent.Note);
+            Assert.DoesNotContain("Id: 134222", mappedEvent.Note);
+            Assert.DoesNotContain("Dear Mrs Lucy Carmen-Minoe", mappedEvent.Note);
+        }
+
+        [Fact]
         public async Task MigrationOutcomeEventMappedCorrectlyWithTbServiceAndCaseManagerAdded()
         {
             // Arrange

--- a/ntbs-service-unit-tests/TestData/MigrationDatabaseMock/transferEvents.csv
+++ b/ntbs-service-unit-tests/TestData/MigrationDatabaseMock/transferEvents.csv
@@ -1,3 +1,3 @@
-OldNotificationId,EventDate,TreatmentEventType,HospitalId,CaseManager
-130331,2016-01-15 12:53:14.630,TransferIn,F026FDCD-7BAF-4C96-994C-20E436CC8C59,Nancy.Pickering@ntbs.phe.com
-130331,2016-01-15 12:53:14.630,TransferOut,0AC033AB-9A11-4FA6-AA1A-1FCA71180C2F,Nancy.Pickering@ntbs.phe.com
+OldNotificationId,EventDate,TreatmentEventType,HospitalId,CaseManager,Notes
+130331,2016-01-15 12:53:14.630,TransferIn,F026FDCD-7BAF-4C96-994C-20E436CC8C59,Nancy.Pickering@ntbs.phe.com,
+130331,2016-01-15 12:53:14.630,TransferOut,0AC033AB-9A11-4FA6-AA1A-1FCA71180C2F,Nancy.Pickering@ntbs.phe.com,

--- a/ntbs-service/DataMigration/RawModels/MigrationDbTransferEvent.cs
+++ b/ntbs-service/DataMigration/RawModels/MigrationDbTransferEvent.cs
@@ -10,5 +10,6 @@ namespace ntbs_service.DataMigration.RawModels
         public string TreatmentEventType { get; set; }
         public Guid? HospitalId { get; set; }
         public string CaseManager { get; set; }
+        public string Notes { get; set; }
     }
 }

--- a/ntbs-service/DataMigration/TreatmentEventMapper.cs
+++ b/ntbs-service/DataMigration/TreatmentEventMapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
-using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Castle.Core.Internal;
 using Hangfire.Server;
 using ntbs_service.DataAccess;
 using ntbs_service.DataMigration.RawModels;
@@ -33,7 +34,8 @@ namespace ntbs_service.DataMigration
             var ev = new TreatmentEvent
             {
                 EventDate = rawEvent.EventDate,
-                TreatmentEventType = Converter.GetEnumValue<TreatmentEventType>(rawEvent.TreatmentEventType)
+                TreatmentEventType = Converter.GetEnumValue<TreatmentEventType>(rawEvent.TreatmentEventType),
+                Note = RemoveUnnecessaryNoteInfo(rawEvent.Notes)
             };
 
             await TryAddTbServiceAndCaseManagerToTreatmentEvent(ev, rawEvent.HospitalId, rawEvent.CaseManager, context, runId);
@@ -76,6 +78,32 @@ namespace ntbs_service.DataMigration
             {
                 await _caseManagerImportService.ImportOrUpdateLegacyUser(caseManagerUsername, ev.TbServiceCode, context, runId);
                 ev.CaseManagerId = (await _referenceDataRepository.GetUserByUsernameAsync(caseManagerUsername)).Id;
+            }
+        }
+
+        private string RemoveUnnecessaryNoteInfo(string note)
+        {
+            if (note.IsNullOrEmpty())
+            {
+                return null;
+            }
+            var trimmedNote = note.Trim();
+            var mainPattern =
+                @"(Dear|Hi)[0-9a-zA-Z -]+,{0,1}[\n\r ]*(?<caseManagerText>[0-9a-zA-Z \/\-—,.'`@#&+;:$_()<>\\\[\]=\*\?\n\r]*)"
+                + @"(?<uselessInfo>Id: [0-9 ]+[\n\r ]*Patient: [a-zA-Z -]+[\n\r ]*Case report date: [0-9 ]{2}\/[0-9]{2}\/[0-9]{4})"
+                + @"(?<appendedNote>[0-9a-zA-Z \/\-—,.'`@#&+;:$_()<>\\\[\]=\*\?\n\r]*)";
+            var caseManagerPattern = @"You have been identified as the new case manager for the case below\.[\n\r]*";
+            var notePatternMatch = Regex.Match(trimmedNote, mainPattern);
+            if (notePatternMatch.Success)
+            {
+                var caseManagerText = notePatternMatch.Groups["caseManagerText"].Value;
+                var appendedNote = notePatternMatch.Groups["appendedNote"].Value;
+                var returnNote = Regex.IsMatch(caseManagerText, caseManagerPattern) ? appendedNote.Trim() : $"{caseManagerText.Trim()} {appendedNote.Trim()}";
+                return returnNote.Length == 0 ? null : returnNote;
+            }
+            else
+            {
+                return trimmedNote;
             }
         }
     }


### PR DESCRIPTION
## Description
Migrate in notes from treatment events in the migration database. There is some boilerplate text that is added to pretty much every note, so I've written a regex to match that so we don't import those parts. 
If the note doesn't match at all then it will just add the whole note into the notes field.
The longest note in ETS (before any removal) is 800 characters and our notes field is 1000, so I'm confident we won't see that error.
The corresponding migration PR: https://github.com/publichealthengland/ntbs-data-migration/pull/167

## Checklist:
- [x] Automated tests are passing locally.