### PR TITLE
NTBS-2768: No longer use includes in duplicate component

### DIFF
--- a/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
+++ b/ntbs-service/wwwroot/source/Components/NhsNumberDuplicateWarning.ts
@@ -46,7 +46,7 @@ const NhsNumberDuplicateWarning = Vue.extend({
                         // New lines required to match output from .cshtml
                         warningContainer.appendChild(document.createTextNode("\r\n,\r\n"));
                     }
-                    if (url.includes("Legacy")) {
+                    if (url.indexOf("Legacy") > -1) {
                         warningContainer.appendChild(this.createAnchorLegacyTag(id, url));
                     }
                     else {


### PR DESCRIPTION
## Description
Includes does not work in IE - oops! 
Tested and working in IE again.

## Checklist:
- [x] Automated tests are passing locally.
