### PR TITLE
NTBS-2709: Add new child ECM level dq alert

### DIFF
--- a/ntbs-service/DataAccess/DataQualityRepository.cs
+++ b/ntbs-service/DataAccess/DataQualityRepository.cs
@@ -49,6 +49,10 @@ namespace ntbs_service.DataAccess
         // Potential Duplicates
         Task<IList<NotificationAndDuplicateIds>>
             GetNotificationIdsEligibleForDqPotentialDuplicateAlertsAsync();
+
+        // Child ECM Levels
+        Task<IList<Notification>> GetNotificationsEligibleForDqChildECMLevelAlertsAsync(int count, int offset);
+        Task<int> GetNotificationsEligibleForDqChildECMLevelAlertsCountAsync();
     }
 
     public class DataQualityRepository : IDataQualityRepository
@@ -174,6 +178,19 @@ namespace ntbs_service.DataAccess
         public Task<int> GetNotificationsEligibleForDqTreatmentOutcome36AlertsCountAsync() =>
             GetNotificationsEligibleForAlertsCount(DataQualityTreatmentOutcome36
                 .NotificationInQualifyingRangeExpression);
+
+        #endregion
+
+        #region Child ECM Level
+
+        public Task<IList<Notification>> GetNotificationsEligibleForDqChildECMLevelAlertsAsync(int count, int offset) =>
+            GetMultipleNotificationsEligibleForAlertsWithOffset<DataQualityChildECMLevel>(
+                DataQualityChildECMLevel.NotificationQualifiesExpression,
+                count,
+                offset);
+
+        public Task<int> GetNotificationsEligibleForDqChildECMLevelAlertsCountAsync() =>
+            GetNotificationsEligibleForAlertsCount(DataQualityChildECMLevel.NotificationQualifiesExpression);
 
         #endregion
 

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -766,6 +766,7 @@ namespace ntbs_service.DataAccess
                     .HasValue<DataQualityTreatmentOutcome24>(AlertType.DataQualityTreatmentOutcome24)
                     .HasValue<DataQualityTreatmentOutcome36>(AlertType.DataQualityTreatmentOutcome36)
                     .HasValue<DataQualityDotVotAlert>(AlertType.DataQualityDotVotAlert)
+                    .HasValue<DataQualityChildECMLevel>(AlertType.DataQualityChildECMLevel)
                     .HasValue<DataQualityPotentialDuplicateAlert>(AlertType.DataQualityPotientialDuplicate);
 
                 entity.HasIndex(e => new { e.AlertStatus, e.AlertType });

--- a/ntbs-service/Jobs/DataQualityAlertsJob.cs
+++ b/ntbs-service/Jobs/DataQualityAlertsJob.cs
@@ -29,7 +29,7 @@ namespace ntbs_service.Jobs
         }
 
         private delegate Task<int> GetNotificationsEligibleForDqAlertsCount();
-        private delegate Task<IList<Notification>> GetMultipleNotificationsEligibleForDataQualityDraftAlerts(
+        private delegate Task<IList<Notification>> GetMultipleNotificationsEligibleForDataQualityAlerts(
             int countPerBatch,
             int offset);
 
@@ -68,9 +68,14 @@ namespace ntbs_service.Jobs
             _dataQualityRepository.GetNotificationsEligibleForDqTreatmentOutcome36AlertsAsync
         );
 
+        private async Task CreateChildECMLevelAlertsInBulkAsync() => await CreateAlertsInBulkAsync<DataQualityChildECMLevel>(
+            _dataQualityRepository.GetNotificationsEligibleForDqChildECMLevelAlertsCountAsync,
+            _dataQualityRepository.GetNotificationsEligibleForDqChildECMLevelAlertsAsync
+        );
+
         private async Task CreateAlertsInBulkAsync<T>(
             GetNotificationsEligibleForDqAlertsCount getCount,
-            GetMultipleNotificationsEligibleForDataQualityDraftAlerts getNotifications) where T : Alert
+            GetMultipleNotificationsEligibleForDataQualityAlerts getNotifications) where T : Alert
         {
             var notificationsForAlertsCount = await getCount();
             var offset = 0;
@@ -107,6 +112,7 @@ namespace ntbs_service.Jobs
             await CreateTreatmentOutcome12MonthAlertsInBulkAsync();
             await CreateTreatmentOutcome24MonthAlertsInBulkAsync();
             await CreateTreatmentOutcome36MonthAlertsInBulkAsync();
+            await CreateChildECMLevelAlertsInBulkAsync();
 
             // When we check for treatment outcome alerts above, quite a lot of notifications are being brought
             // into the context. (This is because the eligibility check cannot be entirely translated into SQL so

--- a/ntbs-service/Migrations/NtbsContextModelSnapshot.cs
+++ b/ntbs-service/Migrations/NtbsContextModelSnapshot.cs
@@ -4837,6 +4837,13 @@ namespace ntbs_service.Migrations
                     b.HasDiscriminator().HasValue("DataQualityBirthCountry");
                 });
 
