### PR TITLE
NTBS-2813: New "No result reason" field

### DIFF
--- a/ntbs-service/Migrations/20211124140116_AddResultReasonToTestResult.Designer.cs
+++ b/ntbs-service/Migrations/20211124140116_AddResultReasonToTestResult.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20211124140116_AddResultReasonToTestResult")]
+    partial class AddResultReasonToTestResult
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20211124140116_AddResultReasonToTestResult.cs
+++ b/ntbs-service/Migrations/20211124140116_AddResultReasonToTestResult.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ntbs_service.Migrations
+{
+    public partial class AddResultReasonToTestResult : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "NoResultReason",
+                table: "ManualTestResult",
+                type: "nvarchar(30)",
+                maxLength: 30,
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NoResultReason",
+                table: "ManualTestResult");
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/ManualTestResult.cs
+++ b/ntbs-service/Models/Entities/ManualTestResult.cs
@@ -4,6 +4,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using EFAuditer;
 using ExpressiveAnnotations.Attributes;
+using ntbs_service.Helpers;
 using ntbs_service.Models.Enums;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Models.Validations;
@@ -31,6 +32,11 @@ namespace ntbs_service.Models.Entities
         [AssertThat(nameof(ResultMatchesTestType), ErrorMessage = "Select a result that matches test type")]
         [Display(Name = "Result")]
         public Result? Result { get; set; }
+
+        [RegularExpression(ValidationRegexes.CharacterValidationLocalPatientId, ErrorMessage = ValidationMessages.InvalidCharacter)]
+        [MaxLength(30, ErrorMessage = ValidationMessages.MaximumTextLength)]
+        [Display(Name = "Reason for no result")]
+        public string NoResultReason { get; set; }
 
         [Required(ErrorMessage = ValidationMessages.RequiredSelect)]
         [Display(Name = "Test type")]
@@ -67,6 +73,12 @@ namespace ntbs_service.Models.Entities
         public bool TestHasSampleTypes =>
             ManualTestType != null
             && ManualTestType.ManualTestTypeSampleTypes.Any();
+
+        [NotMapped]
+        public string ResultDisplayString => Result.GetDisplayName() + "\n" +
+                                             (Result == Enums.Result.NoResult && !string.IsNullOrEmpty(NoResultReason)
+                                                 ? $" - {NoResultReason}"
+                                                 : string.Empty);
 
         string IHasRootEntityForAuditing.RootEntityType => RootEntities.Notification;
         string IHasRootEntityForAuditing.RootId => NotificationId.ToString();

--- a/ntbs-service/Models/Entities/ManualTestResult.cs
+++ b/ntbs-service/Models/Entities/ManualTestResult.cs
@@ -75,9 +75,9 @@ namespace ntbs_service.Models.Entities
             && ManualTestType.ManualTestTypeSampleTypes.Any();
 
         [NotMapped]
-        public string ResultDisplayString => Result.GetDisplayName() + "\n" +
+        public string ResultDisplayString => Result.GetDisplayName() +
                                              (Result == Enums.Result.NoResult && !string.IsNullOrEmpty(NoResultReason)
-                                                 ? $" - {NoResultReason}"
+                                                 ? $"\n - {NoResultReason}"
                                                  : string.Empty);
 
         string IHasRootEntityForAuditing.RootEntityType => RootEntities.Notification;

--- a/ntbs-service/Models/Enums/Result.cs
+++ b/ntbs-service/Models/Enums/Result.cs
@@ -17,6 +17,8 @@ namespace ntbs_service.Models.Enums
         Positive,
         [Display(Name = "Negative")]
         Negative,
+        [Display(Name = "No result available")]
+        NoResult,
         // Universal
         [Display(Name = "Awaiting")]
         Awaiting
@@ -34,6 +36,7 @@ namespace ntbs_service.Models.Enums
                 case Result.ConsistentWithTbOther:
                 case Result.NotConsistentWithTb:
                     return testTypeId == (int)ManualTestTypeId.ChestXRay || testTypeId == (int)ManualTestTypeId.ChestCT;
+                case Result.NoResult:
                 case Result.Positive:
                 case Result.Negative:
                     return testTypeId != (int)ManualTestTypeId.ChestXRay && testTypeId != (int)ManualTestTypeId.ChestCT;

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -69,6 +69,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
             TestResultForEdit.Dob = Notification.PatientDetails.Dob;
             await SetRelatedEntitiesAsync();
             SetDate();
+            RemoveNoResultDescriptionIfOtherResult();
 
             if (TryValidateModel(TestResultForEdit, "TestResultForEdit"))
             {
@@ -157,6 +158,14 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
                 FormattedTestDate);
         }
 
