### PR TITLE
NTBS-2796 Do not show error on test results page for invalid manual test

### DIFF
--- a/ntbs-service/Models/Entities/TestData.cs
+++ b/ntbs-service/Models/Entities/TestData.cs
@@ -16,7 +16,7 @@ namespace ntbs_service.Models.Entities
     {
         public int NotificationId { get; set; }
 
-        [Display(Name = "Has a TB test been carried out")]
+        [Display(Name = "Has a TB test been carried out?")]
         [RequiredIf(nameof(ShouldValidateFull), ErrorMessage = ValidationMessages.Mandatory)]
         [AssertThat(nameof(ResultAddedIfTestCarriedOut), ErrorMessage = ValidationMessages.NoTestResult)]
         public bool? HasTestCarriedOut { get; set; }

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TestResultsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TestResultsOverviewPartial.cshtml
@@ -103,7 +103,7 @@
 
     <nhs-grid-row>
         <nhs-grid-column grid-column-width="OneQuarter">
-            <div class="notification-details-label"> @Html.DisplayNameFor(m => m.Notification.TestData.HasTestCarriedOut)? </div>
+            <div class="notification-details-label"> @Html.DisplayNameFor(m => m.Notification.TestData.HasTestCarriedOut) </div>
             <div class="cell-min-height" id="@sectionId-test-carried-out"> @testData.HasTestCarriedOut.FormatYesNo() </div>
         </nhs-grid-column>
     </nhs-grid-row>


### PR DESCRIPTION
## Description
We validate manual test results on the edit manual test result page. This page makes it impossible to add new invalid test results, or to edit existing invalid results without correcting them.

On the test results page, when the user presses Save, the manual test results were being validated again, leading to the save failing and an error being shown. This fix is to bypass this validation, so that only the "Has a TB test been carried out?" question is validated when saving that page.

## Checklist:
- [x] Automated tests are passing locally.
