### PR TITLE
NTBS-2720 Fix case manager TB service user-sync

### DIFF
--- a/ntbs-service-unit-tests/DataAccess/RepositoryFixture.cs
+++ b/ntbs-service-unit-tests/DataAccess/RepositoryFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.DataAccess;
+using ntbs_service.Models.ReferenceEntities;
 using Xunit;
 
 namespace ntbs_service_unit_tests.DataAccess
@@ -9,14 +10,15 @@ namespace ntbs_service_unit_tests.DataAccess
     public class RepositoryFixture<T> : IAsyncLifetime
     {
         public NtbsContext Context;
+        public DbContextOptions<NtbsContext> ContextOptions;
 
         public async Task InitializeAsync()
         {
-            var contextOptions = new DbContextOptionsBuilder<NtbsContext>()
+            ContextOptions = new DbContextOptionsBuilder<NtbsContext>()
                 .UseSqlite($"Filename={typeof(T)}.db")
                 .Options;
 
-            Context = new NtbsContext(contextOptions);
+            Context = new NtbsContext(ContextOptions);
             await Context.Database.EnsureDeletedAsync();
             await Context.Database.EnsureCreatedAsync();
         }

--- a/ntbs-service-unit-tests/DataAccess/UserRepositoryTests.cs
+++ b/ntbs-service-unit-tests/DataAccess/UserRepositoryTests.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using ntbs_service.DataAccess;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.ReferenceEntities;
+using ntbs_service.Properties;
+using ntbs_service_unit_tests.TestHelpers;
+using Xunit;
+
+namespace ntbs_service_unit_tests.DataAccess
+{
+    public class UserRepositoryTests : IClassFixture<RepositoryFixture<UserRepository>>, IDisposable
+    {
+        private readonly NtbsContext _context;
+        private readonly DbContextOptions<NtbsContext> _contextOptions;
+        private readonly UserRepository _userRepo;
+        private readonly TBService _tbService1;
+        private readonly TBService _tbService2;
+
+        public UserRepositoryTests(RepositoryFixture<UserRepository> userRepositoryFixture)
+        {
+            ContextHelper.DisableAudits();
+            _context = userRepositoryFixture.Context;
+            _contextOptions = userRepositoryFixture.ContextOptions;
+
+            var optionsMonitor = new Mock<IOptionsMonitor<AdOptions>>();
+            optionsMonitor.Setup(om => om.CurrentValue).Returns(new AdOptions { ReadOnlyUserGroup = "ReadOnly" });
+            _userRepo = new UserRepository(_context, optionsMonitor.Object);
+
+            var phec = new PHEC { Code = "E45000001", Name = "London" };
+            _tbService1 = new TBService { Code = "TBS0001", IsLegacy = false, PHECCode = "E45000001" };
+            _tbService2 = new TBService { Code = "TBS0002", IsLegacy = false, PHECCode = "E45000001" };
+            _context.PHEC.Add(phec);
+            _context.TbService.AddRange(_tbService1, _tbService2);
+            _context.SaveChanges();
+        }
+
+        [Fact]
+        public async Task AddOrUpdateData_AddsCaseManagerTbService_ToExistingUser()
+        {
+            // Arrange
+            await AddUserAndTbServices(CreateUser("user1"), null);
+
+            var updateUser = CreateUser("user1");
+            updateUser.IsCaseManager = true;
+            var updateTbServices = new[] { _tbService1 };
+
+            // Act
+            await _userRepo.AddOrUpdateUser(updateUser, updateTbServices);
+
+            // Assert
+            var updatedUser = GetUserUsingNewContext("user1");
+            Assert.NotNull(updatedUser);
+            Assert.True(updatedUser.IsCaseManager);
+            Assert.Collection(updatedUser.CaseManagerTbServices,
+                cmtbs => Assert.Equal(_tbService1.Code, cmtbs.TbService.Code));
+        }
+
+        [Fact]
+        public async Task AddOrUpdateData_AddsAnotherCaseManagerTbService_ToExistingUser()
+        {
+            // Arrange
+            const string username = "user2";
+            await AddUserAndTbServices(CreateUser(username), new[] { _tbService1 });
+
+            var updateUser = CreateUser(username);
+            updateUser.IsCaseManager = true;
+            var updateTbServices = new[] { _tbService1, _tbService2 };
+
+            // Act
+            await _userRepo.AddOrUpdateUser(updateUser, updateTbServices);
+
+            // Assert
+            var updatedUser = GetUserUsingNewContext(username);
+            Assert.NotNull(updatedUser);
+            Assert.True(updatedUser.IsCaseManager);
+            Assert.Equal(2, updatedUser.CaseManagerTbServices.Count);
+            Assert.Contains(updatedUser.CaseManagerTbServices, cmtbs => _tbService1.Code == cmtbs.TbService.Code);
+            Assert.Contains(updatedUser.CaseManagerTbServices, cmtbs => _tbService2.Code == cmtbs.TbService.Code);
+        }
+
+        [Fact]
+        public async Task AddOrUpdateData_RemovesOnlyCaseManagerTbService_FromExistingUser()
+        {
+            // Arrange
+            const string username = "user3";
+            await AddUserAndTbServices(CreateUser(username), new[] { _tbService1 });
+
+            var updateUser = CreateUser(username);
+            updateUser.IsCaseManager = false;
+            var updateTbServices = Enumerable.Empty<TBService>();
+
+            // Act
+            await _userRepo.AddOrUpdateUser(updateUser, updateTbServices);
+
+            // Assert
+            var updatedUser = GetUserUsingNewContext(username);
+            Assert.NotNull(updatedUser);
+            Assert.False(updatedUser.IsCaseManager);
+            Assert.Empty(updatedUser.CaseManagerTbServices);
+        }
+
+        [Fact]
+        public async Task AddOrUpdateData_RemovesSingleCaseManagerTbService_FromExistingUser()
+        {
+            // Arrange
+            const string username = "user4";
+            await AddUserAndTbServices(CreateUser(username), new[] { _tbService1, _tbService2 });
+
+            var updateUser = CreateUser(username);
+            updateUser.IsCaseManager = true;
+            var updateTbServices = new[] { _tbService1 };
+
+            // Act
+            await _userRepo.AddOrUpdateUser(updateUser, updateTbServices);
+
+            // Assert
+            var updatedUser = GetUserUsingNewContext(username);
+            Assert.NotNull(updatedUser);
+            Assert.True(updatedUser.IsCaseManager);
+            Assert.Collection(updatedUser.CaseManagerTbServices,
+                cmtbs => Assert.Equal(_tbService1.Code, cmtbs.TbService.Code));
+        }
+
+        private User GetUserUsingNewContext(string username)
+        {
+            using (var newContext = new NtbsContext(_contextOptions))
+            {
+                var updatedUser = newContext.User
+                    .Include(u => u.CaseManagerTbServices)
+                    .ThenInclude(cmtbs => cmtbs.TbService)
+                    .FirstOrDefault(u => u.Username == username);
+                return updatedUser;
+            }
+        }
+
+        private static User CreateUser(string username) => new User {
+            Username = username,
+            IsActive = true,
+            IsReadOnly = false
+        };
+
+        private async Task AddUserAndTbServices(User user, IList<TBService> tbServices)
+        {
+            user.IsCaseManager = tbServices?.Any() ?? false;
+            user.CaseManagerTbServices =
+                tbServices?
+                    .Select(tbs => new CaseManagerTbService { TbService = tbs, CaseManager = user })
+                    .ToList();
+
+            _context.User.Add(user);
+            await _context.SaveChangesAsync();
+        }
+
+        public void Dispose()
+        {
+            _context.TbService.RemoveRange(_context.TbService);
+            _context.PHEC.RemoveRange(_context.PHEC);
+            _context.User.RemoveRange(_context.User);
+            _context.SaveChanges();
+        }
+    }
+}

--- a/ntbs-service/DataAccess/UserRepository.cs
+++ b/ntbs-service/DataAccess/UserRepository.cs
@@ -148,7 +148,7 @@ namespace ntbs_service.DataAccess
             await _context.SaveChangesAsync();
         }
 
