### PR TITLE
NTBS-2839: Move MDR fields

### DIFF
--- a/ntbs-integration-tests/NotificationPages/MDRDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/MDRDetailsPageTests.cs
@@ -65,6 +65,30 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
+        public async Task Post_ReturnsPageWithErrors_IfNoDateSubmitted()
+        {
+            // Arrange
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
+                ["MDRDetails.ExposureToKnownCaseStatus"] = "Yes",
+                ["MDRDetails.CountryId"] = "1",
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(initialDocument, formData, url);
+
+            // Assert
+            var resultDocument = await GetDocumentAsync(result);
+
+            result.EnsureSuccessStatusCode();
+            resultDocument.AssertErrorSummaryMessage("MDRDetails-MDRTreatmentStartDate", "mdr-treatment-date", "MDR treatment start date is a mandatory field");
+        }
+
+        [Fact]
         public async Task Post_RedirectsToNextPageAndSavesContent_IfModelValid()
         {
             // Arrange
@@ -75,6 +99,10 @@ namespace ntbs_integration_tests.NotificationPages
             var formData = new Dictionary<string, string>
             {
                 ["NotificationId"] = id.ToString(),
+                ["FormattedMdrTreatmentDate.Day"] = "02",
+                ["FormattedMdrTreatmentDate.Month"] = "03",
+                ["FormattedMdrTreatmentDate.Year"] = "2021",
+                ["MDRDetails.ExpectedTreatmentDurationInMonths"] = "23-24",
                 ["MDRDetails.ExposureToKnownCaseStatus"] = "Yes",
                 ["MDRDetails.RelationshipToCase"] = "Cousins",
                 ["MDRDetails.NotifiedToPheStatus"] = "Yes",
@@ -93,6 +121,10 @@ namespace ntbs_integration_tests.NotificationPages
             reloadedDocument.AssertInputRadioValue("exposure-yes", true);
             reloadedDocument.AssertInputTextValue("MDRDetails_RelationshipToCase", "Cousins");
             reloadedDocument.AssertInputTextValue("MDRDetails_RelatedNotificationId", $"{Utilities.NOTIFIED_ID}");
+            reloadedDocument.AssertInputTextValue("FormattedMdrTreatmentDate_Day", "2");
+            reloadedDocument.AssertInputTextValue("FormattedMdrTreatmentDate_Month", "3");
+            reloadedDocument.AssertInputTextValue("FormattedMdrTreatmentDate_Year", "2021");
+            reloadedDocument.AssertInputTextValue("MDRDetails_ExpectedTreatmentDurationInMonths", "23-24");
         }
 
         [Fact]
@@ -106,6 +138,9 @@ namespace ntbs_integration_tests.NotificationPages
             var formData = new Dictionary<string, string>
             {
                 ["NotificationId"] = id.ToString(),
+                ["FormattedMdrTreatmentDate.Day"] = "02",
+                ["FormattedMdrTreatmentDate.Month"] = "03",
+                ["FormattedMdrTreatmentDate.Year"] = "2021",
                 ["MDRDetails.ExposureToKnownCaseStatus"] = "Unknown",
                 ["MDRDetails.RelationshipToCase"] = "Cousins",
                 ["MDRDetails.NotifiedToPheStatus"] = "Unknown",
@@ -139,6 +174,9 @@ namespace ntbs_integration_tests.NotificationPages
             var formData = new Dictionary<string, string>
             {
                 ["NotificationId"] = id.ToString(),
+                ["FormattedMdrTreatmentDate.Day"] = "02",
+                ["FormattedMdrTreatmentDate.Month"] = "03",
+                ["FormattedMdrTreatmentDate.Year"] = "2021",
                 ["MDRDetails.ExposureToKnownCaseStatus"] = "Yes",
                 ["MDRDetails.RelationshipToCase"] = "Cousins",
                 ["MDRDetails.NotifiedToPheStatus"] = "No",
@@ -159,6 +197,9 @@ namespace ntbs_integration_tests.NotificationPages
             reloadedDocument.AssertInputRadioValue("notified-no", false);
             reloadedDocument.AssertInputTextValue("MDRDetails_RelatedNotificationId", "");
             reloadedDocument.AssertInputSelectValue("MDRDetails_CountryId", "1");
+            reloadedDocument.AssertInputTextValue("FormattedMdrTreatmentDate_Day", "2");
+            reloadedDocument.AssertInputTextValue("FormattedMdrTreatmentDate_Month", "3");
+            reloadedDocument.AssertInputTextValue("FormattedMdrTreatmentDate_Year", "2021");
         }
 
         [Fact]
@@ -172,6 +213,9 @@ namespace ntbs_integration_tests.NotificationPages
             var formData = new Dictionary<string, string>
             {
                 ["NotificationId"] = id.ToString(),
+                ["FormattedMdrTreatmentDate.Day"] = "02",
+                ["FormattedMdrTreatmentDate.Month"] = "03",
+                ["FormattedMdrTreatmentDate.Year"] = "2021",
                 ["MDRDetails.ExposureToKnownCaseStatus"] = "Yes",
                 ["MDRDetails.RelationshipToCase"] = "Cousins",
                 ["MDRDetails.NotifiedToPheStatus"] = "No",

--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -146,7 +146,6 @@ namespace ntbs_service_unit_tests.DataMigration
             Assert.Equal(Status.Yes, notification.ClinicalDetails.HomeVisitCarriedOut);
             Assert.Equal(new DateTime(2015, 03, 25, 00, 00, 00), notification.ClinicalDetails.FirstHomeVisitDate);
             Assert.Equal("Patient did not begin course of treatment under DOT", notification.ClinicalDetails.Notes);
-            Assert.Equal("12-13", notification.ClinicalDetails.MDRExpectedTreatmentDurationInMonths);
             Assert.Equal("TestRefX019", notification.ClinicalDetails.HealthProtectionTeamReferenceNumber);
 
             Assert.Equal(Status.Yes, notification.ImmunosuppressionDetails.Status);
@@ -167,6 +166,8 @@ namespace ntbs_service_unit_tests.DataMigration
             Assert.False(notification.SocialRiskFactors.RiskFactorImprisonment.IsCurrent);
             Assert.True(notification.SocialRiskFactors.RiskFactorImprisonment.InPastFiveYears);
             Assert.False(notification.SocialRiskFactors.RiskFactorImprisonment.MoreThanFiveYearsAgo);
+
+            Assert.Equal("12-13", notification.MDRDetails.ExpectedTreatmentDurationInMonths);
 
             Assert.Equal(2, notification.TravelDetails.TotalNumberOfCountries);
             Assert.Equal(Status.Yes, notification.TravelDetails.HasTravel);

--- a/ntbs-service-unit-tests/Models/Entities/ClinicalDetailsTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/ClinicalDetailsTest.cs
@@ -49,34 +49,5 @@ namespace ntbs_service_unit_tests.Models.Entities
             // Assert
             Assert.Equal("Yes - 2000", stateAndYear);
         }
-
-        [Theory]
-        [InlineData(null, 2019, 1, 1, "RR/MDR/XDR treatment - from 01 Jan 2019")]
-        [InlineData("12-13", 2019, 1, 1, "RR/MDR/XDR treatment - from 01 Jan 2019 for 12-13 months (expected)")]
-        [InlineData(null, null, null, null, "RR/MDR/XDR treatment")]
-        public void CreatesMdrTreatmentStringCorrectly(string duration, int? year, int? month, int? day, string expectedResult)
-        {
-
-            // Arrange
-            var clinicalDetails = new ClinicalDetails();
-            if (year != null && month != null && day != null)
-            {
-                var dateTime = new DateTime((int)year, (int)month, (int)day);
-                clinicalDetails.MDRTreatmentStartDate = dateTime;
-            }
-
-            if (duration != null)
-            {
-                clinicalDetails.MDRExpectedTreatmentDurationInMonths = duration;
-            }
-
-            clinicalDetails.TreatmentRegimen = TreatmentRegimen.MdrTreatment;
-
-            // Act
-            var stateAndDate = clinicalDetails.FormattedTreatmentRegimen;
-
-            // Assert
-            Assert.Equal(expectedResult, stateAndDate);
-        }
     }
 }

