### PR TITLE
NTBS-2663 Use github container registry

### DIFF
--- a/.github/workflows/backup-live-image.yml
+++ b/.github/workflows/backup-live-image.yml
@@ -10,36 +10,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
       - name: Get the live release tag
         id: get_tag
         run: echo ::set-output name=BRANCH_TAG::$(echo $GITHUB_REF | cut -d / -f 3)
 
-      - name: Backup live release
-        env:
-          COMMIT_SHA: ${{ github.sha }}
-          DOCKER_REGISTRY_URL: ntbscontainerregistry.azurecr.io
-          DOCKER_REGISTRY_AZURE_NAME: ntbsContainerRegistry
-          DOCKER_REPOSITORY: ntbs-service
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          BACKUP_DOCKER_REGISTRY_URL: ntbsbackups.azurecr.io
-          BACKUP_DOCKER_REPOSITORY: ntbs-backups
-          BACKUP_DOCKER_USERNAME: ${{ secrets.BACKUP_DOCKER_USERNAME }}
-          BACKUP_DOCKER_PASSWORD: ${{ secrets.BACKUP_DOCKER_PASSWORD }}
-          BACKUP_IMAGE_TAG: ${{ steps.get_tag.outputs.BRANCH_TAG }}
-        run: |
-          image_tag=$(az acr repository show-tags -n $DOCKER_REGISTRY_AZURE_NAME --repository $DOCKER_REPOSITORY -u $DOCKER_USERNAME -p $DOCKER_PASSWORD | grep $COMMIT_SHA | cut -d \" -f 2)
-          [ -z "$image_tag" ] && { echo "An image could not be found for the commit $COMMIT_SHA"; exit 1; }
-          echo "Discovered image $image_tag"
-          echo "Logging in to $DOCKER_REGISTRY_URL"
-          echo "$DOCKER_PASSWORD" | docker login -u $DOCKER_USERNAME --password-stdin $DOCKER_REGISTRY_URL
-          full_image="$DOCKER_REGISTRY_URL/$DOCKER_REPOSITORY:$image_tag"
-          echo "Pulling image $full_image"
-          docker pull $full_image
-          full_backup_image="$BACKUP_DOCKER_REGISTRY_URL/$BACKUP_DOCKER_REPOSITORY:$BACKUP_IMAGE_TAG"
-          echo "Setting image tag to $full_backup_image"
-          docker tag $full_image $full_backup_image
-          echo "Logging in to $BACKUP_DOCKER_REGISTRY_URL"
-          echo "$BACKUP_DOCKER_PASSWORD" | docker login -u $BACKUP_DOCKER_USERNAME --password-stdin $BACKUP_DOCKER_REGISTRY_URL
-          echo "Pushing image $full_backup_image"
-          docker image push $full_backup_image
+      - name: Build and publish backup
+        uses: whoan/docker-build-with-cache-action@v5
+        with:
+          image_name: ntbs-backups
+          registry: ntbsbackups.azurecr.io
+          username: ${{ secrets.BACKUP_DOCKER_USERNAME }}
+          password: ${{ secrets.BACKUP_DOCKER_PASSWORD }}
+          # auth token based on https://sentry.io/settings/phe-ntbs/developer-settings/jenkins-build-40d229/
+          build_extra_args: ${{ format('--build-arg RELEASE={0} --build-arg SENTRY_AUTH_TOKEN={1}', steps.get_tag.outputs.BRANCH_TAG, secrets.SENTRY_AUTH_TOKEN) }}
+          image_tag: ${{ steps.get_tag.outputs.BRANCH_TAG }}

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -21,9 +21,9 @@ jobs:
         uses: whoan/docker-build-with-cache-action@v5
         with:
           image_name: ntbs-service
-          registry: ntbscontainerregistry.azurecr.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io/publichealthengland
+          username: whoan
+          password: "${{ secrets.GITHUB_TOKEN }}"
           # auth token based on https://sentry.io/settings/phe-ntbs/developer-settings/jenkins-build-40d229/
           build_extra_args: ${{ format('--build-arg RELEASE={0} --build-arg SENTRY_AUTH_TOKEN={1}', steps.ntbs_build_step.outputs.NTBS_BUILD, secrets.SENTRY_AUTH_TOKEN) }}
           image_tag: ${{ steps.ntbs_build_step.outputs.NTBS_BUILD }}

--- a/.github/workflows/ntbs-test-and-deploy.yml
+++ b/.github/workflows/ntbs-test-and-deploy.yml
@@ -23,9 +23,9 @@ jobs:
         uses: whoan/docker-build-with-cache-action@v5
         with:
           image_name: ntbs-service
-          registry: ntbscontainerregistry.azurecr.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io/publichealthengland
+          username: whoan
+          password: "${{ secrets.GITHUB_TOKEN }}"
           # auth token based on https://sentry.io/settings/phe-ntbs/developer-settings/jenkins-build-40d229/
           build_extra_args: ${{ format('--build-arg RELEASE={0} --build-arg SENTRY_AUTH_TOKEN={1}', steps.ntbs_build_step.outputs.NTBS_BUILD, secrets.SENTRY_AUTH_TOKEN) }}
           image_tag: ${{ steps.ntbs_build_step.outputs.NTBS_BUILD }}

--- a/ntbs-service/README.md
+++ b/ntbs-service/README.md
@@ -134,8 +134,8 @@ docker run -it --rm -p 8000:80 --name ntbs ntbs
 Publishing current image
 ```
 docker build -t ntbs .
-docker tag ntbs ntbscontainerregistry.azurecr.io/ntbs-service
-docker push ntbscontainerregistry.azurecr.io/ntbs-service
+docker tag ntbs ghcr.io/publichealthengland/ntbs-service
+docker push ghcr.io/publichealthengland/ntbs-service
 ```
 
 ## Azure Active Directory Setup

--- a/ntbs-service/deployments/dev.yml
+++ b/ntbs-service/deployments/dev.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: ntbs-dev
-          image: "ntbscontainerregistry.azurecr.io/ntbs-service:dev"
+          image: "ghcr.io/publichealthengland/ntbs-service:dev"
           imagePullPolicy: Always
           resources:
             requests:
@@ -86,7 +86,6 @@ spec:
             - name: ScheduledJobsConfig__UserSyncCron
               value: "00 21 * * *"
       imagePullSecrets:
-        - name: registery-password
         - name: default-dockercfg-bs7wj
 ---
 apiVersion: v1

--- a/ntbs-service/deployments/int.yml
+++ b/ntbs-service/deployments/int.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: ntbs-int
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service:int"
+        image: "ghcr.io/publichealthengland/ntbs-service:int"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -85,8 +85,6 @@ spec:
             value: "development"
           - name: EnvironmentDescription__EnvironmentName
             value: "azure-int"
-      imagePullSecrets:
-      - name: registry-password
 ---
 apiVersion: v1
 kind: Service

--- a/ntbs-service/deployments/live.yml
+++ b/ntbs-service/deployments/live.yml
@@ -29,7 +29,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: ntbs-live
-          image: "ntbscontainerregistry.azurecr.io/ntbs-service:live"
+          image: "ghcr.io/publichealthengland/ntbs-service:live"
           imagePullPolicy: Always
           resources:
             limits:
@@ -138,7 +138,6 @@ spec:
             - mountPath: /krbtab
               name: krb-tab
       imagePullSecrets:
-        - name: registery-password
         - name: default-dockercfg-bs7wj
       volumes:
         - name: krb-tab

--- a/ntbs-service/deployments/load-test.yml
+++ b/ntbs-service/deployments/load-test.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: ntbs-load-test
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service:load-test"
+        image: "ghcr.io/publichealthengland/ntbs-service:load-test"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -90,8 +90,6 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
-      imagePullSecrets:
-      - name: registry-password
 ---
 apiVersion: v1
 kind: Service

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: ntbs-test
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service:test"
+        image: "ghcr.io/publichealthengland/ntbs-service:test"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -89,8 +89,6 @@ spec:
             value: "development"
           - name: EnvironmentDescription__EnvironmentName
             value: "azure-test"
-      imagePullSecrets:
-      - name: registry-password
 ---
 apiVersion: v1
 kind: Service

--- a/ntbs-service/deployments/training.yml
+++ b/ntbs-service/deployments/training.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: ntbs-training
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service:training"
+        image: "ghcr.io/publichealthengland/ntbs-service:training"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -87,8 +87,6 @@ spec:
             value: "training"
           - name: EnvironmentDescription__EnvironmentName
             value: "azure-training"
-      imagePullSecrets:
-      - name: registry-password
 ---
 apiVersion: v1
 kind: Service

--- a/ntbs-service/deployments/uat-phe.yml
+++ b/ntbs-service/deployments/uat-phe.yml
@@ -29,7 +29,7 @@ spec:
                 topologyKey: kubernetes.io/hostname
       containers:
         - name: ntbs-uat
-          image: "ntbscontainerregistry.azurecr.io/ntbs-service:uat"
+          image: "ghcr.io/publichealthengland/ntbs-service:uat"
           imagePullPolicy: Always
           resources:
             requests:
@@ -136,7 +136,6 @@ spec:
             - mountPath: /krbtab
               name: krb-tab
       imagePullSecrets:
-        - name: registery-password
         - name: default-dockercfg-bs7wj
       volumes:
         - name: krb-tab

--- a/ntbs-service/deployments/uat.yml
+++ b/ntbs-service/deployments/uat.yml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: ntbs-uat
-        image: "ntbscontainerregistry.azurecr.io/ntbs-service:uat"
+        image: "ghcr.io/publichealthengland/ntbs-service:uat"
         imagePullPolicy: Always
         ports:
         - containerPort: 8080
@@ -85,8 +85,6 @@ spec:
             value: "development"
           - name: EnvironmentDescription__EnvironmentName
             value: "azure-uat"
-      imagePullSecrets:
-      - name: registry-password
 ---
 apiVersion: v1
 kind: Service

--- a/ntbs-service/kubernetes/README.md
+++ b/ntbs-service/kubernetes/README.md
@@ -10,7 +10,6 @@ Before you begin, you need to generate the required secrets. Assuming that you h
 * development-ad-sync-credentials
 * int-azuread-options
 * int-connection-strings
-* registry-password
 * softwire-container-registry-secret
 * test-azuread-options
 * test-connection-strings
@@ -44,7 +43,7 @@ The following steps assume that you are working in a resource group called `NTBS
     * Get the `int.yml` file from the `deployments` directory in the project.
     * Update the domain to the new DNS Zone.
     * `kubectl apply -f int.yml`
-    * `kubectl set image deployment/ntbs-int ntbs-int=ntbscontainerregistry.azurecr.io/ntbs-service:<current-build>`
+    * `kubectl set image deployment/ntbs-int ntbs-int=ghcr.io/publichealthengland/ntbs-service:<current-build>`
 
 1. Set up the TLS certificates by following the instructions in the cert-manager `readMe`, but remember to update the domains to the new DNS Zone.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -20,7 +20,7 @@ fi
 
 echo "Setting image to build $build"
 # This sets the image to current build. Should be the same as "latest", but triggers pull of the image.
-kubectl set image deployment/ntbs-$env ntbs-$env=ntbscontainerregistry.azurecr.io/ntbs-service:$build --record=true
+kubectl set image deployment/ntbs-$env ntbs-$env=ghcr.io/publichealthengland/ntbs-service:$build --record=true
 
 attempts=0
 maxAttempts=30


### PR DESCRIPTION
Update all the places where we currently use the Azure container registry to use the Github container registry instead

I _think_ I've found all of the places that need to be updated, but I'm not 100% certain.
