### PR TITLE
NTBS-2837 Do not create unmatched lab result alerts if duplicates exist

### DIFF
--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -12,6 +12,8 @@ namespace ntbs_service.DataAccess
     {
         Task<Alert> GetOpenAlertByIdAsync(int? alertId);
         Task<T> GetAlertByNotificationIdAndTypeAsync<T>(int notificationId) where T : Alert;
+        Task<UnmatchedLabResultAlert> GetUnmatchedLabResultAlertForNotificationAndSpecimenAsync(int notificationId,
+            string specimenId);
         Task<T> GetOpenAlertByNotificationId<T>(int notificationId) where T : Alert;
         Task<List<Alert>> GetAllOpenAlertsByNotificationId(int notificationId);
         Task<TransferAlert> GetOpenTransferAlertByNotificationId(int notificationId);
@@ -51,6 +53,15 @@ namespace ntbs_service.DataAccess
             return await _context.Alert
                 .OfType<T>()
                 .SingleOrDefaultAsync(m => m.NotificationId == notificationId);
+        }
+
+        public async Task<UnmatchedLabResultAlert> GetUnmatchedLabResultAlertForNotificationAndSpecimenAsync(
+            int notificationId,
+            string specimenId)
+        {
+            return await _context.Alert
+                .OfType<UnmatchedLabResultAlert>()
+                .SingleOrDefaultAsync(a => a.NotificationId == notificationId && a.SpecimenId == specimenId);
         }
 
         public async Task<T> GetOpenAlertByNotificationId<T>(int notificationId) where T : Alert


### PR DESCRIPTION
## Description
The unmatched lab result alert job was only checking for existing open alerts when determining whether a new alert needs to be created. Consequently, if an alert was manually closed, it was just being recreated on the next run. Here we fix this bug.

## Checklist:
- [x] Automated tests are passing locally.