+        private void RemoveNoResultDescriptionIfOtherResult()
+        {
+            if (TestResultForEdit.Result != Result.NoResult)
+            {
+                TestResultForEdit.NoResultReason = null;
+            }
+        }
+
         public async Task<ContentResult> OnPostValidateTestResultForEditDateAsync([FromBody]DateValidationModel validationData)
         {
             var isLegacy = await NotificationRepository.IsNotificationLegacyAsync(NotificationId);
@@ -180,6 +189,13 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
                         .Where(result => result.IsValidForTestType(value))
                         .Select(result => OptionValue.FromEnum(result))
                 });
+        }
+
+        public ContentResult OnPostValidateManualTestResultProperty([FromBody]InputValidationModel validationData)
+        {
+            // This is a workaround for the fact we need to use a validate-input component on our result field
+            // but we cannot validate it here as we do not know the test type
+            return Content("");
         }
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
@@ -122,9 +122,9 @@
                             </nhs-form-group>
                         </nhs-grid-column>
                         @{
-                            var countryConditionFunctionString = $"function(value) {{ return value && value == {(int)Result.NoResult} }}";
+                            var resultConditionFunctionString = $"function(value) {{ return value && value == {(int)Result.NoResult} }}";
                         }
-                        <conditional-select-wrapper :value-condition-function='@countryConditionFunctionString' ref="results" inline-template>
+                        <conditional-select-wrapper :value-condition-function='@resultConditionFunctionString' ref="results" inline-template>
                             <div class="manual-test-result-container">
                                 <nhs-grid-column grid-column-width="OneThird" >
                                     @{

--- a/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
@@ -121,25 +121,57 @@
                                 </select>
                             </nhs-form-group>
                         </nhs-grid-column>
-                        <nhs-grid-column grid-column-width="Full" ref="results">
-                            @{
-                                var hasResultError = !Model.IsValid("TestResultForEdit.Result");
-                                var resultGroupState = hasResultError ? Error : Standard;
-                            }
-                            <nhs-form-group nhs-form-group-type="@resultGroupState"
-                                            aria-describedby="result-error"
-                                            id="TestResultForEdit-Result">
-                                <label nhs-label-type="Standard" asp-for="TestResultForEdit.Result">
-                                    @Html.DisplayNameFor(m => m.TestResultForEdit.Result)
-                                </label>
-                                <span id="result-error" nhs-span-type="ErrorMessage" has-error="@hasResultError" asp-validation-for="TestResultForEdit.Result"></span>
-                                <select nhs-select-type="@(hasResultError ? SelectType.Error : SelectType.Standard)"
-                                        asp-for="TestResultForEdit.Result"
-                                        asp-items="Html.GetEnumSelectList<Result>()">
-                                    <option value="">Please select</option>
-                                </select>
-                            </nhs-form-group>
-                        </nhs-grid-column>
+                        @{
+                            var countryConditionFunctionString = $"function(value) {{ return value && value == {(int)Result.NoResult} }}";
+                        }
+                        <conditional-select-wrapper :value-condition-function='@countryConditionFunctionString' ref="results" inline-template>
+                            <div class="manual-test-result-container">
+                                <nhs-grid-column grid-column-width="OneThird" >
+                                    @{
+                                        var hasResultError = !Model.IsValid("TestResultForEdit.Result");
+                                        var resultGroupState = hasResultError ? Error : Standard;
+                                    }
+                                    <validate-input model="ManualTestResult" property="Result" v-on:validate="handleChange" v-on:mounted="innerValidateMounted" ref="inner-validate" inline-template>
+                                        <nhs-form-group nhs-form-group-type="@resultGroupState"
+                                                    aria-describedby="result-error"
+                                                    id="TestResultForEdit-Result">
+                                            <label nhs-label-type="Standard" asp-for="TestResultForEdit.Result">
+                                                @Html.DisplayNameFor(m => m.TestResultForEdit.Result)
+                                            </label>
+                                            <span ref="errorField" id="result-error" nhs-span-type="ErrorMessage" has-error="@hasResultError" asp-validation-for="TestResultForEdit.Result"></span>
+                                            <select v-on:change="validate" nhs-select-type="@(hasResultError ? SelectType.Error : SelectType.Standard)"
+                                                    asp-for="TestResultForEdit.Result"
+                                                    asp-items="Html.GetEnumSelectList<Result>()" ref="selectField">
+                                                <option value="">Please select</option>
+                                            </select>
+                                        </nhs-form-group>
+                                    </validate-input>
+                                </nhs-grid-column>
+                                <div ref="conditional-control" id="no-result-reason-conditional" class="govuk-radios__conditional">
+                                    <nhs-grid-column grid-column-width="OneThird">
+                                        @{
+                                            var hasReasonError = !Model.IsValid("TestResultForEdit.ResultReason");
+                                            var reasonGroupState = hasReasonError ? Error : Standard;
+                                        }
+                                        <validate-input model="ManualTestResult" property="NoResultReason" inline-template>
+                                            <nhs-form-group nhs-form-group-type="@reasonGroupState"
+                                                            aria-describedby="reason-error"
+                                                            id="TestResultForEdit-ResultReason">
+                                                <label nhs-label-type="Standard" asp-for="TestResultForEdit.NoResultReason">
+                                                    @Html.DisplayNameFor(m => m.TestResultForEdit.NoResultReason)
+                                                </label>
+                                                <span ref="errorField" id="reason-error" nhs-span-type="ErrorMessage" has-error="@hasReasonError" asp-validation-for="TestResultForEdit.NoResultReason"></span>
+                                                <input ref="inputField"
+                                                       v-on:blur="validate"
+                                                       is-error-input="@hasReasonError"
+                                                       nhs-input-type="Standard"
+                                                       asp-for="TestResultForEdit.NoResultReason"/>
+                                            </nhs-form-group>
+                                        </validate-input>
+                                    </nhs-grid-column>
+                                </div>
+                            </div>
+                        </conditional-select-wrapper>
                     </nhs-grid-row>
                 </filtered-dropdown>
 

--- a/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
+++ b/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
@@ -1,4 +1,6 @@
+@using Castle.Core.Internal
 @using ntbs_service.Helpers
+@using ntbs_service.Models.Enums
 @model ICollection<ntbs_service.Models.Entities.ManualTestResult>
 
 @{
@@ -50,7 +52,7 @@
                         @result?.SampleType?.Description
                     </nhs-table-item>
                     <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.Result)">
-                        @result.Result.GetDisplayName()
+                        @result.ResultDisplayString
                     </nhs-table-item>
                     @if (showEditLinks)
                     {

--- a/ntbs-service/wwwroot/css/testResults.scss
+++ b/ntbs-service/wwwroot/css/testResults.scss
@@ -25,3 +25,8 @@
     padding-top: 5px;
     padding-bottom: 5px;
 }
+
+.manual-test-result-container {
+  width: 100%;
+  float: left;
+}

--- a/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
+++ b/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
@@ -106,11 +106,15 @@ const FilteredDropdown = Vue.extend({
             }
 
             selectElement.value = "";
+            selectElement.dispatchEvent(new Event("change"));
         },
         getSelectElementInRef(refName: string) {
             const filterValueContainer = this.$refs[refName];
             if (filterValueContainer.$refs) {
-                return filterValueContainer.$refs["selectField"];
+                const selectField = this.findSelectFieldInContainer(filterValueContainer);
+                if (selectField) {
+                    return selectField;
+                }
             }
 
             return filterValueContainer.getElementsByTagName("select")[0];
@@ -164,6 +168,19 @@ const FilteredDropdown = Vue.extend({
 
             optionInnerHtml += "</optgroup>";
             return optionInnerHtml;
+        },
+        findSelectFieldInContainer(container: Vue) {
+            if (container.$refs["selectField"]) {
+                return container.$refs["selectField"];
+            }
+            let selectField: Vue;
+            for(let i = 0; i < container.$children.length; i++) {
+                selectField = this.findSelectFieldInContainer(container.$children[i]);
+                if (selectField) {
+                    return selectField;
+                }
+            }
+            return;
         }
     }
 });

--- a/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
+++ b/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
@@ -180,7 +180,7 @@ const FilteredDropdown = Vue.extend({
                     return selectField;
                 }
             }
-            return;
+            return null;
         }
     }
 });


### PR DESCRIPTION
## Description
Added new NoResultReason field to manual test result.
This is only visible when the "No result" result is chosen.
Changed filteredDropdown to search for the "selectField" ref element recursively through the Vue component's children, so that we can use a `conditional-select-wrapper` inside a `filtered-dropdown`

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
### Schema changes
If the NTBS schema changes, that might affect the related components!
- [x] EF migrations created and committed. Snapshot committed
- [x] On-demand migration impact considered
- [ ] Reporting database DACPAC updated
- [ ] Specimen matching database DACPAC updated
- [x] Reporting database ingestion considered (uspGenerateReusableNotification)
### Accessibility testing
Features with UI components should consider items on this list
- [ ] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
