### PR TITLE
NTBS-2907: Case Manager changes

### DIFF
--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -42,6 +42,7 @@ namespace ntbs_integration_tests.Helpers
         public const int DRAFT_WITH_TBSERVICE = 10042;
         public const int NOTIFIED_WITH_ACTIVE_HOSPITAL = 10043;
         public const int NOTIFIED_WITH_INACTIVE_CASEMANAGER = 10111;
+        public const int NOTIFIED_WITH_ACTIVE_CASEMANAGER_NOT_IN_TB_SERVICE = 10555;
         public const int NOTIFIED_WITH_LEGACY_HOSPITAL = 10044;
         public const int MDR_DETAILS_EXIST = 10050;
 

--- a/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/HospitalDetailsPageTests.cs
@@ -454,6 +454,35 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
+        public async Task PostNotified_AddCaseManagerThatDoesNotMatchTbService_IsNotValid()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_WITH_TBSERVICE;
+            var url = GetCurrentPathForId(id);
+            var document = await GetDocumentForUrlAsync(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = id.ToString(),
+                ["HospitalDetails.CaseManagerId"] = Utilities.CASEMANAGER_ABINGDON_ID.ToString(),
+                ["HospitalDetails.HospitalId"] = Utilities.HOSPITAL_SOUTH_TYNESIDE_DISTRICT_HOSPITAL_ID,
+                ["HospitalDetails.TBServiceCode"] = Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID,
+                ["HospitalDetails.Consultant"] = "Consultant",
+                ["FormattedNotificationDate.Day"] = "1",
+                ["FormattedNotificationDate.Month"] = "1",
+                ["FormattedNotificationDate.Year"] = "2012",
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(document, formData, url);
+
+            // Assert
+            var resultDocument = await GetDocumentAsync(result);
+            result.EnsureSuccessStatusCode();
+            resultDocument.AssertErrorSummaryMessage("HospitalDetails-CaseManagerId", "case-manager", "Case Manager must be allowed for selected TB Service");
+        }
+
+        [Fact]
         public async Task PostNotified_TBServiceHasChanged_ReturnsValidationError()
         {
             // Arrange

--- a/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
+++ b/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
@@ -11,7 +11,6 @@ using ntbs_service.DataMigration.RawModels;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Properties;
-using ntbs_service.Services;
 using ntbs_service_unit_tests.TestHelpers;
 using Xunit;
 
@@ -55,7 +54,7 @@ namespace ntbs_service_unit_tests.DataMigration
         }
 
         [Fact]
-        public async Task WhenCaseManagerForLegacyNotificationWithCorrectPermissionsDoesNotExistInNtbs_AddsCaseManagerWithTbServices()
+        public async Task WhenCaseManagerForLegacyNotificationDoesNotExistInNtbs_AddsInactiveUserWhoIsNotACaseManager()
         {
             // Arrange
             GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "John", "Johnston");
@@ -70,28 +69,8 @@ namespace ntbs_service_unit_tests.DataMigration
             Assert.Equal("John", addedUser.GivenName);
             Assert.Equal("Johnston", addedUser.FamilyName);
             Assert.False(addedUser.IsActive);
-            Assert.True(addedUser.IsCaseManager);
-            Assert.Contains("TBS00TEST", addedUser.CaseManagerTbServices.Select(cmtb => cmtb.TbServiceCode));
-        }
-
-        [Fact]
-        public async Task WhenCaseManagerForLegacyNotificationWithIncorrectPermissionsDoesNotExistInNtbs_AddsCaseManagerWithNoTbServices()
-        {
-            // Arrange
-            GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "John", "Johnston");
-            await GivenLegacyUserHasPermissionsForTbServiceInHospital(CASE_MANAGER_USERNAME_1, "TBS11FAKE", HOSPITAL_GUID_1);
-
-            // Act
-            await _caseManagerImportService.ImportOrUpdateLegacyUser(CASE_MANAGER_USERNAME_1, "TBS00TEST", null, BATCH_ID);
-
-            // Assert
-            var addedUser = _context.User.SingleOrDefault();
-            Assert.NotNull(addedUser);
-            Assert.Equal("John", addedUser.GivenName);
-            Assert.Equal("Johnston", addedUser.FamilyName);
-            Assert.False(addedUser.IsActive);
-            Assert.True(addedUser.IsCaseManager);
-            Assert.DoesNotContain("TBS00TEST", addedUser.CaseManagerTbServices.Select(cmtb => cmtb.TbServiceCode));
+            Assert.False(addedUser.IsCaseManager);
+            Assert.Empty(addedUser.CaseManagerTbServices);
         }
 
         [Fact]

