### PR TITLE
NTBS-2936: Only add type if exists in dictionary

### DIFF
--- a/EFAuditer/EFAuditServiceExtensions.cs
+++ b/EFAuditer/EFAuditServiceExtensions.cs
@@ -72,7 +72,7 @@ namespace EFAuditer
                         JsonSerializer.Serialize(entry.ColumnValues, Audit.Core.Configuration.JsonSettings);
                     break;
                 case "Update":
-                    if (Boolean.Parse(GetCustomKey(ev, CustomFields.IncludeTypeInUpdate) ?? "false"))
+                    if (Boolean.Parse(GetCustomKey(ev, CustomFields.IncludeTypeInUpdate) ?? "false") && entry.ColumnValues.ContainsKey("Type"))
                     {
                         entry.Changes.Insert(0, new EventEntryChange{ColumnName = "Type", OriginalValue = entry.ColumnValues["Type"]});
                     }


### PR DESCRIPTION
## Description
This was happening for the SocialRiskFactor audits, as the flag was set but the RiskFactorDetails audits are the ones which we are adding "type" for.

## Checklist:
- [x] Automated tests are passing locally.
