### PR TITLE
NTBS-2685: Fix transfer comment regex

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/TreatmentEventMapperTest.cs
@@ -106,7 +106,7 @@ namespace ntbs_service_unit_tests.DataMigration
                 CaseManager = "miles.davis@columbia.nhs.uk",
                 HospitalId = new Guid("B8AA918D-233F-4C41-B9AE-BE8A8DC8BE7B"),
                 TreatmentEventType = "TransferIn",
-                Notes = "Dear Mrs Lucy Carmen-Minoe, \n This patient was moved from XYX hospital in London. This is very important information.\n"
+                Notes = "Dear Mrs Lucy Carmen-Minoe, \n You have been identified as the new case manager for the case below. This patient was moved from XYX hospital in London. This is very important information.\n"
                         + "Id: 134222 \n\n Patient: Harry Swingset  Case report date: 11/11/2009 \n Also they are allergic to mung beans"
             };
 
@@ -120,6 +120,7 @@ namespace ntbs_service_unit_tests.DataMigration
             Assert.Contains("Also they are allergic to mung beans", mappedEvent.Note);
             Assert.DoesNotContain("Id: 134222", mappedEvent.Note);
             Assert.DoesNotContain("Dear Mrs Lucy Carmen-Minoe", mappedEvent.Note);
+            Assert.DoesNotContain("You have been identified as the new case manager for the case below.", mappedEvent.Note);
         }
 
         [Fact]

--- a/ntbs-service/DataMigration/TreatmentEventMapper.cs
+++ b/ntbs-service/DataMigration/TreatmentEventMapper.cs
@@ -92,13 +92,14 @@ namespace ntbs_service.DataMigration
                 @"(Dear|Hi)[0-9a-zA-Z -]+,{0,1}[\n\r ]*(?<caseManagerText>[0-9a-zA-Z \/\-—,.'`@#&+;:$_()<>\\\[\]=\*\?\n\r]*)"
                 + @"(?<uselessInfo>Id: [0-9 ]+[\n\r ]*Patient: [a-zA-Z -]+[\n\r ]*Case report date: [0-9 ]{2}\/[0-9]{2}\/[0-9]{4})"
                 + @"(?<appendedNote>[0-9a-zA-Z \/\-—,.'`@#&+;:$_()<>\\\[\]=\*\?\n\r]*)";
-            var caseManagerPattern = @"You have been identified as the new case manager for the case below\.[\n\r]*";
+            var caseManagerPattern = @"You have been identified as the new case manager for the case below\.[\n\r ]*\z";
             var notePatternMatch = Regex.Match(trimmedNote, mainPattern);
             if (notePatternMatch.Success)
             {
                 var caseManagerText = notePatternMatch.Groups["caseManagerText"].Value;
                 var appendedNote = notePatternMatch.Groups["appendedNote"].Value;
-                var returnNote = Regex.IsMatch(caseManagerText, caseManagerPattern) ? appendedNote.Trim() : $"{caseManagerText.Trim()} {appendedNote.Trim()}";
+                var returnNote = Regex.IsMatch(caseManagerText, caseManagerPattern) ? appendedNote.Trim()
+                    : $"{caseManagerText.Replace("You have been identified as the new case manager for the case below.", "").Trim()} {appendedNote.Trim()}";
                 return returnNote.Length == 0 ? null : returnNote;
             }
             else


### PR DESCRIPTION
## Description
I was helping Nancy find notifications to import to test this and realised that it was only taking the appended part of the comment every time. Turns out that this is because the "You have been identified as the new case manager for the case below." is present pretty much all the time, and the regex wasn't looking to make sure that this was the ONLY text in the string. 
Eg. "You have been identified as the new case manager for the case below. They moved from London, this is important" was counting as a match, and it was moving on.
Now the "They moved from London, this is important" will get picked up, as intended. 

## Checklist:
- [x] Automated tests are passing locally.
