### PR TITLE
NTBS-2940 Fix dropdown click area

### DIFF
--- a/ntbs-service/wwwroot/source/Components/NavigationWithSubmenu.ts
+++ b/ntbs-service/wwwroot/source/Components/NavigationWithSubmenu.ts
@@ -14,7 +14,7 @@ const NavigationWithSubmenu = Vue.extend({
         {
             let inputElement = (<HTMLInputElement>event.target);
             let headerLink = this.$el.getElementsByClassName('nav-with-submenu-header-link')[0];
-            if (inputElement != headerLink) {
+            if (inputElement != headerLink && !headerLink.contains(inputElement)) {
                 this.showMenu = false;
             }
         },


### PR DESCRIPTION
## Description
Fix an issue where we close submenu dropdowns straight after opening them if we click on the arrow, because this is not the `<a>` tag and we treated it like clicking off the menu, because the `<i>` arrow is a child of the `<a>` tag instead of being the tag itself.

Note that the click box for this "image" is rotated because the image is defined entirely in CSS:

![image](https://user-images.githubusercontent.com/3650110/145783975-a85a30d2-e84a-4099-9a6d-9eacc0ff66bf.png)


## Checklist:
- [x] Automated tests are passing locally.