-        private static void SyncCaseManagerTbServices(User user, IEnumerable<TBService> tbServices)
+        private void SyncCaseManagerTbServices(User user, IEnumerable<TBService> tbServices)
         {
             var caseManagerTbServices = tbServices
                 .Select(tb => new CaseManagerTbService
@@ -176,21 +176,16 @@ namespace ntbs_service.DataAccess
             }
         }
 
-        private static void RemoveUnmatchedCaseManagerTbServices(
+        private void RemoveUnmatchedCaseManagerTbServices(
             ICollection<CaseManagerTbService> userCaseManagerTbServices,
             IList<CaseManagerTbService> adCaseManagerTbServices)
         {
-            var caseManagerTbServicesToRemove = new List<CaseManagerTbService>();
             foreach (var caseManagerTbService in userCaseManagerTbServices)
             {
                 if (!adCaseManagerTbServices.Any(c => caseManagerTbService.Equals(c)))
                 {
-                    caseManagerTbServicesToRemove.Add(caseManagerTbService);
+                    _context.Remove(caseManagerTbService);
                 }
-            }
-            foreach (var caseManagerTbService in caseManagerTbServicesToRemove)
-            {
-                userCaseManagerTbServices.Remove(caseManagerTbService);
             }
         }
     }


### PR DESCRIPTION
## Description
Change the way we delete CaseManagerTbService relations in EF, so that the changes actually get saved.

Add some unit tests for this.

## Checklist:
- [x] Automated tests are passing locally.