### PR TITLE
NTBS-2734 Split banner model query

### DIFF
--- a/ntbs-service/Models/Projections/NotificationForBannerModel.cs
+++ b/ntbs-service/Models/Projections/NotificationForBannerModel.cs
@@ -10,6 +10,7 @@ namespace ntbs_service.Models.Projections
         public int NotificationId { get; set; }
         public DateTime? CreationDate { get; set; }
         public DateTime? NotificationDate { get; set; }
+        public int? GroupId { get; set; }
         public string TbService { get; set; }
         public string TbServiceCode { get; set; }
         public string TbServicePHECCode { get; set; }


### PR DESCRIPTION
## Description
Split out the collection queries for previous TB services and linked notifications. This is quite a lot uglier, but does lead EF to produce smaller and more straightforward SQL, which gives the query optimiser a better chance at picking a good plan. If you can think of neater ways of doing this whilst also keeping the EF queries separate I'm all ears.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Load tests pass ([15 minute run](https://github.com/publichealthengland/ntbs_Beta/runs/3722333247?check_suite_focus=true))