--- a/ntbs-service/DataMigration/NotificationMapper.cs
+++ b/ntbs-service/DataMigration/NotificationMapper.cs
@@ -494,8 +494,6 @@ namespace ntbs_service.DataMigration
                 DiagnosisDate = notification.DiagnosisDate ?? notification.StartOfTreatmentDate ?? notification.NotificationDate,
                 StartedTreatment = !Converter.GetNullableBoolValue(notification.DidNotStartTreatment),
                 TreatmentStartDate = notification.StartOfTreatmentDate,
-                MDRTreatmentStartDate = notification.MDRTreatmentStartDate,
-                MDRExpectedTreatmentDurationInMonths = notification.MDRExpectedDuration,
                 IsSymptomatic = Converter.GetNullableBoolValue(notification.IsSymptomatic),
                 HomeVisitCarriedOut = Converter.GetStatusFromString(notification.HomeVisitCarriedOut),
                 FirstHomeVisitDate = notification.FirstHomeVisitDate,
@@ -873,6 +871,8 @@ namespace ntbs_service.DataMigration
         {
             var mdr = new MDRDetails
             {
+                MDRTreatmentStartDate = rawNotification.MDRTreatmentStartDate,
+                ExpectedTreatmentDurationInMonths = rawNotification.MDRExpectedDuration,
                 ExposureToKnownCaseStatus = Converter.GetStatusFromString(rawNotification.mdr_ExposureToKnownTbCase),
                 RelationshipToCase = rawNotification.mdr_RelationshipToCase,
                 // Notification.mdr_CaseInUKStatus is not used, as in NTBS it's calculated on the fly

--- a/ntbs-service/Migrations/20211104164435_MoveMDRFieldsToMDRModel.Designer.cs
+++ b/ntbs-service/Migrations/20211104164435_MoveMDRFieldsToMDRModel.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20211104164435_MoveMDRFieldsToMDRModel")]
+    partial class MoveMDRFieldsToMDRModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -5186,10 +5188,6 @@ namespace ntbs_service.Migrations
                             b1.Property<string>("HIVTestState")
                                 .HasMaxLength(30)
                                 .HasColumnType("nvarchar(30)");
-
-                            b1.Property<string>("HealthProtectionTeamReferenceNumber")
-                                .HasMaxLength(40)
-                                .HasColumnType("nvarchar(40)");
 
                             b1.Property<string>("HealthcareDescription")
                                 .HasMaxLength(100)

--- a/ntbs-service/Migrations/20211104164435_MoveMDRFieldsToMDRModel.cs
+++ b/ntbs-service/Migrations/20211104164435_MoveMDRFieldsToMDRModel.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class MoveMDRFieldsToMDRModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExpectedTreatmentDurationInMonths",
+                table: "MDRDetails",
+                type: "nvarchar(10)",
+                maxLength: 10,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "MDRTreatmentStartDate",
+                table: "MDRDetails",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.DropColumn(
+                name: "MDRExpectedTreatmentDurationInMonths",
+                table: "ClinicalDetails");
+
+            migrationBuilder.DropColumn(
+                name: "MDRTreatmentStartDate",
+                table: "ClinicalDetails");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExpectedTreatmentDurationInMonths",
+                table: "MDRDetails");
+
+            migrationBuilder.DropColumn(
+                name: "MDRTreatmentStartDate",
+                table: "MDRDetails");
+
+            migrationBuilder.AddColumn<string>(
+                name: "MDRExpectedTreatmentDurationInMonths",
+                table: "ClinicalDetails",
+                type: "nvarchar(10)",
+                maxLength: 10,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "MDRTreatmentStartDate",
+                table: "ClinicalDetails",
+                type: "datetime2",
+                nullable: true);
+        }
+    }
+}

