### PR TITLE
NTBS-2871 Improve manual test ordering

### DIFF
--- a/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
+++ b/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
@@ -5,7 +5,11 @@
     var header = Model.FirstOrDefault();
     var showEditLinks = (bool)(ViewData["ShowManualResultsEditLinks"] ?? false);
     var isReducedTable = (bool)(ViewData["RenderReducedSizeManualResultsTable"] ?? false);
-    var orderedResults = Model.OrderByDescending(r => r.TestDate);
+    var orderedResults = Model
+        .OrderByDescending(r => r.TestDate)
+        .ThenBy(r => r.SampleType?.Description)    // Chest x-rays and CTs don't have a sample type
+        .ThenBy(r => r.ManualTestType.Description)
+        .ThenBy(r => r.Result.ToString());
 }
 
 @if (Model.Count != 0)


### PR DESCRIPTION
## Description
Order by sample and test type, and result as well as test date when displaying manual tests.

## Checklist:
- [x] Automated tests are passing locally.

---
<details>
  <summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/3650110/143288306-aae13e50-c370-432e-b46a-f2b9afdea6ed.png)  
</details>

