### PR TITLE
DRAFT: NTBS-2848 Embedded PowerBI dashboard spike

### DIFF
--- a/ntbs-service/Pages/PowerBiDashboard.cshtml
+++ b/ntbs-service/Pages/PowerBiDashboard.cshtml
@@ -1,0 +1,21 @@
+﻿@page
+@model ntbs_service.Pages.PowerBiDashboard
+
+@{
+    ViewData["Title"] = "PowerBI";
+    Layout = "./Shared/_Layout.cshtml";
+}
+
+<nhs-width-container container-width="Standard">
+    <h1>Embedded PowerBI dashboard</h1>
+
+    @if (string.IsNullOrEmpty(Model.DashboardUrl))
+    {
+        @: The embedded dashboard could not be found.
+    }
+    else
+    {
+        <iframe src="@Model.DashboardUrl" class="embedded-dashboard" allow="fullscreen">
+        </iframe>
+    }
+</nhs-width-container>

--- a/ntbs-service/Pages/PowerBiDashboard.cshtml.cs
+++ b/ntbs-service/Pages/PowerBiDashboard.cshtml.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
+using ntbs_service.Properties;
+
+namespace ntbs_service.Pages
+{
+    public class PowerBiDashboard : PageModel
+    {
+        public string DashboardUrl { get; }
+
+        public PowerBiDashboard(IConfiguration configuration)
+        {
+            var links = new ExternalLinks();
+            configuration.GetSection(Constants.ExternalLinks).Bind(links);
+
+            DashboardUrl = links.EmbeddedPowerBiDashboard;
+        }
+    }
+}

--- a/ntbs-service/Properties/ExternalLinks.cs
+++ b/ntbs-service/Properties/ExternalLinks.cs
@@ -12,5 +12,6 @@
         public string ReportingOverview { get; set; }
         public string SharePointHomePage { get; set; }
         public string ClusterReport { get; set; }
+        public string EmbeddedPowerBiDashboard { get; set; }
     }
 }

--- a/ntbs-service/appsettings.Development.json
+++ b/ntbs-service/appsettings.Development.json
@@ -38,7 +38,8 @@
     "reporting": "data source=localhost;initial catalog=reporting;trusted_connection=true;MultipleActiveResultSets=true"
   },
   "ExternalLinks": {
-    "ReportingOverview": ""
+    "ReportingOverview": "",
+    "EmbeddedPowerBiDashboard": ""
   },
   "EnvironmentDescription": {
     "ContainsLiveData": false,

--- a/ntbs-service/deployments/dev.yml
+++ b/ntbs-service/deployments/dev.yml
@@ -67,6 +67,8 @@ spec:
               value: "https://app.powerbi.com/Redirect?action=OpenApp&appId=5ae64787-d2aa-4beb-8bf8-18340efe12ab&ctid=ee4e1499-4a35-4b2e-ad47-5f3cf9de8666"
             - name: ExternalLinks__ClusterReport
               value: "https://app.powerbi.com/groups/me/apps/5ae64787-d2aa-4beb-8bf8-18340efe12ab/reports/7b0921bd-8e4b-46f3-8e4b-dc9b7e7c982b/ReportSection?ctid=ee4e1499-4a35-4b2e-ad47-5f3cf9de8666&filter=Cluster%2FClusterId%20eq '<CLUSTER_ID>'"
+            - name: ExternalLinks__EmbeddedPowerBiDashboard
+              value: ""
             - name: MigrationConfig__NtbsEnvironment
               value: "PheDev"
             - name: Sentry__Environment

--- a/ntbs-service/deployments/test.yml
+++ b/ntbs-service/deployments/test.yml
@@ -77,6 +77,8 @@ spec:
             value: "https://app.powerbi.com/Redirect?action=OpenApp&appId=e3e5baa2-50f6-42c8-ae97-7c1bd720a204&ctid=dde2b1dd-a61c-4a89-9734-382c1f37630e"
           - name: ExternalLinks__ClusterReport
             value: "https://app.powerbi.com/groups/me/apps/e3e5baa2-50f6-42c8-ae97-7c1bd720a204/reports/639c1990-d44b-45c9-82b2-2fec2f5ce932/ReportSection?ctid=dde2b1dd-a61c-4a89-9734-382c1f37630e&filter=Cluster%2FClusterId%20eq '<CLUSTER_ID>'"
+          - name: ExternalLinks__EmbeddedPowerBiDashboard
+            value: ""
           - name: MigrationConfig__NtbsEnvironment
             value: "Test"
           - name: Sentry__Environment

--- a/ntbs-service/deployments/uat-phe.yml
+++ b/ntbs-service/deployments/uat-phe.yml
@@ -96,6 +96,8 @@ spec:
               value: "https://app.powerbi.com/Redirect?action=OpenApp&appId=5ae64787-d2aa-4beb-8bf8-18340efe12ab&ctid=ee4e1499-4a35-4b2e-ad47-5f3cf9de8666"
             - name: ExternalLinks__ClusterReport
               value: "https://app.powerbi.com/groups/me/apps/5ae64787-d2aa-4beb-8bf8-18340efe12ab/reports/7b0921bd-8e4b-46f3-8e4b-dc9b7e7c982b/ReportSection?ctid=ee4e1499-4a35-4b2e-ad47-5f3cf9de8666&filter=Cluster%2FClusterId%20eq '<CLUSTER_ID>'"
+            - name: ExternalLinks__EmbeddedPowerBiDashboard
+              value: ""
             - name: MigrationConfig__NtbsEnvironment
               value: "UatPheMigration"
             - name: Sentry__Environment

--- a/ntbs-service/wwwroot/css/home.scss
+++ b/ntbs-service/wwwroot/css/home.scss
@@ -65,3 +65,9 @@
       display: inline;
     }
 }
+
+.embedded-dashboard {
+    width: 100%;
+    aspect-ratio: 3/2;
+    border: none;
+}


### PR DESCRIPTION
## Description
This is a draft because we are just going to build this off the this branch and deploy that image, instead of merging this to `master`, but I thought I would put this up in case you were interested. We can use the Kubernetes config to set the dashboard URL when we are experimenting with this in UAT, meaning we won't need to change any code as we try different dashboards.

* Add a new page to demo an embedded PowerBI dashboard, with a little CSS for the dashboard iframe.
* Configure the dashboard URL using Kubernetes config. This follows the existing pattern for external links like the reporting link.

## Checklist:
- [x] Automated tests are passing locally.