### PR TITLE
NTBS-2709: Use notification date instead of creation date in logic

### DIFF
--- a/ntbs-service/Models/Entities/Alerts/DataQualityChildECMLevel.cs
+++ b/ntbs-service/Models/Entities/Alerts/DataQualityChildECMLevel.cs
@@ -12,7 +12,7 @@ namespace ntbs_service.Models.Entities.Alerts
 
         public static readonly Expression<Func<Notification, bool>> NotificationQualifiesExpression =
             n => n.NotificationStatus == NotificationStatus.Notified
-                 && n.CreationDate < DateTime.Now.AddDays(-MinNumberDaysDraftForAlert)
+                 && n.NotificationDate < DateTime.Now.AddDays(-MinNumberDaysDraftForAlert)
                  && n.NotificationDate.Value < n.PatientDetails.Dob.Value.AddYears(16)
                  && n.ClinicalDetails.EnhancedCaseManagementLevel == 0;
 


### PR DESCRIPTION
Accidentally using creation date instead of notification date. 

## Checklist:
- [x] Automated tests are passing locally.