--- a/ntbs-service/Migrations/20211104164435_MoveMDRFieldsToMDRModel.cs
+++ b/ntbs-service/Migrations/20211104164435_MoveMDRFieldsToMDRModel.cs
@@ -20,6 +20,12 @@ namespace ntbs_service.Migrations
                 type: "datetime2",
                 nullable: true);
 
+            migrationBuilder.Sql(
+                @"UPDATE MDRDetails SET ExpectedTreatmentDurationInMonths = cd.MDRExpectedTreatmentDurationInMonths,
+                    MDRTreatmentStartDate = cd.MDRTreatmentStartDate
+                FROM ClinicalDetails cd
+                WHERE cd.NotificationId = MDRDetails.NotificationId");
+
             migrationBuilder.DropColumn(
                 name: "MDRExpectedTreatmentDurationInMonths",
                 table: "ClinicalDetails");
@@ -31,13 +37,6 @@ namespace ntbs_service.Migrations
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "ExpectedTreatmentDurationInMonths",
-                table: "MDRDetails");
-
-            migrationBuilder.DropColumn(
-                name: "MDRTreatmentStartDate",
-                table: "MDRDetails");
 
             migrationBuilder.AddColumn<string>(
                 name: "MDRExpectedTreatmentDurationInMonths",
@@ -51,6 +50,20 @@ namespace ntbs_service.Migrations
                 table: "ClinicalDetails",
                 type: "datetime2",
                 nullable: true);
+
+            migrationBuilder.Sql(
+                @"UPDATE ClinicalDetails SET MDRExpectedTreatmentDurationInMonths = mdr.ExpectedTreatmentDurationInMonths,
+                    MDRTreatmentStartDate = mdr.MDRTreatmentStartDate
+                FROM MDRDetails mdr
+                WHERE mdr.NotificationId = ClinicalDetails.NotificationId");
+
+            migrationBuilder.DropColumn(
+                name: "ExpectedTreatmentDurationInMonths",
+                table: "MDRDetails");
+
+            migrationBuilder.DropColumn(
+                name: "MDRTreatmentStartDate",
+                table: "MDRDetails");
         }
     }
 }

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -67,21 +67,6 @@ namespace ntbs_service.Models.Entities
         public TreatmentRegimen? TreatmentRegimen { get; set; }
         public bool IsMDRTreatment => TreatmentRegimen == Enums.TreatmentRegimen.MdrTreatment;
 
