### PR TITLE
NTBS-2878 Allow printable ASCII chars in healthcare description

### DIFF
--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -102,7 +102,7 @@ namespace ntbs_service.Models.Entities
 
         [MaxLength(100)]
         [Display(Name = "Other description")]
-        [RegularExpression(ValidationRegexes.CharacterValidation, ErrorMessage = ValidationMessages.StandardStringFormat)]
+        [RegularExpression(ValidationRegexes.CharacterValidationAsciiBasic, ErrorMessage = ValidationMessages.InvalidCharacter)]
         public string HealthcareDescription { get; set; }
 
         [MaxLength(40, ErrorMessage = ValidationMessages.MaximumTextLength)]


### PR DESCRIPTION
Allow a wider character set for the healthcare description field
