### PR TITLE
NTBS-2723 Make authentication and user-sync consistent

### DIFF
--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -363,7 +363,7 @@ namespace ntbs_service
                         var username = context.Principal.Username();
                         if (username == null)
                         {
-                            username = context.Principal.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name");
+                            username = context.Principal.FindFirstValue(ClaimTypes.Email);
                         }
 
                         // add group claims.


### PR DESCRIPTION
## Description
User-sync makes user names using UPNs for internal users and emails
for external users. Authentication used to use "name", a form of
unique name for external users, which often was the email, but is not
for EOTP users. Use email in authentication to make the two consistent.

## Checklist:
- [x] Automated tests are passing locally.
- [ ] Not managed to run UI tests locally because I can't selenium working