### PR TITLE
NTBS-2666 Add a PostLogout page

### DIFF
--- a/ntbs-service/Pages/Logout.cshtml.cs
+++ b/ntbs-service/Pages/Logout.cshtml.cs
@@ -12,7 +12,7 @@ namespace ntbs_service.Pages
         private readonly IOptionsMonitor<AzureAdOptions> _azureAdOptions;
         private readonly IOptionsMonitor<AdfsOptions> _adfsOptions;
 
-        private string IndexUrl => $"{Request.Scheme}://{Request.Host}/Index";
+        private string IndexUrl => $"{Request.Scheme}://{Request.Host}/PostLogout";
 
         public LogoutModel(IOptionsMonitor<AdfsOptions> adfsOptions, IOptionsMonitor<AzureAdOptions> azureAdOptions)
         {

--- a/ntbs-service/Pages/PostLogout.cshtml
+++ b/ntbs-service/Pages/PostLogout.cshtml
@@ -1,0 +1,22 @@
+﻿@page
+@model PostLogoutModel
+@{
+    ViewData["Title"] = "You have been logged out";
+}
+
+<!DOCTYPE html>
+
+<html>
+<head>
+    <title>You have been logged out</title>
+</head>
+<body>
+<nhs-width-container container-width="Standard">
+    <h1>You have been logged out</h1>
+
+    <a href="/Index" role="button" draggable="false" class="nhsuk-button ntbsuk-button--primary">
+        Log back in
+    </a>
+</nhs-width-container>
+</body>
+</html>

--- a/ntbs-service/Pages/PostLogout.cshtml.cs
+++ b/ntbs-service/Pages/PostLogout.cshtml.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace ntbs_service.Pages
+{
+    public class PostLogoutModel : PageModel
+    {
+        public void OnGet()
+        {
+
+        }
+    }
+}

--- a/ntbs-service/Pages/Shared/_Header.cshtml
+++ b/ntbs-service/Pages/Shared/_Header.cshtml
@@ -125,26 +125,28 @@
                         </li>
                     }
 
-                    <navigation-with-submenu inline-template>
-                        <li class="nav-with-submenu-header govuk-header__navigation-item header-navigation-link">
-                            <a v-on:click="toggleMenu" href="/ContactDetails/Menu" class="govuk-header__link header-navigation-list-item nav-with-submenu-header-link">
-                                @UserService.GetUserDisplayName(@User) <i class="arrow down"></i>
-                            </a>
-                            <ul ref="navigation-submenu" v-if="showMenu" class="nav-submenu-list">
-                                <li class="header-navigation-link nav-submenu-list-item">
-                                    <a class="govuk-header__link header-navigation-list-item" href="/ContactDetails">
-                                        View personal details
-                                    </a>
-                                </li>
-                                <li class="header-navigation-link nav-submenu-list-item">
-                                    <a class="govuk-header__link header-navigation-list-item" href="/Logout">
-                                        Logout
-                                    </a>
-                                </li>
-                            </ul>
-                        </li>
-                    </navigation-with-submenu>
-
+                    @if (User.Identity != null && User.Identity.IsAuthenticated)
+                    {
+                        <navigation-with-submenu inline-template>
+                            <li class="nav-with-submenu-header govuk-header__navigation-item header-navigation-link">
+                                <a v-on:click="toggleMenu" href="/ContactDetails/Menu" class="govuk-header__link header-navigation-list-item nav-with-submenu-header-link">
+                                    @UserService.GetUserDisplayName(@User) <i class="arrow down"></i>
+                                </a>
+                                <ul ref="navigation-submenu" v-if="showMenu" class="nav-submenu-list">
+                                    <li class="header-navigation-link nav-submenu-list-item">
+                                        <a class="govuk-header__link header-navigation-list-item" href="/ContactDetails">
+                                            View personal details
+                                        </a>
+                                    </li>
+                                    <li class="header-navigation-link nav-submenu-list-item">
+                                        <a class="govuk-header__link header-navigation-list-item" href="/Logout">
+                                            Logout
+                                        </a>
+                                    </li>
+                                </ul>
+                            </li>
+                        </navigation-with-submenu>
+                    }
                 </ul>
             </nav>
 

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -157,6 +157,7 @@ namespace ntbs_service
             {
                 options.Conventions.AllowAnonymousToPage("/Account/AccessDenied");
                 options.Conventions.AllowAnonymousToPage("/Logout");
+                options.Conventions.AllowAnonymousToPage("/PostLogout");
             });
 
             services.AddAuthorization(options =>


### PR DESCRIPTION
## Description
Add a page telling the user the have been logged out, with a button to log back in. This page can be accessed anonymously (by users who have not been authenticated). Before we would redirect to a log in page with a correlation cookie that would time out after 15 minutes, so the user would need to log in twice (with the first causing a warning in Sentry). Now, by redirecting to this post-logout page the user can choose when they get sent to Azure AD with that cookie.

This won't prevent the correlation cookie issue, if the user visits the log in page and leaves it for 15 mins it will still happen, but
now the user needs to do something to visit the login page, instead of getting redirected after timing out.

## Checklist:
- [x] Automated tests are passing locally.
- [ ] No new tests added. I don't think this could easily be tested with unit/integration tests, and although I could write a UI test I'm not sure how valuable it would be.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript (log in flow doesn't really work without JS anyway)
- [x] Test in small window (imitating small screen)
- [x] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [x] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))

## Screenshots
![image](https://user-images.githubusercontent.com/3650110/135098035-d69d55bf-52cf-4eb1-825b-24b1eca22317.png)