### PR TITLE
NBTS-2838 Order Case Managers on no-JS transfer request page

### DIFF
--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -173,6 +173,7 @@ namespace ntbs_service.DataAccess
         {
             return await _context.User
                 .Where(u => u.IsCaseManager && u.IsActive)
+                .OrderBy(u => u.DisplayName)
                 .ToListAsync();
         }
 


### PR DESCRIPTION
## Description

From QA: order the case managers on the transfer request page when JavaScript is disabled by ordering it server-side.

## Checklist:
- [x] Automated tests are passing locally.