### PR TITLE
NTBS-2709: Auto-dismiss ECM alerts when details updated

### DIFF
--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -85,6 +85,7 @@ namespace ntbs_service.Services
 
             await _notificationRepository.SaveChangesAsync();
             await _alertService.AutoDismissAlertAsync<DataQualityBirthCountryAlert>(notification);
+            await _alertService.AutoDismissAlertAsync<DataQualityChildECMLevel>(notification);
         }
 
         public void UpdatePatientDetailsWithoutSave(Notification notification, PatientDetails patient)
@@ -152,6 +153,7 @@ namespace ntbs_service.Services
 
             await _alertService.AutoDismissAlertAsync<DataQualityClinicalDatesAlert>(notification);
             await _alertService.AutoDismissAlertAsync<DataQualityDotVotAlert>(notification);
+            await _alertService.AutoDismissAlertAsync<DataQualityChildECMLevel>(notification);
         }
 
         public async Task UpdateTestDataAsync(Notification notification, TestData testData)


### PR DESCRIPTION
## Description
Now auto-dismiss the child ECM alert if the change has meant the alert should no longer exist. Found a DQ alerts bug while testing this, details in slack - haven't made a ticket for it yet.

## Checklist:
- [x] Automated tests are passing locally.
