### PR TITLE
NTBS-2904 Fix breadcrumbs for NotificationChanges

### DIFF
--- a/ntbs-service/Pages/Notifications/NotificationChanges.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/NotificationChanges.cshtml.cs
@@ -47,6 +47,7 @@ namespace ntbs_service.Pages.Notifications
             Changes = (await _notificationChangesService.GetChangesList(NotificationId))
                 .OrderByDescending(change => change.Date);
 
+            PrepareBreadcrumbs();
             return Page();
         }
     }


### PR DESCRIPTION
## Description
Generate breadcrumbs on the `NotificationChanges` page, we weren't before for some reaon.

## Checklist:
- [x] Automated tests are passing locally.