+            modelBuilder.Entity("ntbs_service.Models.Entities.Alerts.DataQualityChildECMLevel", b =>
+                {
+                    b.HasBaseType("ntbs_service.Models.Entities.Alerts.Alert");
+
+                    b.HasDiscriminator().HasValue("DataQualityChildECMLevel");
+                });
+
             modelBuilder.Entity("ntbs_service.Models.Entities.Alerts.DataQualityClinicalDatesAlert", b =>
                 {
                     b.HasBaseType("ntbs_service.Models.Entities.Alerts.Alert");

--- a/ntbs-service/Models/Entities/Alerts/DataQualityChildECMLevel.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityChildECMLevel.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq.Expressions;
+using ntbs_service.Helpers;
+using ntbs_service.Models.Enums;
+
+namespace ntbs_service.Models.Entities.Alerts
+
+{
+    public class DataQualityChildECMLevel : Alert
+    {
+        private const int MinNumberDaysDraftForAlert = 45;
+
+        public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
+            n => n.NotificationStatus == NotificationStatus.Notified
+                 && n.CreationDate < DateTime.Now.AddDays(-MinNumberDaysDraftForAlert)
+                 && (n.PatientDetails.Dob.Value.Month * 100 + n.PatientDetails.Dob.Value.Day > n.NotificationDate.Value.Month * 100 + n.NotificationDate.Value.Day
+                     ? (n.NotificationDate.Value.Year - n.PatientDetails.Dob.Value.Year - 1) < 16
+                     : n.NotificationDate.Value.Year - n.PatientDetails.Dob.Value.Year < 16)
+                 && n.ClinicalDetails.EnhancedCaseManagementLevel == 0;
+
+        public static readonly Func<Notification, bool> NotificationQualifies =
+            NotificationQualifiesExpression.Compile();
+
+        public override string Action => "Please review whether the value given for ECM is correct.";
+
+        public override string ActionLink => RouteHelper.GetNotificationPath(
+            NotificationId.GetValueOrDefault(),
+            NotificationSubPaths.EditClinicalDetails);
+
+        public DataQualityChildECMLevel()
+        {
+            AlertType = AlertType.DataQualityChildECMLevel;
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/Alerts/DataQualityChildECMLevel.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityChildECMLevel.cs
@@ -13,15 +13,13 @@ namespace ntbs_service.Models.Entities.Alerts
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
             n => n.NotificationStatus == NotificationStatus.Notified
                  && n.CreationDate < DateTime.Now.AddDays(-MinNumberDaysDraftForAlert)
-                 && (n.PatientDetails.Dob.Value.Month * 100 + n.PatientDetails.Dob.Value.Day > n.NotificationDate.Value.Month * 100 + n.NotificationDate.Value.Day
-                     ? (n.NotificationDate.Value.Year - n.PatientDetails.Dob.Value.Year - 1) < 16
-                     : n.NotificationDate.Value.Year - n.PatientDetails.Dob.Value.Year < 16)
+                 && n.NotificationDate.Value < n.PatientDetails.Dob.Value.AddYears(16)
                  && n.ClinicalDetails.EnhancedCaseManagementLevel == 0;
 
         public static readonly Func<Notification, bool> NotificationQualifies =
             NotificationQualifiesExpression.Compile();
 
-        public override string Action => "Please review whether the value given for ECM is correct.";
+        public override string Action => "Please review whether the Enhanced Case Management information is correct.";
 
         public override string ActionLink => RouteHelper.GetNotificationPath(
             NotificationId.GetValueOrDefault(),

--- a/ntbs-service/Models/Enums/AlertType.cs
+++ b/ntbs-service/Models/Enums/AlertType.cs
@@ -32,6 +32,8 @@ namespace ntbs_service.Models.Enums
         DataQualityDotVotAlert,
         [Display(Name = "Potential duplicate notification")]
         DataQualityPotientialDuplicate,
+        [Display(Name = "ECM value not recorded for child")]
+        DataQualityChildECMLevel,
         [Display(Name = "Test Alert")]
         Test
     }

--- a/ntbs-service/Models/Enums/AlertType.cs
+++ b/ntbs-service/Models/Enums/AlertType.cs
@@ -32,7 +32,7 @@ namespace ntbs_service.Models.Enums
         DataQualityDotVotAlert,
         [Display(Name = "Potential duplicate notification")]
         DataQualityPotientialDuplicate,
-        [Display(Name = "ECM value not recorded for child")]
+        [Display(Name = "ECM level not recorded for child")]
         DataQualityChildECMLevel,
         [Display(Name = "Test Alert")]
         Test

--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsTreatmentOptions.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsTreatmentOptions.cshtml
@@ -53,7 +53,7 @@
         </nhs-fieldset>
     </nhs-form-group>
 
-    <nhs-form-group nhs-form-group-type="Standard">
+    <nhs-form-group nhs-form-group-type="Standard" id="ClinicalDetails-ECM">
         <nhs-fieldset>
             <nhs-fieldset-legend nhs-legend-size="Standard">Enhanced Case Management?</nhs-fieldset-legend>
 

--- a/ntbs-service/Services/AlertService.cs
+++ b/ntbs-service/Services/AlertService.cs
@@ -100,6 +100,9 @@ namespace ntbs_service.Services
                 case DataQualityDotVotAlert _:
                     notificationQualifiesCheck = DataQualityDotVotAlert.NotificationQualifies;
                     break;
+                case DataQualityChildECMLevel _:
+                    notificationQualifiesCheck = DataQualityChildECMLevel.NotificationQualifies;
+                    break;
                 default: throw new ArgumentException("Unexpected alert type passed for automatic closing");
             }
 


### PR DESCRIPTION
## Description
Added a new DQ alert: Child ECM level. This alert with show up if the patient is <16y/o at time of notification and if their ECM level is not set (= 0 as default).
Age at notification is worked out the same way it is in NotificationDisplay, I was going to commonise but LINQ shouted at me when I tried to put a call to a helper in the qualifies expression.
Added this to the creation job, and to the auto-dismissal job. 

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