--- a/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
+++ b/ntbs-service-unit-tests/DataMigration/CaseManagerImportServiceTests.cs
@@ -54,7 +54,7 @@ namespace ntbs_service_unit_tests.DataMigration
         }
 
         [Fact]
-        public async Task WhenCaseManagerForLegacyNotificationDoesNotExistInNtbs_AddsInactiveUserWhoIsNotACaseManager()
+        public async Task WhenCaseManagerForLegacyNotificationDoesNotExistInNtbs_AddsInactiveUserWhoIsACaseManager()
         {
             // Arrange
             GivenLegacyUserWithName(CASE_MANAGER_USERNAME_1, "John", "Johnston");
@@ -69,7 +69,7 @@ namespace ntbs_service_unit_tests.DataMigration
             Assert.Equal("John", addedUser.GivenName);
             Assert.Equal("Johnston", addedUser.FamilyName);
             Assert.False(addedUser.IsActive);
-            Assert.False(addedUser.IsCaseManager);
+            Assert.True(addedUser.IsCaseManager);
             Assert.Empty(addedUser.CaseManagerTbServices);
         }
 

--- a/ntbs-service/DataMigration/CaseManagerImportService.cs
+++ b/ntbs-service/DataMigration/CaseManagerImportService.cs
@@ -55,10 +55,7 @@ namespace ntbs_service.DataMigration
                 ntbsCaseManager.FamilyName = legacyCaseManager.FamilyName;
                 ntbsCaseManager.DisplayName = $"{legacyCaseManager.GivenName} {legacyCaseManager.FamilyName}";
             }
-            else
-            {
-                ntbsCaseManager.IsCaseManager = true;
-            }
+            ntbsCaseManager.IsCaseManager = true;
 
             await _userRepository.AddOrUpdateUser(ntbsCaseManager, ntbsCaseManager.CaseManagerTbServices.Select(cmtb => cmtb.TbService));
 

--- a/ntbs-service/Models/Entities/HospitalDetails.cs
+++ b/ntbs-service/Models/Entities/HospitalDetails.cs
@@ -19,7 +19,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Consultant")]
         public string Consultant { get; set; }
 
-        [AssertThat("CaseManagerAllowedForTbService", ErrorMessage = ValidationMessages.CaseManagerMustBeAllowedForSelectedTbService)]
+        [AssertThat("ExistingCaseManagerId == null || CaseManagerId == ExistingCaseManagerId || CaseManagerAllowedForTbService", ErrorMessage = ValidationMessages.CaseManagerMustBeAllowedForSelectedTbService)]
         [Display(Name = "Case Manager")]
         public int? CaseManagerId { get; set; }
         public virtual User CaseManager { get; set; }
@@ -62,6 +62,9 @@ namespace ntbs_service.Models.Entities
         [NotMapped]
         [Display(Name = "Case Manager")]
         public string CaseManagerName => CaseManager?.DisplayName;
+        
+        [NotMapped]
+        public int? ExistingCaseManagerId { get; set; }
 
         string IOwnedEntityForAuditing.RootEntityType => RootEntities.Notification;
     }

--- a/ntbs-service/Models/Entities/HospitalDetails.cs
+++ b/ntbs-service/Models/Entities/HospitalDetails.cs
@@ -19,7 +19,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Consultant")]
         public string Consultant { get; set; }
 
