### PR TITLE
NTBS-2941: Allow regional user to accept transfer

### DIFF
--- a/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
@@ -1,0 +1,225 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Moq;
+using ntbs_service.DataAccess;
+using ntbs_service.Helpers;
+using ntbs_service.Models;
+using ntbs_service.Models.Entities;
+using ntbs_service.Models.Entities.Alerts;
+using ntbs_service.Models.Enums;
+using ntbs_service.Models.ReferenceEntities;
+using ntbs_service.Services;
+using Xunit;
+
+namespace ntbs_service_unit_tests.Services
+{
+    public class AuthorizationServiceTest
+    {
+        private readonly IAuthorizationService _authorizationService;
+        private readonly Mock<IUserService> _mockUserService;
+        private UserPermissionsFilter _userPermissionsFilter;
+        private readonly Mock<IUserHelper> _mockUserHelper;
+        private readonly Mock<INotificationRepository> _mockNotificationRepository;
+
+        public AuthorizationServiceTest()
+        {
+            _mockUserService = new Mock<IUserService>();
+            _mockNotificationRepository = new Mock<INotificationRepository>();
+            _mockUserHelper = new Mock<IUserHelper>();
+
+            _authorizationService = new AuthorizationService(
+                _mockUserService.Object,
+                _mockNotificationRepository.Object,
+                _mockUserHelper.Object);
+        }
+
+        [Fact]
+        public async Task IsUserAuthorizedToManageAlert_AllowsUserWithCorrectTbServiceToManageTransferAlert()
+        {
+            // Arrange
+            var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
+            var tbService = new TBService() {Code = "TBS0008"};
+            var testAlert = new TransferAlert()
+            {
+                NotificationId = 2, AlertType = AlertType.TransferRequest, TbServiceCode = tbService.Code
+            };
+            _mockUserHelper.Setup(uh => uh.UserIsReadOnly(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
+                .Returns(Task.FromResult((new List<TBService> { tbService }).AsEnumerable()));
+
+            // Act
+            var result = await _authorizationService.IsUserAuthorizedToManageAlert(testUser, testAlert);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsUserAuthorizedToManageAlert_DoesNotAllowUserWithoutTbServiceToManageTransferAlert()
+        {
+            // Arrange
+            var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
+            var tbService = new TBService() {Code = "TBS0008"};
+            var testAlert = new TransferAlert()
+            {
+                NotificationId = 2, AlertType = AlertType.TransferRequest, TbServiceCode = tbService.Code
+            };
+            _mockUserHelper.Setup(uh => uh.UserIsReadOnly(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
+                .Returns(Task.FromResult((new List<TBService>()).AsEnumerable()));
+
+            // Act
+            var result = await _authorizationService.IsUserAuthorizedToManageAlert(testUser, testAlert);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsUserAuthorizedToManageAlert_DoesNotAllowReadOnlyUserToManageAlert()
+        {
+            // Arrange
+            var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
+            var testAlert = new TestAlert()
+            {
+                NotificationId = 2, AlertType = AlertType.Test
+            };
+            _mockUserHelper.Setup(uh => uh.UserIsReadOnly(It.IsAny<ClaimsPrincipal>())).Returns(true);
+
+            // Act
+            var result = await _authorizationService.IsUserAuthorizedToManageAlert(testUser, testAlert);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task IsUserAuthorizedToManageAlert_AllowsUserWithCorrectTbServiceToManageNonTransferAlert()
+        {
+            // Arrange
+            var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
+            var tbService = new TBService() {Code = "TBS0008"};
+            var testAlert = new TestAlert()
+            {
+                NotificationId = 2, AlertType = AlertType.Test
+            };
+            var testNotification = new Notification{HospitalDetails = new HospitalDetails{TBServiceCode = tbService.Code}};
+            _mockUserHelper.Setup(uh => uh.UserIsReadOnly(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
+                .Returns(Task.FromResult((new List<TBService>{tbService}).AsEnumerable()));
+            _mockNotificationRepository.Setup(nr => nr.GetNotificationAsync((int)testAlert.NotificationId))
+                .Returns(Task.FromResult(testNotification));
+
+            // Act
+            var result = await _authorizationService.IsUserAuthorizedToManageAlert(testUser, testAlert);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task IsUserAuthorizedToManageAlert_DoesNotAllowUserWithoutTbServiceToManageNonTransferAlert()
+        {
+            // Arrange
+            var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
+            var tbService = new TBService() {Code = "TBS0008"};
+            var testAlert = new TestAlert()
+            {
+                NotificationId = 2, AlertType = AlertType.Test
+            };
+            var testNotification = new Notification{HospitalDetails = new HospitalDetails{TBServiceCode = "TBS1111"}};
+            _mockUserHelper.Setup(uh => uh.UserIsReadOnly(It.IsAny<ClaimsPrincipal>())).Returns(false);
+            _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
+                .Returns(Task.FromResult((new List<TBService> {tbService}).AsEnumerable()));
+            _mockNotificationRepository.Setup(nr => nr.GetNotificationAsync((int)testAlert.NotificationId))
+                .Returns(Task.FromResult(testNotification));
+
+            // Act
+            var result = await _authorizationService.IsUserAuthorizedToManageAlert(testUser, testAlert);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData(UserType.NhsUser)]
+        [InlineData(UserType.PheUser)]
+        [InlineData(UserType.NationalTeam)]
+        public async Task FilterAlertsForUser_FiltersByTheUsersTbServicesForAllUserTypes(UserType userType)
+        {
+            // Arrange
+            var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
+            var tbService = new TBService() {Code = "TBS0008"};
+            var alertToExpect = new AlertWithTbServiceForDisplay()
+            {
+                AlertId = 1, NotificationId = 2, AlertType = AlertType.Test, TbServiceCode = tbService.Code
+            };
+            var testAlerts = new List<AlertWithTbServiceForDisplay>
+            {
+                alertToExpect,
+                new AlertWithTbServiceForDisplay()
+                {
+                    AlertId = 2, NotificationId = 3, AlertType = AlertType.Test, TbServiceCode = "TBS0DOG"
+                }
+            };
+            _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
+                .Returns(Task.FromResult((new List<TBService> {tbService}).AsEnumerable()));
+            _mockUserService.Setup(us => us.GetUserType(It.IsAny<ClaimsPrincipal>()))
+                .Returns(userType);
+
+            // Act
+            var result = await _authorizationService.FilterAlertsForUserAsync(testUser, testAlerts);
+
+            // Assert
+            Assert.Single(result);
+            Assert.Contains(alertToExpect, result);
+        }
+
+        [Fact]
+        public async Task FilterAlertsForUser_OnlyFiltersOutTransferRejectedForPheUser()
+        {
+            // Arrange
+            var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
+            var tbService = new TBService() {Code = "TBS0008"};
+            var alertsToExpect = new List<AlertWithTbServiceForDisplay>
+            {
+                new AlertWithTbServiceForDisplay()
+                {
+                    AlertId = 1,
+                    NotificationId = 2,
+                    AlertType = AlertType.TransferRequest,
+                    TbServiceCode = tbService.Code
+                },
+                new AlertWithTbServiceForDisplay()
+                {
+                    AlertId = 1,
+                    NotificationId = 2,
+                    AlertType = AlertType.Test,
+                    TbServiceCode = tbService.Code
+                }
+            };
+            var testAlerts = new List<AlertWithTbServiceForDisplay>
+            {
+                new AlertWithTbServiceForDisplay()
+                {
+                    AlertId = 2, NotificationId = 3, AlertType = AlertType.TransferRejected, TbServiceCode = tbService.Code
+                }
+            };
+            testAlerts = testAlerts.Concat(alertsToExpect).ToList();
+            _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
+                .Returns(Task.FromResult((new List<TBService> {tbService}).AsEnumerable()));
+            _mockUserService.Setup(us => us.GetUserType(It.IsAny<ClaimsPrincipal>()))
+                .Returns(UserType.PheUser);
+
+            // Act
+            var result = await _authorizationService.FilterAlertsForUserAsync(testUser, testAlerts);
+
+            // Assert
+            Assert.Equal(alertsToExpect.Count, result.Count);
+            Assert.Contains(alertsToExpect[0], result);
+            Assert.Contains(alertsToExpect[1], result);
+        }
+    }
+}

--- a/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Moq;
 using ntbs_service.DataAccess;
 using ntbs_service.Helpers;
-using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
 using ntbs_service.Models.Enums;
@@ -19,7 +18,6 @@ namespace ntbs_service_unit_tests.Services
     {
         private readonly IAuthorizationService _authorizationService;
         private readonly Mock<IUserService> _mockUserService;
-        private UserPermissionsFilter _userPermissionsFilter;
         private readonly Mock<IUserHelper> _mockUserHelper;
         private readonly Mock<INotificationRepository> _mockNotificationRepository;
 
@@ -178,7 +176,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Fact]
-        public async Task FilterAlertsForUser_OnlyFiltersOutTransferRejectedForPheUser()
+        public async Task FilterAlertsForUser_DoesNotFilterAnyAlertsForPheUser()
         {
             // Arrange
             var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));
@@ -198,28 +196,28 @@ namespace ntbs_service_unit_tests.Services
                     NotificationId = 2,
                     AlertType = AlertType.Test,
                     TbServiceCode = tbService.Code
-                }
-            };
-            var testAlerts = new List<AlertWithTbServiceForDisplay>
-            {
+                },
                 new AlertWithTbServiceForDisplay()
                 {
-                    AlertId = 2, NotificationId = 3, AlertType = AlertType.TransferRejected, TbServiceCode = tbService.Code
+                    AlertId = 2,
+                    NotificationId = 3,
+                    AlertType = AlertType.TransferRejected,
+                    TbServiceCode = tbService.Code
                 }
             };
-            testAlerts = testAlerts.Concat(alertsToExpect).ToList();
             _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
                 .Returns(Task.FromResult((new List<TBService> {tbService}).AsEnumerable()));
             _mockUserService.Setup(us => us.GetUserType(It.IsAny<ClaimsPrincipal>()))
                 .Returns(UserType.PheUser);
 
             // Act
-            var result = await _authorizationService.FilterAlertsForUserAsync(testUser, testAlerts);
+            var result = await _authorizationService.FilterAlertsForUserAsync(testUser, alertsToExpect);
 
             // Assert
             Assert.Equal(alertsToExpect.Count, result.Count);
             Assert.Contains(alertsToExpect[0], result);
             Assert.Contains(alertsToExpect[1], result);
+            Assert.Contains(alertsToExpect[2], result);
         }
     }
 }

--- a/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/TransferRequestAction.cshtml.cs
@@ -108,6 +108,7 @@ namespace ntbs_service.Pages.Alerts
             if (AcceptTransfer == true)
             {
                 await AcceptTransferAndDismissAlertAsync();
+                await AuthorizeAndSetBannerAsync();
                 return Partial("_AcceptedTransferConfirmation", this);
             }
 

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -213,12 +213,7 @@ namespace ntbs_service.Services
         public async Task<IList<AlertWithTbServiceForDisplay>> FilterAlertsForUserAsync(ClaimsPrincipal user, IList<AlertWithTbServiceForDisplay> alerts)
         {
             var userTbServiceCodes = (await _userService.GetTbServicesAsync(user)).Select(s => s.Code).ToList();
-            var userType = _userService.GetUserType(user);
             alerts = alerts.Where(a => userTbServiceCodes.Contains(a.TbServiceCode)).ToList();
-            if (userType == UserType.PheUser)
-            {
-                alerts = alerts.Where(a => a.AlertType != AlertType.TransferRejected).ToList();
-            }
             return alerts.ToList();
         }
 

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -220,8 +220,7 @@ namespace ntbs_service.Services
             alerts = alerts.Where(a => userTbServiceCodes.Contains(a.TbServiceCode)).ToList();
             if (userType == UserType.PheUser)
             {
-                alerts = alerts.Where(a => a.AlertType != AlertType.TransferRequest &&
-                                           a.AlertType != AlertType.TransferRejected).ToList();
+                alerts = alerts.Where(a => a.AlertType != AlertType.TransferRejected).ToList();
             }
             return alerts.ToList();
         }

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -50,18 +50,15 @@ namespace ntbs_service.Services
             }
 
             var userTbServiceCodes = (await _userService.GetTbServicesAsync(user)).Select(s => s.Code).ToList();
-            var userPhecCodes = (await _userService.GetPhecCodesAsync(user)).ToList();
             if (alert is TransferAlert transferAlert)
             {
-                return userTbServiceCodes.Contains(transferAlert.TbServiceCode)
-                       || userPhecCodes.Contains(transferAlert.TbService.PHECCode);
+                return userTbServiceCodes.Contains(transferAlert.TbServiceCode);
             }
 
             if (alert.NotificationId != null)
             {
-                var notification = await _notificationRepository.GetNotificationAsync((int)alert.NotificationId);
-                return userTbServiceCodes.Contains(notification.HospitalDetails.TBServiceCode)
-                    || userPhecCodes.Contains(notification.HospitalDetails.TBService.PHECCode);
+                return userTbServiceCodes.Contains(
+                    (await _notificationRepository.GetNotificationAsync((int)alert.NotificationId)).HospitalDetails.TBServiceCode);
             }
 
             return false;

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -52,7 +52,9 @@ namespace ntbs_service.Services
             var userTbServiceCodes = (await _userService.GetTbServicesAsync(user)).Select(s => s.Code).ToList();
             if (alert is TransferAlert transferAlert)
             {
-                return userTbServiceCodes.Contains(transferAlert.TbServiceCode);
+                var userPhecCodes = (await _userService.GetPhecCodesAsync(user)).ToList();
+                return userTbServiceCodes.Contains(transferAlert.TbServiceCode)
+                       || userPhecCodes.Contains(transferAlert.TbService.PHECCode);
             }
 
             if (alert.NotificationId != null)

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -50,17 +50,18 @@ namespace ntbs_service.Services
             }
 
             var userTbServiceCodes = (await _userService.GetTbServicesAsync(user)).Select(s => s.Code).ToList();
