### PR TITLE
NTBS-NONE npm security update revert

### DIFF
--- a/ntbs-service/package-lock.json
+++ b/ntbs-service/package-lock.json
@@ -1373,9 +1373,9 @@
       }
     },
     "axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
+      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
       "requires": {
         "follow-redirects": "^1.14.0"
       }

--- a/ntbs-service/package-lock.json
+++ b/ntbs-service/package-lock.json
@@ -1373,11 +1373,11 @@
       }
     },
     "axios": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.2.tgz",
-      "integrity": "sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.10.0"
       }
     },
     "babel-loader": {
@@ -1860,9 +1860,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.4.tgz",
-      "integrity": "sha512-zwGkiSXC1MUJG/qmeIFH2HBJx9u0V46QGUe3YR1fXG8bXQxq7fLj0RjLZQ5nubr9qNJUZrH+xUcwXEoXNpfS+g=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
     },
     "formdata-polyfill": {
       "version": "4.0.6",

--- a/ntbs-service/package.json
+++ b/ntbs-service/package.json
@@ -21,7 +21,7 @@
     "@sentry/browser": "6.12.0",
     "@sentry/integrations": "6.12.0",
     "accessible-autocomplete": "2.0.3",
-    "axios": "0.21.2",
+    "axios": "0.21.1",
     "babel-loader": "8.2.2",
     "css-vars-ponyfill": "2.4.6",
     "es6-promise": "4.2.8",

--- a/ntbs-service/package.json
+++ b/ntbs-service/package.json
@@ -21,7 +21,7 @@
     "@sentry/browser": "6.12.0",
     "@sentry/integrations": "6.12.0",
     "accessible-autocomplete": "2.0.3",
-    "axios": "0.21.4",
+    "axios": "0.21.2",
     "babel-loader": "8.2.2",
     "css-vars-ponyfill": "2.4.6",
     "es6-promise": "4.2.8",

--- a/ntbs-service/webpack.common.js
+++ b/ntbs-service/webpack.common.js
@@ -23,7 +23,6 @@ module.exports = {
       },
       {
           test: /\.js/,
-          exclude: /node_modules/,
           use: {
               loader: 'babel-loader',
               options: {


### PR DESCRIPTION
## Description
Revert the changes made for the `axios` security patch. The webpack config change made to fix the previous issue broke the menu bar in IE11. Some webpack settings will need tweaking but it's going to be safer to do this next release and with the next round of package updates, when there is more time to test it.

## Checklist:
- [x] Automated tests are passing locally.