-        [AssertThat("ExistingCaseManagerId == null || CaseManagerId == ExistingCaseManagerId || CaseManagerAllowedForTbService", ErrorMessage = ValidationMessages.CaseManagerMustBeAllowedForSelectedTbService)]
+        [AssertThat("CaseManagerId == ExistingCaseManagerId || CaseManagerAllowedForTbService", ErrorMessage = ValidationMessages.CaseManagerMustBeAllowedForSelectedTbService)]
         [Display(Name = "Case Manager")]
         public int? CaseManagerId { get; set; }
         public virtual User CaseManager { get; set; }

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
@@ -132,27 +132,16 @@
                 </nhs-form-group>
             </validate-input>
 
-            <validate-input model="HospitalDetails" property="CaseManagerId" shouldvalidatefull="@fullValidation"
-                            ref="caseManagers" inline-template>
-                @{
-                    var hasCaseManagerError = !Model.IsValid("HospitalDetails.CaseManagerId");
-                    var caseManagerGroupState = hasCaseManagerError ? Error : Standard;
-                    var caseManagerSelectErrorState = hasCaseManagerError ? SelectType.Error : SelectType.Standard;
-                }
-                <nhs-form-group nhs-form-group-type="@caseManagerGroupState" id="HospitalDetails-CaseManagerId">
-                    <label nhs-label-type="Standard" asp-for="HospitalDetails.CaseManagerId">
-                        Case manager
-                    </label>
-                    <span nhs-span-type="ErrorMessage" id="case-manager-error" has-error="@hasCaseManagerError"
-                          ref="errorField" asp-validation-for="HospitalDetails.CaseManagerId"></span>
-                    <select ref="selectField" nhs-select-type="@caseManagerSelectErrorState" asp-for="HospitalDetails.CaseManagerId"
-                            asp-items="Model.CaseManagers" v-on:change="validate">
-                        <option value="" selected>Please select</option>
-                    </select>
-                </nhs-form-group>
-            </validate-input>
+            <nhs-form-group nhs-form-group-type="Standard" id="HospitalDetails-CaseManagerId" ref="caseManagers">
+                <label nhs-label-type="Standard" asp-for="HospitalDetails.CaseManagerId">
+                    Case manager
+                </label>
+                <select ref="selectField" nhs-select-type="Standard" asp-for="HospitalDetails.CaseManagerId"
+                        asp-items="Model.CaseManagers">
+                    <option value="" selected>Please select</option>
+                </select>
+            </nhs-form-group>
             <br />
-
         </nhs-fieldset>
     </filtered-dropdown>
 

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
@@ -132,7 +132,7 @@
                 </nhs-form-group>
             </validate-input>
 
-            <govuk-warning-text id="case-manager-warning" ref="case-manager-warning" is-hidden="@(!Model.HasNonActiveCaseManager)">
+            <govuk-warning-text id="case-manager-warning" is-hidden="@(!Model.HasNonActiveCaseManager)">
                 <strong>The case manager assigned to the notification is not active, or is no longer a member of this TB service.</strong>
             </govuk-warning-text>
             @{

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml
@@ -132,11 +132,21 @@
                 </nhs-form-group>
             </validate-input>
 
-            <nhs-form-group nhs-form-group-type="Standard" id="HospitalDetails-CaseManagerId" ref="caseManagers">
+            <govuk-warning-text id="case-manager-warning" ref="case-manager-warning" is-hidden="@(!Model.HasNonActiveCaseManager)">
+                <strong>The case manager assigned to the notification is not active, or is no longer a member of this TB service.</strong>
+            </govuk-warning-text>
+            @{
+                var hasCaseManagerError = !Model.IsValid("HospitalDetails.CaseManagerId");
+                var caseManagerGroupState = hasCaseManagerError ? Error : Standard;
+                var caseManagerSelectErrorState = hasCaseManagerError ? SelectType.Error : SelectType.Standard;
+            }
+            <nhs-form-group nhs-form-group-type="@caseManagerGroupState" id="HospitalDetails-CaseManagerId" ref="caseManagers">
                 <label nhs-label-type="Standard" asp-for="HospitalDetails.CaseManagerId">
                     Case manager
                 </label>
-                <select ref="selectField" nhs-select-type="Standard" asp-for="HospitalDetails.CaseManagerId"
+                <span nhs-span-type="ErrorMessage" id="case-manager-error" has-error="@hasCaseManagerError"
+                      ref="errorField" asp-validation-for="HospitalDetails.CaseManagerId"></span>
+                <select ref="selectField" nhs-select-type="@caseManagerSelectErrorState" asp-for="HospitalDetails.CaseManagerId"
                         asp-items="Model.CaseManagers">
                     <option value="" selected>Please select</option>
                 </select>

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -133,6 +133,10 @@ namespace ntbs_service.Pages.Notifications.Edit
                 nameof(Notification),
                 Notification.NotificationDate,
                 nameof(Notification.NotificationDate));
