### PR TITLE
NTBS-2813: Add line break before no result reason

### DIFF
--- a/ntbs-service/Models/Entities/ManualTestResult.cs
+++ b/ntbs-service/Models/Entities/ManualTestResult.cs
@@ -74,12 +74,6 @@ namespace ntbs_service.Models.Entities
             ManualTestType != null
             && ManualTestType.ManualTestTypeSampleTypes.Any();
 
-        [NotMapped]
-        public string ResultDisplayString => Result.GetDisplayName() +
-                                             (Result == Enums.Result.NoResult && !string.IsNullOrEmpty(NoResultReason)
-                                                 ? $"\n - {NoResultReason}"
-                                                 : string.Empty);
-
         string IHasRootEntityForAuditing.RootEntityType => RootEntities.Notification;
         string IHasRootEntityForAuditing.RootId => NotificationId.ToString();
     }

--- a/ntbs-service/Models/Enums/Result.cs
+++ b/ntbs-service/Models/Enums/Result.cs
@@ -18,7 +18,7 @@ namespace ntbs_service.Models.Enums
         [Display(Name = "Negative")]
         Negative,
         [Display(Name = "No result available")]
-        NoResult,
+        NoResultAvailable,
         // Universal
         [Display(Name = "Awaiting")]
         Awaiting
@@ -36,7 +36,7 @@ namespace ntbs_service.Models.Enums
                 case Result.ConsistentWithTbOther:
                 case Result.NotConsistentWithTb:
                     return testTypeId == (int)ManualTestTypeId.ChestXRay || testTypeId == (int)ManualTestTypeId.ChestCT;
-                case Result.NoResult:
+                case Result.NoResultAvailable:
                 case Result.Positive:
                 case Result.Negative:
                     return testTypeId != (int)ManualTestTypeId.ChestXRay && testTypeId != (int)ManualTestTypeId.ChestCT;

--- a/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/Items/ManualTestResult.cshtml.cs
@@ -160,7 +160,7 @@ namespace ntbs_service.Pages.Notifications.Edit.Items
 
         private void RemoveNoResultDescriptionIfOtherResult()
         {
-            if (TestResultForEdit.Result != Result.NoResult)
+            if (TestResultForEdit.Result != Result.NoResultAvailable)
             {
                 TestResultForEdit.NoResultReason = null;
             }

--- a/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
@@ -122,7 +122,7 @@
                             </nhs-form-group>
                         </nhs-grid-column>
                         @{
-                            var resultConditionFunctionString = $"function(value) {{ return value && value == {(int)Result.NoResult} }}";
+                            var resultConditionFunctionString = $"function(value) {{ return value && value == {(int)Result.NoResultAvailable} }}";
                         }
                         <conditional-select-wrapper :value-condition-function='@resultConditionFunctionString' ref="results" inline-template>
                             <div class="manual-test-result-container">

--- a/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
+++ b/ntbs-service/Pages/Shared/_ManualTestResultTable.cshtml
@@ -52,7 +52,12 @@
                         @result?.SampleType?.Description
                     </nhs-table-item>
                     <nhs-table-item heading-text="@Html.DisplayNameFor(_ => header.Result)">
-                        @result.ResultDisplayString
+                        @result.Result.GetDisplayName()
+                        @if (!string.IsNullOrEmpty(result.NoResultReason))
+                        {
+                            <br/>
+                            @($"- {result.NoResultReason}")
+                        }
                     </nhs-table-item>
                     @if (showEditLinks)
                     {


### PR DESCRIPTION
## Description
Realised the line wasn't breaking with \n, so now using a `<br/>` tag

## Checklist:
- [x] Automated tests are passing locally.
