### PR TITLE
NTBS-2838 TransferRequest FilteredDropdown fix

### DIFF
--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml
@@ -15,7 +15,7 @@
     <form method="post" autocomplete="off">
         <h2> You are about to transfer this notification </h2>
         <div>
-            <filtered-dropdown filter-handler-path="FilteredCaseManagersListByTbServiceCode" :filtering-refs="['caseManagers']" inline-template>
+            <filtered-dropdown filter-handler-path="FilteredCaseManagersListByTbServiceCode" :filtering-refs="['caseManagers']" :should-filter-on-load="true" inline-template>
                 <div>
                     @{
                         var hasTbServiceCodeError = !Model.ValidationService.IsValid("TransferRequest.TbServiceCode");

--- a/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/Items/_ManualTestResult.cshtml
@@ -15,7 +15,7 @@
             <form method="post" autocomplete="off" v-on:submit="disableButton">
                 <filtered-dropdown filter-handler-path="FilteredSampleTypesForManualTestType"
                                    :filtering-refs="['sampleTypes', 'results']"
-                                   :wait-for-child-mount="false"
+                                   :should-filter-on-load="true"
                                    hide-on-empty="true"
                                    inline-template>
                     <nhs-grid-row>
@@ -178,7 +178,7 @@
                 <button ref="submitButton" id="save-test-result-button" nhs-button-type="Standard" classes="ntbsuk-button--primary">
                     Save
                 </button>
-                
+
                 @if (Model.RowId != null)
                 {
                     <button id="delete-test-result-button"

--- a/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
+++ b/ntbs-service/wwwroot/source/Components/FilteredDropdown.ts
@@ -11,10 +11,10 @@ type OptionValue = {
 const DEFAULT_SELECT_INNER_HTML = "<option value=\"\">Please select</option>";
 
 /*
- The component only works for a single select field to filter one or more other fields, 
+ The component only works for a single select field to filter one or more other fields,
  any cascading nonsense will require more specific handling.
 
- 'filteringRefs' prop is required to be an array of strings corresponding to a 
+ 'filteringRefs' prop is required to be an array of strings corresponding to a
  ref containing a select element (if ref is a vue component, requires a 'selectField' ref within that).
  Each string in the array is also an expected response-object key from the endpoint:
  see OnGetGetFilteredListsByTbService in Episode.cshtml.cs
@@ -22,10 +22,9 @@ const DEFAULT_SELECT_INNER_HTML = "<option value=\"\">Please select</option>";
  Additionally to the ref requirements above the input to drive the filtering must be within a ref
  of name 'filterContainer' containing a select element (if ref is a vue component, requires a 'selectField' ref within that).
 
- waitForChildMount is intended to be used to either trigger filtering on mount of this component,
- or if relevant to be triggered on mount of the filterContainer's vue component.
+ shouldFilterOnLoad is intended to be used to either trigger filtering on mount of this component.
 
- hideOnEmptyOptions configures whether the component should hide the dependent control if the returned list 
+ hideOnEmptyOptions configures whether the component should hide the dependent control if the returned list
  of OptionValues from the server is empty.
 */
 const FilteredDropdown = Vue.extend({
@@ -36,9 +35,9 @@ const FilteredDropdown = Vue.extend({
         filteringRefs: {
             type: Array
         },
-        waitForChildMount: {
+        shouldFilterOnLoad: {
             type: Boolean,
-            default: true
+            default: false
         },
         hideOnEmpty: {
             type: Boolean,
@@ -46,7 +45,7 @@ const FilteredDropdown = Vue.extend({
         }
     },
     mounted: function () {
-        if (!this.waitForChildMount) {
+        if (this.shouldFilterOnLoad) {
             this.filteringMounted();
         }
     },


### PR DESCRIPTION
## Description
Set `waitForChildMount` to false for the TbService/CaseManager dropdown on the transfer request creation page, meaning that the case manager list will not be populated before the TbService is selected.

## Checklist:
- [x] Automated tests are passing locally.