### PR TITLE
NTBS-2891 Make config changes following pen test

### DIFF
--- a/ntbs-service/Program.cs
+++ b/ntbs-service/Program.cs
@@ -65,13 +65,17 @@ namespace ntbs_service
 
         private static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .UseSentry(o =>
+                .ConfigureKestrel(options =>
                 {
-                    o.Release = Environment.GetEnvironmentVariable(Constants.Release);
+                    options.AddServerHeader = false;
+                })
+                .UseStartup<Startup>()
+                .UseSentry(options =>
+                {
+                    options.Release = Environment.GetEnvironmentVariable(Constants.Release);
                     // This is a workaround for a known issue in Sentry.
                     // See https://github.com/getsentry/sentry-dotnet/issues/1210
-                    o.DisableDiagnosticSourceIntegration();
+                    options.DisableDiagnosticSourceIntegration();
                 })
                 .UseSerilog();
 

--- a/ntbs-service/Startup.cs
+++ b/ntbs-service/Startup.cs
@@ -74,6 +74,11 @@ namespace ntbs_service
                 options.MinimumSameSitePolicy = SameSiteMode.None;
             });
 
+            services.AddHsts(options =>
+            {
+                options.MaxAge = TimeSpan.FromSeconds(63072000); // Two years
+            });
+
             var adConfig = Configuration.GetSection("AdOptions");
             var adfsConfig = Configuration.GetSection("AdfsOptions");
             var azureAdConfig = Configuration.GetSection("AzureAdOptions");
@@ -113,6 +118,7 @@ namespace ntbs_service
             services.AddSession(options =>
             {
                 options.Cookie.IsEssential = true;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
             });
 
             // select authentication method


### PR DESCRIPTION
Make 3 config changes to make the site slightly more secure:

1. Increase the max-age of the strict-transport-security (HSTS) header to 2 years
2. Make the session cookie "secure"
3. Remove the Server header from the response

I've tested these changes by deploying to the azure `test` and PHE `dev` environments. Weirdly the strict-transport-security header is being overwritten in azure, but you can see that it has been set correctly on `dev`