+            if (Notification.HospitalDetails.CaseManagerId == HospitalDetails.CaseManagerId)
+            {
+                ModelState.Remove("HospitalDetails.CaseManagerId");
+            }
             if (ModelState.IsValid)
             {
                 await Service.UpdateHospitalDetailsAsync(Notification, HospitalDetails);

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -25,6 +25,7 @@ namespace ntbs_service.Pages.Notifications.Edit
         public SelectList TbServices { get; set; }
         public SelectList Hospitals { get; set; }
         public SelectList CaseManagers { get; set; }
+        public bool HasNonActiveCaseManager { get; set; }
 
         [BindProperty]
         public FormattedDate FormattedNotificationDate { get; set; }
@@ -176,9 +177,10 @@ namespace ntbs_service.Pages.Notifications.Edit
         private async Task<IList<User>> GetCaseManagerDropdownValues(IList<string> tbServiceCodes)
         {
             var caseManagersToReturn = await _referenceDataRepository.GetActiveCaseManagersByTbServiceCodesAsync(tbServiceCodes);
-            if (HospitalDetails.CaseManager?.IsActive == false)
+            if (HospitalDetails.CaseManager != null && !caseManagersToReturn.Select(u => u.Username).Contains(HospitalDetails.CaseManager.Username))
             {
                 caseManagersToReturn.Add(Notification.HospitalDetails.CaseManager);
+                HasNonActiveCaseManager = true;
             }
 
             return caseManagersToReturn;

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -134,10 +134,6 @@ namespace ntbs_service.Pages.Notifications.Edit
                 nameof(Notification),
                 Notification.NotificationDate,
                 nameof(Notification.NotificationDate));
-            if (Notification.HospitalDetails.CaseManagerId == HospitalDetails.CaseManagerId)
-            {
-                ModelState.Remove("HospitalDetails.CaseManagerId");
-            }
             if (ModelState.IsValid)
             {
                 await Service.UpdateHospitalDetailsAsync(Notification, HospitalDetails);
@@ -164,6 +160,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         private async Task SetValuesForValidation()
         {
+            HospitalDetails.ExistingCaseManagerId = Notification.HospitalDetails.CaseManagerId;
             HospitalDetails.SetValidationContext(Notification);
             ValidationService.TrySetFormattedDate(Notification, "Notification", nameof(Notification.NotificationDate), FormattedNotificationDate);
             /*

--- a/ntbs-service/Services/AdUserService.cs
+++ b/ntbs-service/Services/AdUserService.cs
@@ -37,7 +37,7 @@ namespace ntbs_service.Services
                 Log.Information($"Updating user {user.Username}");
                 user.IsActive = false;
                 user.AdGroups = null;
-                await _userRepository.AddOrUpdateUser(user, user.CaseManagerTbServices.Select(cmtb => cmtb.TbService));
+                await _userRepository.AddOrUpdateUser(user, new List<TBService>());
             }
         }
     }


### PR DESCRIPTION
## Description
To satisfy the condition of "Any case manager that is already assigned to a notification should be allowed" I have gone with the approach of removing the case manager ID from the model state if the case manager ID matches. Let me know if you think this isn't the right approach. 
Removed the case manager dropdown JS validation, all this checks is if the user is in the TB service and actually you can never pick a user that isn't in the dropdown so this isn't needed. The error span is still there for any errors after submitting, which still works.
During user sync we now remove all case manager TB services from inactive users. 
During case manager import we never add any case manager TB services, and never set inactive users as IsCaseManager.
I haven't done anything about setting IsCaseManager if a user is:
- becoming inactive
- moving from a TB service user to a regional/national user


## Checklist:
- [x] Automated tests are passing locally.
