### PR TITLE
NTBS-2840: Remove alert when potential match is rejected

### DIFF
--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -30,6 +30,7 @@ namespace ntbs_service.DataAccess
 
         Task CloseAlertRangeAsync(IEnumerable<Alert> alerts);
         Task CloseUnmatchedLabResultAlertsForSpecimenIdAsync(string specimenId);
+        Task CloseUnmatchedLabResultAlertForSpecimenAndNotificationAsync(string specimenId, int notificationId);
         Task SaveAlertChangesAsync(NotificationAuditType auditType = NotificationAuditType.Edited);
     }
 
@@ -191,6 +192,18 @@ namespace ntbs_service.DataAccess
                 .ToListAsync();
 
             await CloseAlertRangeAsync(alertsToClose);
+        }
+
+        public async Task CloseUnmatchedLabResultAlertForSpecimenAndNotificationAsync(string specimenId,
+            int notificationId)
+        {
+            var alertToClose = await _context.Alert.OfType<UnmatchedLabResultAlert>()
+                .SingleAsync(alert => alert.AlertStatus == AlertStatus.Open
+                                      && alert.SpecimenId == specimenId
+                                      && alert.NotificationId == notificationId);
+
+            alertToClose.AlertStatus = AlertStatus.Closed;
+            await _context.SaveChangesAsync();
         }
 
         public async Task SaveAlertChangesAsync(NotificationAuditType auditType = NotificationAuditType.Edited)

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -198,12 +198,15 @@ namespace ntbs_service.DataAccess
             int notificationId)
         {
             var alertToClose = await _context.Alert.OfType<UnmatchedLabResultAlert>()
-                .SingleAsync(alert => alert.AlertStatus == AlertStatus.Open
+                .SingleOrDefaultAsync(alert => alert.AlertStatus == AlertStatus.Open
                                       && alert.SpecimenId == specimenId
                                       && alert.NotificationId == notificationId);
 
-            alertToClose.AlertStatus = AlertStatus.Closed;
-            await _context.SaveChangesAsync();
+            if (alertToClose != null)
+            {
+                alertToClose.AlertStatus = AlertStatus.Closed;
+                await _context.SaveChangesAsync();
+            }
         }
 
         public async Task SaveAlertChangesAsync(NotificationAuditType auditType = NotificationAuditType.Edited)

--- a/ntbs-service/Services/SpecimenService.cs
+++ b/ntbs-service/Services/SpecimenService.cs
@@ -214,6 +214,7 @@ namespace ntbs_service.Services
                             userName,
                             NotificationAuditType.Edited);
                     }
+                    await _alertRepository.CloseUnmatchedLabResultAlertForSpecimenAndNotificationAsync(labReferenceNumber, notificationId);
                 }
 
                 return success;


### PR DESCRIPTION
## Description
Now close the alert when a potential specimen is rejected. Caught while testing before QA

## Checklist:
- [x] Automated tests are passing locally.
