### PR TITLE
NTBS-2854 Allow multiple specimen matches

### DIFF
--- a/ntbs-service-unit-tests/TestData/auditLogsWithMultipleMatches.csv
+++ b/ntbs-service-unit-tests/TestData/auditLogsWithMultipleMatches.csv
@@ -1,0 +1,5 @@
+﻿Id,OriginalId,EntityType,EventType,AuditData,AuditDateTime,AuditUser,AuditDetails,RootEntity,RootId
+9998,305160,Notification,Insert,"{""NotificationId"":1463,""ClusterId"":null,""CreationDate"":""2020-07-01T11:40:42.405727+00:00"",""DeletionReason"":null,""ETSID"":null,""GroupId"":null,""LTBRID"":null,""LTBRPatientId"":null,""NotificationDate"":null,""NotificationStatus"":""Draft"",""SubmissionDate"":null}",2021-09-21 06:34:26.4166667,Developer@ntbs.phe.com,Added,Notification,10
+9999,305160,Notification,Update,"[{""ColumnName"":""NotificationStatus"",""OriginalValue"":""Draft"",""NewValue"":""Notified""},{""ColumnName"":""SubmissionDate"",""NewValue"":""2020-07-01T11:45:54.0461774Z""}]",2021-09-22 06:34:26.4166667,Developer2@ntbs.phe.com,Notified,Notification,10
+10001,H123,Specimen,Match,,2021-09-26 06:34:26.4166667,SYSTEM,,Notification,10
+10002,H124,Specimen,Match,,2021-09-26 06:34:26.4166667,SYSTEM,,Notification,10

--- a/ntbs-service/Services/NotificationChangesService.cs
+++ b/ntbs-service/Services/NotificationChangesService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -212,6 +212,13 @@ namespace ntbs_service.Services
             if (group.Count == 1 && group.Single().EventType == AuditEventType.REJECT_POTENTIAL)
             {
                 return new List<AuditLog>();
+            }
+
+            // Multiple specimens may be matched to a notification at the same time by the specimen
+            // matching database. We want a change to appear for each of them on the changes page.
+            if (group.All(log => log.EventType == AuditEventType.MATCH_EVENT))
+            {
+                return group;
             }
 
             // We want this check at the end, since some of the group checks above may have a single member but still


### PR DESCRIPTION
Allow multiple simultaneous specimen matches to each appear on the notification changes page, without warning Sentry.

## Checklist:
- [x] Automated tests are passing locally.