+            var userPhecCodes = (await _userService.GetPhecCodesAsync(user)).ToList();
             if (alert is TransferAlert transferAlert)
             {
-                var userPhecCodes = (await _userService.GetPhecCodesAsync(user)).ToList();
                 return userTbServiceCodes.Contains(transferAlert.TbServiceCode)
                        || userPhecCodes.Contains(transferAlert.TbService.PHECCode);
             }
 
             if (alert.NotificationId != null)
             {
-                return userTbServiceCodes.Contains(
-                    (await _notificationRepository.GetNotificationAsync((int)alert.NotificationId)).HospitalDetails.TBServiceCode);
+                var notification = await _notificationRepository.GetNotificationAsync((int)alert.NotificationId);
+                return userTbServiceCodes.Contains(notification.HospitalDetails.TBServiceCode)
+                    || userPhecCodes.Contains(notification.HospitalDetails.TBService.PHECCode);
             }
 
             return false;


### PR DESCRIPTION
## Description
It turns out regional users are able to accept transfers, we just weren't showing the alerts to them. So the only thing that needed to change in the end was which alerts we were filtering for regional users. I've added tests for the auth service, and fixed a tiny bug to do with what the banner shows when you accept a transfer.

## Checklist:
- [x] Automated tests are passing locally.
