### PR TITLE
NTBS-2936: Add custom field which will add type to audit changes

### DIFF
--- a/EFAuditer/CustomFields.cs
+++ b/EFAuditer/CustomFields.cs
@@ -4,6 +4,7 @@
     {
         public const string AuditDetails = "AuditDetails";
         public const string AppUser = "AppUser";
+        public const string IncludeTypeInUpdate = "IncludeType";
         public const string RootEntity = "RootEntity";
         public const string RootId = "RootId";
         public const string OverrideUser = "OverrideUser";

--- a/EFAuditer/EFAuditServiceExtensions.cs
+++ b/EFAuditer/EFAuditServiceExtensions.cs
@@ -72,6 +72,10 @@ namespace EFAuditer
                         JsonSerializer.Serialize(entry.ColumnValues, Audit.Core.Configuration.JsonSettings);
                     break;
                 case "Update":
+                    if (Boolean.Parse(GetCustomKey(ev, CustomFields.IncludeTypeInUpdate) ?? "false"))
+                    {
+                        entry.Changes.Insert(0, new EventEntryChange{ColumnName = "Type", OriginalValue = entry.ColumnValues["Type"]});
+                    }
                     audit.AuditData =
                         JsonSerializer.Serialize(entry.Changes, Audit.Core.Configuration.JsonSettings);
                     break;

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using EFAuditer;
 using Microsoft.EntityFrameworkCore;
 using ntbs_service.DataAccess;
 using ntbs_service.Helpers;
@@ -242,6 +243,7 @@ namespace ntbs_service.Services
             _context.SetValues(notification.SocialRiskFactors.RiskFactorImprisonment, socialRiskFactors.RiskFactorImprisonment);
             _context.SetValues(notification.SocialRiskFactors.RiskFactorSmoking, socialRiskFactors.RiskFactorSmoking);
 
+            _context.AddAuditCustomField(CustomFields.IncludeTypeInUpdate, true);
             await _notificationRepository.SaveChangesAsync();
             await _alertService.AutoDismissAlertAsync<DataQualityDotVotAlert>(notification);
         }


### PR DESCRIPTION
## Description
After thinking about it I think this is the nicest way we have to do this. The other option would be to override the EntityType with the name of the risk factor (eg. RiskFactorSmoking instead of RiskFactorDetails) but this seems strange as the object itself isn't named "RiskFactorSmoking" so it would not play nicely with our frontend. The logs now will look like this:
![image](https://user-images.githubusercontent.com/78739678/145571412-f94cc6b4-155e-470d-beab-fbc2f704be01.png)

Where previously it would not have had the type at all.
## Checklist:
- [x] Automated tests are passing locally.
