### PR TITLE
NTBS-2883 Fix XSS attack via referer header

### DIFF
--- a/ntbs-service-unit-tests/Helpers/UrlHelperTest.cs
+++ b/ntbs-service-unit-tests/Helpers/UrlHelperTest.cs
@@ -1,0 +1,74 @@
+﻿using ntbs_service.Helpers;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Helpers
+{
+    public class UrlHelperTest
+    {
+        [Fact]
+        public void SanitiseHttpsUrl_ReturnsInput_ForHttpsUrl()
+        {
+            // Arrange
+            const string inputUrl = "https://ntbs.phe.nhs.uk/Region/E45000010";
+
+            // Act
+            var result = UrlHelper.SanitiseHttpsUrl(inputUrl);
+
+            // Assert
+            Assert.Equal(inputUrl, result);
+        }
+
+        [Fact]
+        public void SanitiseHttpsUrl_ReturnsRoot_ForHttpUrl()
+        {
+            // Arrange
+            const string inputUrl = "http://ntbs.phe.nhs.uk/Region/E45000010";
+
+            // Act
+            var result = UrlHelper.SanitiseHttpsUrl(inputUrl);
+
+            // Assert
+            Assert.Equal("/", result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void SanitiseHttpsUrl_ReturnsRoot_ForNullOrEmpty(string inputUrl)
+        {
+            // Act
+            var result = UrlHelper.SanitiseHttpsUrl(inputUrl);
+
+            // Assert
+            Assert.Equal("/", result);
+        }
+
+        [Fact]
+        public void SanitiseHttpsUrl_ReturnsRoot_ForInlineJavaScript()
+        {
+            // Arrange
+            const string inputUrl = "javascript:window.alert(\"Hello there\")";
+
+            // Act
+            var result = UrlHelper.SanitiseHttpsUrl(inputUrl);
+
+            // Assert
+            Assert.Equal("/", result);
+        }
+
+        [Fact]
+        public void SanitiseHttpsUrl_ReturnsSanitisedUrl_WhenUrlHasInvalidCharacters()
+        {
+            // Arrange
+            const string inputUrl = "https://ntbs.phe.nhs.uk/Region/E45000010\"></a> <script><script> <a href=\"/";
+
+            // Act
+            var result = UrlHelper.SanitiseHttpsUrl(inputUrl);
+
+            // Assert
+            Assert.Equal(
+                "https://ntbs.phe.nhs.uk/Region/E45000010%22%3E%3C/a%3E%20%3Cscript%3E%3Cscript%3E%20%3Ca%20href=%22/",
+                result);
+        }
+    }
+}

--- a/ntbs-service/Helpers/UrlHelper.cs
+++ b/ntbs-service/Helpers/UrlHelper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Castle.Core.Internal;
+
+namespace ntbs_service.Helpers
+{
+    public static class UrlHelper
+    {
+        public static string SanitiseHttpsUrl(string url)
+        {
+            bool isHttps = Uri.TryCreate(url, UriKind.Absolute, out var uriResult)
+                           && uriResult.Scheme == Uri.UriSchemeHttps;
+
+            return isHttps ? uriResult.AbsoluteUri : "/";
+        }
+    }
+}

--- a/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
+++ b/ntbs-service/Pages/ContactDetails/Index.cshtml.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using Microsoft.Extensions.Primitives;
 using ntbs_service.DataAccess;
 using ntbs_service.Helpers;
 using ntbs_service.Models;
@@ -27,7 +26,7 @@ namespace ntbs_service.Pages.ContactDetails
         }
 
         public User ContactDetails { get; set; }
-        
+
         public IList<PHEC> RegionalMemberships { get; set; }
 
         [BindProperty(SupportsGet = true)]
@@ -54,9 +53,7 @@ namespace ntbs_service.Pages.ContactDetails
                 .ThenBy(x => x.TbService.Name)
                 .ToList();
 
-            ViewData["Referer"] = StringValues.IsNullOrEmpty(Request.Headers["Referer"])
-                ? "/"
-                : Request.Headers["Referer"].ToString();
+            ViewData["Referer"] = UrlHelper.SanitiseHttpsUrl(Request.Headers["Referer"].ToString());
 
             PrepareBreadcrumbs();
 


### PR DESCRIPTION
## Description
Sanitise the referer header value before putting it in a web page.

Do this using a new helper method, and add some unit tests for this

## Checklist:
- [x] Automated tests are passing locally.