### PR TITLE
Ntbs 2855 auth for load test

### DIFF
--- a/.github/workflows/run-load-tests.yml
+++ b/.github/workflows/run-load-tests.yml
@@ -1,14 +1,15 @@
 name: run load tests
 
 on:
-  schedule:
-    - cron:  '00 12 * * 0'
   workflow_dispatch:
     inputs:
       duration:
         description: 'Length of test in minutes'
         required: true
         default: '30'
+      cookie_header:
+        description: 'Cookie header from authenticated web request'
+        required: true
 
 jobs:
   run-load-tests:
@@ -29,6 +30,7 @@ jobs:
       - name: Run load tests
         env:
           LOAD_TEST_DURATION_IN_MINUTES: ${{ steps.set_duration.outputs.duration_in_minutes }}
+          COOKIE_HEADER: ${{ github.event.inputs.cookie_header }}
         run: bash gradlew gatlingRun-NtbsLoadTest
       - name: Find stats output file
         run: echo "STATS_FILE=$(find . -name 'stats.js')" >> $GITHUB_ENV

--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -13,7 +13,15 @@ Additionally, before you use the Gatling recorder, you must:
 
 ## Running the tests
 
-In order to the run tests, simply run the `bash gradlew gatlingRun-NtbsLoadTest` from Git Bash in the [gradle](gradle) directory.
+Before you can run tests, you first need to acquire authentication cookies. One way to do this is:
+
+- In a browser, visit the site that you want to run the load tests against and sign-in.
+  - It's a good idea to use a national team user for this, so that they have access to all of the records in the environment.
+- Open your browser's dev tools, and load any page on the site.
+- In the network tab, find the request you just made, and copy the value of the "cookie" header on the request.
+- Go to [Config.scala](gradle/src/gatling/scala/Config.scala) and paste the value as the default for the  `COOKIE_HEADER` environment variable (i.e. in place of `<insert cookie here>`).
+ 
+Then to run the tests, simply run the command `bash gradlew gatlingRun-NtbsLoadTest --rerun-tasks` from Git Bash in the [gradle](gradle) directory.
 
 ## Using the Gatling recorder
 

--- a/load-tests/gradle/build.gradle
+++ b/load-tests/gradle/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     // The following line allows to load io.gatling.gradle plugin and directly apply it
-    id 'io.gatling.gradle' version '3.5.1'
+    id 'io.gatling.gradle' version '3.7.2'
 }
 
 dependencies {

--- a/load-tests/gradle/src/gatling/scala/Config.scala
+++ b/load-tests/gradle/src/gatling/scala/Config.scala
@@ -1,4 +1,12 @@
+import java.net.HttpCookie;
+import scala.collection.JavaConverters._
+
 object Config {
     val urlUnderTest = "https://ntbs-load-test.e32846b1ddf0432eb63f.northeurope.aksapp.io"
-    val lengthOfTestInMinutes = sys.env.getOrElse("LOAD_TEST_DURATION_IN_MINUTES", "5").toInt
+    val lengthOfTestInMinutes = sys.env.getOrElse("LOAD_TEST_DURATION_IN_MINUTES", "1").toInt
+    val cookieHeader = sys.env.getOrElse(
+        "COOKIE_HEADER",
+        "<insert cookie here>"
+    )
+    val cookieList = cookieHeader.split(";").map(c => HttpCookie.parse(c).asScala.head)
 }

--- a/load-tests/gradle/src/gatling/scala/ScenarioBuilders/CreateOrEditScenarioBuilder.scala
+++ b/load-tests/gradle/src/gatling/scala/ScenarioBuilders/CreateOrEditScenarioBuilder.scala
@@ -2,6 +2,7 @@ import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import io.gatling.core.structure.ChainBuilder
 import io.gatling.http.check.HttpCheck
+import java.net.HttpCookie
 
 class CreateOrEditScenarioBuilder(
     protected val pageName: String,
@@ -28,7 +29,16 @@ class CreateOrEditScenarioBuilder(
     }
 
     def build(): ChainBuilder  = {
-        var action: ChainBuilder  = exec(NtbsRequestBuilder.getRequest(s"${pageName}_page", initialUrl, initialChecks)).pause(1)
+        val cookies = Config.cookieList
+        val firstCookie = cookies.head
+        val remainingCookies = cookies.tail
+
+        var action: ChainBuilder = exec(addCookie(Cookie(firstCookie.getName(), firstCookie.getValue())))
+        for (cookie <- remainingCookies) {
+            action = action.exec(addCookie(Cookie(cookie.getName(), cookie.getValue())))
+        }
+        
+        action = action.exec(NtbsRequestBuilder.getRequest(s"${pageName}_page", initialUrl, initialChecks)).pause(1)
 
         for ((endpoint, queryString) <- filters) {
             action = action.exec(NtbsRequestBuilder.getRequest(s"${pageName}_filter", s"${baseUrl}/${endpoint}?${queryString}"))

--- a/ntbs-service/deployments/load-test.yml
+++ b/ntbs-service/deployments/load-test.yml
@@ -61,8 +61,23 @@ spec:
               secretKeyRef:
                 name: load-test-connection-strings
                 key: applicationInsights
-          - name: AdOptions__UseDummyAuth
+          - name: AzureAdOptions__Enabled
             value: "true"
+          - name: AzureAdOptions__ClientId
+            valueFrom:
+              secretKeyRef:
+                name: load-test-azuread-options
+                key: clientId
+          - name: AzureAdOptions__ClientSecret
+            valueFrom:
+              secretKeyRef:
+                name: load-test-azuread-options
+                key: clientSecret
+          - name: AzureAdOptions__Authority
+            valueFrom:
+              secretKeyRef:
+                name: load-test-azuread-options
+                key: authority
           - name: MigrationConfig__NtbsEnvironment
             value: "LoadTest"
           - name: Sentry__Environment


### PR DESCRIPTION
Update the load-test environment so that it is authenticated by Azure AD.

Update the load tests so they are able to test against an authenticated environment. This involves a manual step where the user needs to authenticate with the site under test and then provide their "cookie" header to the tests.

Update the github action so that it no longer runs on a schedule (it can't because of the manual step involved) and allows the user to upload the cookie header as a parameter.