### PR TITLE
NTBS-2752 Attempt to remove span warnings from pod output

### DIFF
--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using ntbs_service.DataAccess;
 using ntbs_service.Models;
+using Sentry;
 using Serilog;
 using Serilog.Events;
 
@@ -65,7 +66,13 @@ namespace ntbs_service
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
-                .UseSentry(o => o.Release = Environment.GetEnvironmentVariable(Constants.Release))
+                .UseSentry(o =>
+                {
+                    o.Release = Environment.GetEnvironmentVariable(Constants.Release);
+                    // This is a workaround for a known issue in Sentry.
+                    // See https://github.com/getsentry/sentry-dotnet/issues/1210
+                    o.DisableDiagnosticSourceIntegration();
+                })
                 .UseSerilog();
 
         private static void MigrateAppDb(IServiceProvider services)


### PR DESCRIPTION
Disable diagnostic source integration in sentry, as it was producing lots of spurious warnings.

We're not using this feature (since we're only using sentry for errors/warnings, and not performance monitoring) so turning it off should do no harm.

I've deployed this to `test` and observed the lack of warnings in the pod logs :-)