### PR TITLE
NTBS-2843 Show legacy case manager names on alerts on dashboard

### DIFF
--- a/ntbs-service-unit-tests/DataAccess/AlertRepositoryTests.cs
+++ b/ntbs-service-unit-tests/DataAccess/AlertRepositoryTests.cs
@@ -65,7 +65,7 @@ namespace ntbs_service_unit_tests.DataAccess
 
         [Theory]
         [InlineData(true, true, "Pharoah Sanders")]
-        [InlineData(true, false, null)]
+        [InlineData(true, false, "Pharoah Sanders")]
         [InlineData(false, false, null)]
         public async void CorrectlyMapsUserOnNonTransferAlertToDisplayAlert
             (bool hasCaseManager, bool caseManagerIsActive, string expectedCaseManagerName)

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -153,8 +153,7 @@ namespace ntbs_service.DataAccess
                             : alert.Notification.HospitalDetails.TBService.Name,
                         CaseManagerName = alert is TransferAlert
                             ? ((TransferAlert)alert).CaseManager.DisplayName
-                            : alert.Notification.HospitalDetails.CaseManager.IsActive
-                                ? alert.Notification.HospitalDetails.CaseManager.DisplayName : null,
+                            : alert.Notification.HospitalDetails.CaseManager.DisplayName,
                         AlertType = alert.AlertType,
                         Action = alert.Action,
                         ActionLink = alert.ActionLink,


### PR DESCRIPTION
## Description
Display the names of legacy case managers on all alerts with a case manager

## Checklist:
- [x] Automated tests are passing locally.