-        [Display(Name = "RR/MDR/XDR treatment date")]
-        // This use of the DatesHaveBeenSet property is a bit hacky - we want to make sure that the property is
-        // only "required" after it has been set (from the formatted date). If we don't do this, then an error
-        // will be produced when the form data is initially validated by the framework, whether or not a valid
-        // date has actually been provided.
-        [RequiredIf(@"DatesHaveBeenSet && IsMDRTreatment && IsLegacy != true", ErrorMessage = ValidationMessages.FieldRequired)]
-        [AssertThat(@"AfterDob(MDRTreatmentStartDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
-        [ValidClinicalDate]
-        public DateTime? MDRTreatmentStartDate { get; set; }
-
-        [MaxLength(10)]
-        [ValidDuration]
-        [Display(Name = "Expected treatment duration")]
-        public string MDRExpectedTreatmentDurationInMonths { get; set; }
-
         [MaxLength(100)]
         [Display(Name = "Treatment regimen other description")]
         [RegularExpression(ValidationRegexes.CharacterValidation, ErrorMessage = ValidationMessages.StandardStringFormat)]

--- a/ntbs-service/Models/Entities/ClinicalDetailsDisplay.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetailsDisplay.cs
@@ -21,9 +21,6 @@ namespace ntbs_service.Models.Entities
         public string DaysFromDiagnosisToTreatment => FormatNullableDateDifference(TreatmentStartDate, DiagnosisDate);
         public string BCGVaccinationStateAndYear => FormatStateAndYear(BCGVaccinationState, BCGVaccinationYear);
 
-        [NotMapped]
-        public bool DatesHaveBeenSet { get; set; }
-
         private string GetFormattedTreatmentRegimen()
         {
             if (TreatmentRegimen == null)
@@ -33,17 +30,6 @@ namespace ntbs_service.Models.Entities
 
             switch (TreatmentRegimen)
             {
-                case Enums.TreatmentRegimen.MdrTreatment:
-                    var displayString = TreatmentRegimen.GetDisplayName();
-                    if (MDRTreatmentStartDate != null)
-                    {
-                        displayString += $" - from {MDRTreatmentStartDate.ConvertToString()}";
-                    }
-                    if (MDRExpectedTreatmentDurationInMonths != null)
-                    {
-                        displayString += $" for {MDRExpectedTreatmentDurationInMonths} months (expected)";
-                    }
-                    return displayString;
                 case Enums.TreatmentRegimen.Other:
                     return TreatmentRegimenOtherDescription == null
                         ? TreatmentRegimen.GetDisplayName()

--- a/ntbs-service/Models/Entities/MDRDetails.cs
+++ b/ntbs-service/Models/Entities/MDRDetails.cs
@@ -18,7 +18,7 @@ namespace ntbs_service.Models.Entities
         public TreatmentRegimen? Treatment { get; set; }
         public bool IsMDRTreatment => Treatment == Enums.TreatmentRegimen.MdrTreatment;
         
-        [Display(Name = "RR/MDR/XDR treatment date")]
+        [Display(Name = "MDR treatment start date")]
         // This use of the DatesHaveBeenSet property is a bit hacky - we want to make sure that the property is
         // only "required" after it has been set (from the formatted date). If we don't do this, then an error
         // will be produced when the form data is initially validated by the framework, whether or not a valid

--- a/ntbs-service/Models/Entities/MDRDetails.cs
+++ b/ntbs-service/Models/Entities/MDRDetails.cs
@@ -14,16 +14,12 @@ namespace ntbs_service.Models.Entities
     [Display(Name = "MDR details")]
     public partial class MDRDetails : ModelBase, IOwnedEntityForAuditing
     {
-        [NotMapped]
-        public TreatmentRegimen? Treatment { get; set; }
-        public bool IsMDRTreatment => Treatment == Enums.TreatmentRegimen.MdrTreatment;
-        
         [Display(Name = "MDR treatment start date")]
         // This use of the DatesHaveBeenSet property is a bit hacky - we want to make sure that the property is
         // only "required" after it has been set (from the formatted date). If we don't do this, then an error
         // will be produced when the form data is initially validated by the framework, whether or not a valid
         // date has actually been provided.
-        [RequiredIf(@"DatesHaveBeenSet && IsMDRTreatment && IsLegacy != true", ErrorMessage = ValidationMessages.FieldRequired)]
+        [RequiredIf(@"DatesHaveBeenSet && IsLegacy != true", ErrorMessage = ValidationMessages.FieldRequired)]
         [AssertThat(@"AfterDob(MDRTreatmentStartDate)", ErrorMessage = ValidationMessages.DateShouldBeLaterThanDob)]
         [ValidClinicalDate]
         public DateTime? MDRTreatmentStartDate { get; set; }

--- a/ntbs-service/Models/Entities/MDRDetailsDisplay.cs
+++ b/ntbs-service/Models/Entities/MDRDetailsDisplay.cs
@@ -1,7 +1,17 @@
-﻿namespace ntbs_service.Models.Entities
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using ntbs_service.Helpers;
+
+namespace ntbs_service.Models.Entities
 {
     public partial class MDRDetails
     {
         public string MDRCaseCountryName => Country?.Name;
+
+        [NotMapped]
+        public bool DatesHaveBeenSet { get; set; }
+
+        public string FormattedTreatmentStartDate => MDRTreatmentStartDate.ConvertToString();
+
+        public string FormattedExpectedDuration => ExpectedTreatmentDurationInMonths == null ? "" : $"{ExpectedTreatmentDurationInMonths} months";
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -35,7 +35,6 @@ namespace ntbs_service.Pages.Notifications.Edit
         public FormattedDate FormattedTbServicePresentationDate { get; set; }
         public FormattedDate FormattedDiagnosisDate { get; set; }
         public FormattedDate FormattedTreatmentDate { get; set; }
-        public FormattedDate FormattedMdrTreatmentDate { get; set; }
         public FormattedDate FormattedHomeVisitDate { get; set; }
 
         public ClinicalDetailsModel(
@@ -78,7 +77,6 @@ namespace ntbs_service.Pages.Notifications.Edit
             FormattedTbServicePresentationDate = ClinicalDetails.TBServicePresentationDate.ConvertToFormattedDate();
             FormattedDiagnosisDate = ClinicalDetails.DiagnosisDate.ConvertToFormattedDate();
             FormattedTreatmentDate = ClinicalDetails.TreatmentStartDate.ConvertToFormattedDate();
-            FormattedMdrTreatmentDate = ClinicalDetails.MDRTreatmentStartDate.ConvertToFormattedDate();
             FormattedHomeVisitDate = ClinicalDetails.FirstHomeVisitDate.ConvertToFormattedDate();
 
             if (ClinicalDetails.ShouldValidateFull)
@@ -196,12 +194,10 @@ namespace ntbs_service.Pages.Notifications.Edit
                 (nameof(ClinicalDetails.TBServicePresentationDate), FormattedTbServicePresentationDate),
                 (nameof(ClinicalDetails.DiagnosisDate), FormattedDiagnosisDate),
                 (nameof(ClinicalDetails.TreatmentStartDate), FormattedTreatmentDate),
-                (nameof(ClinicalDetails.FirstHomeVisitDate), FormattedHomeVisitDate),
-                (nameof(ClinicalDetails.MDRTreatmentStartDate), FormattedMdrTreatmentDate)
+                (nameof(ClinicalDetails.FirstHomeVisitDate), FormattedHomeVisitDate)
             }.ForEach(item =>
                 ValidationService.TrySetFormattedDate(ClinicalDetails, "ClinicalDetails", item.key, item.date)
             );
-            ClinicalDetails.DatesHaveBeenSet = true;
         }
 
         private void UpdateFlags()
@@ -224,20 +220,6 @@ namespace ntbs_service.Pages.Notifications.Edit
             {
                 ClinicalDetails.BCGVaccinationYear = null;
                 ModelState.Remove("ClinicalDetails.BCGVaccinationYear");
-            }
-
-            if (!ClinicalDetails.IsMDRTreatment)
-            {
-                ClinicalDetails.MDRTreatmentStartDate = null;
-                ClinicalDetails.MDRExpectedTreatmentDurationInMonths = null;
-                FormattedMdrTreatmentDate = ClinicalDetails.MDRTreatmentStartDate.ConvertToFormattedDate();
-                ModelState.Remove("ClinicalDetails.MDRTreatmentStartDate");
-                ModelState.Remove("ClinicalDetails.MDRExpectedTreatmentDurationInMonths");
-            }
-            else
-            {
-                ClinicalDetails.MDRExpectedTreatmentDurationInMonths =
-                    ClinicalDetails.MDRExpectedTreatmentDurationInMonths?.Replace(" ", "");
             }
 
             if (ClinicalDetails.TreatmentRegimen != TreatmentRegimen.Other)

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml
@@ -17,9 +17,64 @@
 
 <div>
     <nhs-form-group nhs-form-group-type="Standard">
-        <nhs-fieldset>
-            <nhs-fieldset-legend nhs-legend-size="Standard">@Html.DisplayNameFor(model => model.MDRDetails.ExposureToKnownCaseStatus)</nhs-fieldset-legend>
+        <nhs-fieldset>   
+            <validate-date model="MDRDetails" property="MDRTreatmentStartDate" inline-template>
+                @{
+                    var hasMdrTreatmentDateError = !Model.IsValid("MDRDetails.MDRTreatmentStartDate");
+                    var mdrTreatmentDateState = hasMdrTreatmentDateError ? Error : Standard;
+                }
+                <nhs-form-group nhs-form-group-type=@mdrTreatmentDateState id="MDRDetails-MDRTreatmentStartDate">
+                    <nhs-fieldset aria-describedby="mdr-treatment-date-error" role="group">
+                        <nhs-fieldset-legend nhs-legend-size="Standard">MDR treatment start date</nhs-fieldset-legend>
+                        <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="MDRDetails.MDRTreatmentStartDate"
+                              has-error="@hasMdrTreatmentDateError" id="mdr-treatment-date-error"></span>
+                        <nhs-date-input id="mdr-treatment-date">
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="FormattedMdrTreatmentDate.Day">Day</label>
+                                    <input v-on:blur="validate" ref="dayInput" nhs-input-type="Date" fixed-width="Two"
+                                           is-error-input=@hasMdrTreatmentDateError asp-for="FormattedMdrTreatmentDate.Day"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="FormattedMdrTreatmentDate.Month">Month</label>
+                                    <input v-on:blur="validate" ref="monthInput" nhs-input-type="Date" fixed-width="Two"
+                                           is-error-input=@hasMdrTreatmentDateError asp-for="FormattedMdrTreatmentDate.Month"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                            <nhs-date-input-item>
+                                <nhs-form-group nhs-form-group-type="Standard">
+                                    <label nhs-label-type="Date" asp-for="FormattedMdrTreatmentDate.Year">Year</label>
+                                    <input v-on:blur="validate" ref="yearInput" nhs-input-type="Date" fixed-width="Four"
+                                           is-error-input=@hasMdrTreatmentDateError asp-for="FormattedMdrTreatmentDate.Year"/>
+                                </nhs-form-group>
+                            </nhs-date-input-item>
+                        </nhs-date-input>
+                    </nhs-fieldset>
+                </nhs-form-group>
+            </validate-date>
 
+            <validate-input model="MDRDetails" property="ExpectedTreatmentDurationInMonths" inline-template>
+                @{
+                    var hasMdrExpectedDurationError = !Model.IsValid("MDRDetails.ExpectedTreatmentDurationInMonths");
+                    var mdrExpectedDurationState = hasMdrExpectedDurationError ? Error : Standard;
+                }
+                <nhs-form-group nhs-form-group-type=@mdrExpectedDurationState id="MDRDetails-ExpectedTreatmentDurationInMonths">
+                    <span nhs-span-type="ErrorMessage" asp-validation-for="MDRDetails.ExpectedTreatmentDurationInMonths"
+                          has-error="@hasMdrExpectedDurationError" ref="errorField" id="expected-treatment-duration-error">
+                    </span>
+                    <label asp-for="MDRDetails.ExpectedTreatmentDurationInMonths" nhs-label-type="Standard">
+                        Expected treatment duration in months
+                    </label>
+                    <input nhs-input-type="Standard" asp-for="MDRDetails.ExpectedTreatmentDurationInMonths" is-error-input="@hasMdrExpectedDurationError"
+                           v-on:blur="validate" ref="inputField" fixed-width="Five" aria-describedby="expected-treatment-duration-error"/>
+                </nhs-form-group>
+            </validate-input>
+        </nhs-fieldset> <br/>
+        
+        <nhs-fieldset> 
+        <nhs-fieldset-legend nhs-legend-size="Standard">@Html.DisplayNameFor(model => model.MDRDetails.ExposureToKnownCaseStatus)</nhs-fieldset-legend>
             <div class="nhsuk-radios govuk-radios--conditional" data-module="govuk-radios">
                 <div class="nhsuk-radios__item">
                     <input asp-for="MDRDetails.ExposureToKnownCaseStatus" id="exposure-yes" class="nhsuk-radios__input" type="radio"

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using ntbs_service.DataAccess;
 using ntbs_service.Helpers;
+using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
 using ntbs_service.Models.ReferenceEntities;
@@ -42,6 +43,9 @@ namespace ntbs_service.Pages.Notifications.Edit
         [BindProperty]
         public MDRDetails MDRDetails { get; set; }
 
+        [BindProperty]
+        public FormattedDate FormattedMdrTreatmentDate { get; set; }
+
         public SelectList Countries { get; set; }
 
 
@@ -56,6 +60,8 @@ namespace ntbs_service.Pages.Notifications.Edit
             Countries = new SelectList(countries, nameof(Country.CountryId), nameof(Country.Name));
 
             MDRDetails = Notification.MDRDetails;
+            MDRDetails.Treatment = Notification.ClinicalDetails.TreatmentRegimen;
+            FormattedMdrTreatmentDate = MDRDetails.MDRTreatmentStartDate.ConvertToFormattedDate();
             await SetNotificationProperties(isBeingSubmitted, MDRDetails);
 
             if (MDRDetails.ShouldValidateFull)
@@ -91,6 +97,14 @@ namespace ntbs_service.Pages.Notifications.Edit
 
             UpdateFlags();
             ValidateRelatedNotificationId();
+
+            ValidationService.TrySetFormattedDate(MDRDetails, "MDRDetails", nameof(MDRDetails.MDRTreatmentStartDate), FormattedMdrTreatmentDate);
+            MDRDetails.DatesHaveBeenSet = true;
+
+            // Add additional field required for date validation
+            MDRDetails.Dob = Notification.PatientDetails.Dob;
+            MDRDetails.Treatment = Notification.ClinicalDetails.TreatmentRegimen;
+
             MDRDetails.SetValidationContext(Notification);
 
             if (TryValidateModel(MDRDetails, nameof(MDRDetails)))
@@ -141,6 +155,12 @@ namespace ntbs_service.Pages.Notifications.Edit
         public ContentResult OnPostValidateMDRDetailsProperty([FromBody]InputValidationModel validationData)
         {
             return ValidationService.GetPropertyValidationResult<MDRDetails>(validationData.Key, validationData.Value, validationData.ShouldValidateFull);
+        }
+
+        public async Task<ContentResult> OnPostValidateMDRDetailsDate([FromBody]DateValidationModel validationData)
+        {
+            var isLegacy = await NotificationRepository.IsNotificationLegacyAsync(NotificationId);
+            return ValidationService.GetDateValidationResult<MDRDetails>(validationData.Key, validationData.Day, validationData.Month, validationData.Year, isLegacy);
         }
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/MDRDetails.cshtml.cs
@@ -60,7 +60,6 @@ namespace ntbs_service.Pages.Notifications.Edit
             Countries = new SelectList(countries, nameof(Country.CountryId), nameof(Country.Name));
 
             MDRDetails = Notification.MDRDetails;
-            MDRDetails.Treatment = Notification.ClinicalDetails.TreatmentRegimen;
             FormattedMdrTreatmentDate = MDRDetails.MDRTreatmentStartDate.ConvertToFormattedDate();
             await SetNotificationProperties(isBeingSubmitted, MDRDetails);
 
@@ -103,7 +102,6 @@ namespace ntbs_service.Pages.Notifications.Edit
 
             // Add additional field required for date validation
             MDRDetails.Dob = Notification.PatientDetails.Dob;
-            MDRDetails.Treatment = Notification.ClinicalDetails.TreatmentRegimen;
 
             MDRDetails.SetValidationContext(Notification);
 

--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsTreatmentOptions.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsTreatmentOptions.cshtml
@@ -126,67 +126,7 @@
                 </div>
 
                 <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-mdr-conditional">
-                    <validate-date model="ClinicalDetails" property="MDRTreatmentStartDate" inline-template>
-                        @{
-                            var hasMdrTreatmentDateError = !Model.IsValid("ClinicalDetails.MDRTreatmentStartDate");
-                            var mdrTreatmentDateState = hasMdrTreatmentDateError ? Error : Standard;
-                        }
-                        <nhs-form-group nhs-form-group-type=@mdrTreatmentDateState id="ClinicalDetails-MDRTreatmentStartDate">
-                            <nhs-fieldset aria-describedby="mdr-treatment-date-error" role="group">
-                                <nhs-fieldset-legend nhs-legend-size="Standard">Treatment date</nhs-fieldset-legend>
-                                <span nhs-span-type="ErrorMessage" ref="errorField" asp-validation-for="ClinicalDetails.MDRTreatmentStartDate"
-                                      has-error="@hasMdrTreatmentDateError" id="mdr-treatment-date-error"></span>
-                                <nhs-date-input id="mdr-treatment-date">
-                                    <nhs-date-input-item>
-                                        <nhs-form-group nhs-form-group-type="Standard">
-                                            <label nhs-label-type="Date" asp-for="FormattedMdrTreatmentDate.Day">Day</label>
-                                            <input v-on:blur="validate" ref="dayInput" nhs-input-type="Date" fixed-width="Two"
-                                                   is-error-input=@hasMdrTreatmentDateError asp-for="FormattedMdrTreatmentDate.Day" />
-                                        </nhs-form-group>
-                                    </nhs-date-input-item>
-                                    <nhs-date-input-item>
-                                        <nhs-form-group nhs-form-group-type="Standard">
-                                            <label nhs-label-type="Date" asp-for="FormattedMdrTreatmentDate.Month">Month</label>
-                                            <input v-on:blur="validate" ref="monthInput" nhs-input-type="Date" fixed-width="Two"
-                                                   is-error-input=@hasMdrTreatmentDateError asp-for="FormattedMdrTreatmentDate.Month" />
-                                        </nhs-form-group>
-                                    </nhs-date-input-item>
-                                    <nhs-date-input-item>
-                                        <nhs-form-group nhs-form-group-type="Standard">
-                                            <label nhs-label-type="Date" asp-for="FormattedMdrTreatmentDate.Year">Year</label>
-                                            <input v-on:blur="validate" ref="yearInput" nhs-input-type="Date" fixed-width="Four"
-                                                   is-error-input=@hasMdrTreatmentDateError asp-for="FormattedMdrTreatmentDate.Year" />
-                                        </nhs-form-group>
-                                    </nhs-date-input-item>
-                                </nhs-date-input>
-                            </nhs-fieldset>
-                        </nhs-form-group>
-                    </validate-date>
-
-                    <validate-input model="ClinicalDetails" property="MDRExpectedTreatmentDurationInMonths" inline-template>
-                        @{
-                            var hasMdrExpectedDurationError = !Model.IsValid("ClinicalDetails.MDRExpectedTreatmentDurationInMonths");
-                            var mdrExpectedDurationState = hasMdrExpectedDurationError ? Error : Standard;
-                        }
-                        <nhs-form-group nhs-form-group-type=@mdrExpectedDurationState id="ClinicalDetails-MDRExpectedTreatmentDurationInMonths">
-                            <span nhs-span-type="ErrorMessage" asp-validation-for="ClinicalDetails.MDRExpectedTreatmentDurationInMonths"
-                                  has-error="@hasMdrExpectedDurationError" ref="errorField" id="expected-treatment-duration-error">
-                            </span>
-                            <label asp-for="ClinicalDetails.MDRExpectedTreatmentDurationInMonths" nhs-label-type="Standard">
-                                Expected treatment duration in months
-                            </label>
-                            <input nhs-input-type="Standard" asp-for="ClinicalDetails.MDRExpectedTreatmentDurationInMonths" is-error-input="@hasMdrExpectedDurationError"
-                                 v-on:blur="validate" ref="inputField" fixed-width="Five" aria-describedby="expected-treatment-duration-error" />
-                        </nhs-form-group>
-                    </validate-input>
-                </div>
-
-                <div class="nhsuk-radios__item">
-                    <input asp-for="ClinicalDetails.TreatmentRegimen" id="regimen-other" class="nhsuk-radios__input" type="radio" value="@TreatmentRegimen.Other"
-                        data-aria-controls="conditional-regimen-other-conditional">
-                    <label class="nhsuk-label nhsuk-radios__label" for="regimen-other">
-                        Other
-                    </label>
+                    Please provide the start date and expected duration of treatment on the MDR questionnaire
                 </div>
 
 

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_MDRDetailsOverviewPartial.cshtml
@@ -20,6 +20,16 @@
 <div class="notification-overview-details-container" id="@sectionId">
     <nhs-grid-row>
         <nhs-grid-column grid-column-width="OneQuarter">
+            <div class="notification-details-label"> MDR treatment start date </div>
+            <div class="cell-min-height" id="@sectionId-treatment-start-date"> @Model.Notification.MDRDetails.FormattedTreatmentStartDate </div>
+        </nhs-grid-column>
+        <nhs-grid-column grid-column-width="OneHalf">
+            <div class="notification-details-label"> MDR treatment expected duration </div>
+            <div class="cell-min-height" id="@sectionId-expected-duration"> @Model.Notification.MDRDetails.FormattedExpectedDuration</div>
+        </nhs-grid-column>
+    </nhs-grid-row>
+    <nhs-grid-row>
+        <nhs-grid-column grid-column-width="OneQuarter">
             <div class="notification-details-label"> Exposure to known TB case </div>
             <div class="cell-min-height" id="@sectionId-known-case-exposure"> @Model.Notification.MDRDetails.ExposureToKnownCaseStatus </div>
         </nhs-grid-column>
@@ -27,12 +37,12 @@
             <div class="notification-details-label"> Relationship to case </div>
             <div class="cell-min-height" id="@sectionId-relationship-to-case"> @Model.Notification.MDRDetails.RelationshipToCase </div>
         </nhs-grid-column>
-        
+
         <nhs-grid-column grid-column-width="OneQuarter">
             <div class="notification-details-label"> @Html.DisplayNameFor(x => x.Notification.MDRDetails.CountryId) </div>
             <div class="cell-min-height" id="@sectionId-country-name"> @Model.Notification.MDRDetails.MDRCaseCountryName </div>
         </nhs-grid-column>
-        
+
         <nhs-grid-column grid-column-width="OneQuarter">
             <div class="notification-details-label"> @Html.DisplayNameFor(x => x.Notification.MDRDetails.RelatedNotificationId) </div>
             <div class="cell-min-height" id="@sectionId-related-notification-id">
@@ -48,7 +58,7 @@
         </nhs-grid-column>
     </nhs-grid-row>
     <nhs-grid-row>
-        <nhs-grid-column grid-column-width="OneThird">
+        <nhs-grid-column grid-column-width="OneHalf">
             <div class="notification-details-label"> @Html.DisplayNameFor(x => x.Notification.MDRDetails.DiscussedAtMDRForum) </div>
             <div class="cell-min-height" id="@sectionId-discussed-at-forum"> @Model.Notification.MDRDetails.DiscussedAtMDRForum </div>
         </nhs-grid-column>


### PR DESCRIPTION
## Description
Moved the 2 MDR conditional fields to the MDR model/page. I think there may still be some cleaning up to do, but wanted to get a review to make sure it looks okay otherwise. 

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [x] EF migrations created and committed. Snapshot committed
- [x] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Specimen matching database DACPAC updated
- [ ] Reporting database ingestion considered (uspGenerateReusableNotification)
