### PR TITLE
NTBS-2905: Post mortem changes

### DIFF
--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -98,6 +98,31 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
+        public async Task PostDraft_ReturnsModelError_IfPostMortemAndStartedTreatmentBothSelected()
+        {
+            // Arrange
+            var url = GetCurrentPathForId(Utilities.DRAFT_ID);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+
+            var formData = new Dictionary<string, string>
+            {
+                ["NotificationId"] = Utilities.DRAFT_ID.ToString(),
+                ["NotificationSiteMap[PULMONARY]"] = "true",
+                ["ClinicalDetails.StartedTreatment"] = "true",
+                ["ClinicalDetails.IsPostMortem"] = "true"
+            };
+
+            // Act
+            var result = await Client.SendPostFormWithData(initialDocument, formData, url);
+
+            // Assert
+            var resultDocument = await GetDocumentAsync(result);
+
+            result.EnsureSuccessStatusCode();
+            resultDocument.AssertErrorSummaryMessage("ClinicalDetails-IsPostMortem", null, "Unable to save value of ‘Diagnosis after death’ field due to conflicting information on the record: Started treatment is set to true");
+        }
+
+        [Fact]
         public async Task PostDraft_ReturnsPageWithTabError_IfNotesContainTabs()
         {
             // Arrange

--- a/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ClinicalDetailsPageTests.cs
@@ -119,7 +119,7 @@ namespace ntbs_integration_tests.NotificationPages
             var resultDocument = await GetDocumentAsync(result);
 
             result.EnsureSuccessStatusCode();
-            resultDocument.AssertErrorSummaryMessage("ClinicalDetails-IsPostMortem", null, "Unable to save value of ‘Diagnosis after death’ field due to conflicting information on the record: Started treatment is set to true");
+            resultDocument.AssertErrorSummaryMessage("ClinicalDetails-IsPostMortem", null, ValidationMessages.IsPostMortemButStartedTreatment);
         }
 
         [Fact]

--- a/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
+++ b/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
@@ -80,10 +80,8 @@ namespace ntbs_service_unit_tests.Helpers
                 _testTreatmentEvents[1].EventDate);
 
             var expectedPeriod1 = TreatmentPeriod.CreateTransferPeriod(_testTreatmentEvents[2]);
-            expectedPeriod1.PeriodEndDate = _testTreatmentEvents[2].EventDate;
             
             var expectedPeriod2 = TreatmentPeriod.CreateTreatmentPeriod(2, _testTreatmentEvents[3]);
-            expectedPeriod2.PeriodEndDate = _testTreatmentEvents[3].EventDate;
 
             var expectedPeriod3 = TreatmentPeriod.CreatePeriodFromEvents(3,
                 new List<TreatmentEvent> {_testTreatmentEvents[5], _testTreatmentEvents[4] },
@@ -159,7 +157,6 @@ namespace ntbs_service_unit_tests.Helpers
                 testTransferEvents[1].EventDate);
 
             var expectedPeriod1 = TreatmentPeriod.CreateTransferPeriod(testTransferEvents[2]);
-            expectedPeriod1.PeriodEndDate = testTransferEvents[2].EventDate;
 
             var expectedPeriod2 = TreatmentPeriod.CreatePeriodFromEvents(2,
                 new List<TreatmentEvent> { testTransferEvents[3], testTransferEvents[4], testTransferEvents[5] }, 

--- a/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
+++ b/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
@@ -24,7 +24,8 @@ namespace ntbs_service_unit_tests.Helpers
             {
                 EventDate = new DateTime(2011, 6, 1),
                 TreatmentEventType = TreatmentEventType.TreatmentOutcome,
-                TreatmentOutcome = new TreatmentOutcome {TreatmentOutcomeType = TreatmentOutcomeType.TreatmentStopped}
+                TreatmentOutcome =
+                    new TreatmentOutcome {TreatmentOutcomeType = TreatmentOutcomeType.TreatmentStopped}
             },
             // Transfer
             new TreatmentEvent
@@ -74,25 +75,23 @@ namespace ntbs_service_unit_tests.Helpers
 
             // Assert
             Assert.Equal(5, periods.Count);
-            var expectedPeriod0 = TreatmentPeriod.CreateTreatmentPeriod(1, _testTreatmentEvents[0]);
-            expectedPeriod0.PeriodStartDate = _testTreatmentEvents[0].EventDate;
-            expectedPeriod0.TreatmentEvents.Add(_testTreatmentEvents[1]);
-            expectedPeriod0.PeriodEndDate = _testTreatmentEvents[1].EventDate;
+            var expectedPeriod0 = TreatmentPeriod.CreatePeriodFromEvents(1,
+                new List<TreatmentEvent> {_testTreatmentEvents[0], _testTreatmentEvents[1]},
+                _testTreatmentEvents[1].EventDate);
 
             var expectedPeriod1 = TreatmentPeriod.CreateTransferPeriod(_testTreatmentEvents[2]);
-            expectedPeriod1.PeriodStartDate = expectedPeriod1.PeriodEndDate = _testTreatmentEvents[2].EventDate;
+            expectedPeriod1.PeriodEndDate = _testTreatmentEvents[2].EventDate;
+            
             var expectedPeriod2 = TreatmentPeriod.CreateTreatmentPeriod(2, _testTreatmentEvents[3]);
-            expectedPeriod2.PeriodStartDate = expectedPeriod2.PeriodEndDate = _testTreatmentEvents[3].EventDate;
+            expectedPeriod2.PeriodEndDate = _testTreatmentEvents[3].EventDate;
 
-            var expectedPeriod3 = TreatmentPeriod.CreateTreatmentPeriod(3, _testTreatmentEvents[5]);
-            expectedPeriod3.PeriodStartDate = _testTreatmentEvents[5].EventDate;
-            expectedPeriod3.TreatmentEvents.Add(_testTreatmentEvents[4]);
-            expectedPeriod3.PeriodEndDate = _testTreatmentEvents[4].EventDate;
+            var expectedPeriod3 = TreatmentPeriod.CreatePeriodFromEvents(3,
+                new List<TreatmentEvent> {_testTreatmentEvents[5], _testTreatmentEvents[4] },
+                _testTreatmentEvents[4].EventDate);
 
-            var expectedPeriod4 = TreatmentPeriod.CreateTreatmentPeriod(4, _testTreatmentEvents[6]);
-            expectedPeriod4.PeriodStartDate = _testTreatmentEvents[6].EventDate;
-            expectedPeriod4.TreatmentEvents.AddRange(new[] { _testTreatmentEvents[8], _testTreatmentEvents[7] });
-            expectedPeriod4.PeriodEndDate = _testTreatmentEvents[7].EventDate;
+            var expectedPeriod4 = TreatmentPeriod.CreatePeriodFromEvents(4,
+                new List<TreatmentEvent> { _testTreatmentEvents[6], _testTreatmentEvents[8], _testTreatmentEvents[7]},
+                _testTreatmentEvents[7].EventDate);
 
             AssertTreatmentPeriodMatchesExpected(expectedPeriod0, periods[0]);
             AssertTreatmentPeriodMatchesExpected(expectedPeriod1, periods[1]);
@@ -116,7 +115,8 @@ namespace ntbs_service_unit_tests.Helpers
                 {
                     EventDate = new DateTime(2011, 1, 1),
                     TreatmentEventType = TreatmentEventType.TreatmentOutcome,
-                    TreatmentOutcome = new TreatmentOutcome {TreatmentOutcomeType = TreatmentOutcomeType.TreatmentStopped}
+                    TreatmentOutcome =
+                        new TreatmentOutcome {TreatmentOutcomeType = TreatmentOutcomeType.TreatmentStopped}
                 },
                 // Transfer
                 new TreatmentEvent
@@ -134,14 +134,12 @@ namespace ntbs_service_unit_tests.Helpers
                 },
                 new TreatmentEvent
                 {
-                    EventDate = new DateTime(2015, 1, 1),
-                    TreatmentEventType = TreatmentEventType.TransferOut
+                    EventDate = new DateTime(2015, 1, 1), TreatmentEventType = TreatmentEventType.TransferOut
                 },
                 // Episode 3
                 new TreatmentEvent
                 {
-                    EventDate = new DateTime(2016, 1, 1),
-                    TreatmentEventType = TreatmentEventType.TransferIn
+                    EventDate = new DateTime(2016, 1, 1), TreatmentEventType = TreatmentEventType.TransferIn
                 },
                 new TreatmentEvent
                 {
@@ -156,23 +154,20 @@ namespace ntbs_service_unit_tests.Helpers
 
             // Assert
             Assert.Equal(4, periods.Count);
-            var expectedPeriod0 = TreatmentPeriod.CreateTreatmentPeriod(1, testTransferEvents[0]);
-            expectedPeriod0.PeriodStartDate = testTransferEvents[0].EventDate;
-            expectedPeriod0.TreatmentEvents.Add(testTransferEvents[1]);
-            expectedPeriod0.PeriodEndDate = testTransferEvents[1].EventDate;
+            var expectedPeriod0 = TreatmentPeriod.CreatePeriodFromEvents(1,
+                new List<TreatmentEvent> { testTransferEvents[0], testTransferEvents[1] }, 
+                testTransferEvents[1].EventDate);
 
             var expectedPeriod1 = TreatmentPeriod.CreateTransferPeriod(testTransferEvents[2]);
-            expectedPeriod1.PeriodStartDate = expectedPeriod1.PeriodEndDate = testTransferEvents[2].EventDate;
+            expectedPeriod1.PeriodEndDate = testTransferEvents[2].EventDate;
 
-            var expectedPeriod2 = TreatmentPeriod.CreateTreatmentPeriod(2, testTransferEvents[3]);
-            expectedPeriod2.PeriodStartDate = testTransferEvents[3].EventDate;
-            expectedPeriod2.TreatmentEvents.AddRange(new[] { testTransferEvents[4], testTransferEvents[5] });
-            expectedPeriod2.PeriodEndDate = testTransferEvents[5].EventDate;
+            var expectedPeriod2 = TreatmentPeriod.CreatePeriodFromEvents(2,
+                new List<TreatmentEvent> { testTransferEvents[3], testTransferEvents[4], testTransferEvents[5] }, 
+                testTransferEvents[5].EventDate);
 
-            var expectedPeriod3 = TreatmentPeriod.CreateTreatmentPeriod(3, testTransferEvents[6]);
-            expectedPeriod3.PeriodStartDate = testTransferEvents[6].EventDate;
-            expectedPeriod3.TreatmentEvents.Add(testTransferEvents[7]);
-            expectedPeriod3.PeriodEndDate = testTransferEvents[7].EventDate;
+            var expectedPeriod3 = TreatmentPeriod.CreatePeriodFromEvents(3,
+                new List<TreatmentEvent> { testTransferEvents[6], testTransferEvents[7] },
+                testTransferEvents[7].EventDate);
 
             AssertTreatmentPeriodMatchesExpected(expectedPeriod0, periods[0]);
             AssertTreatmentPeriodMatchesExpected(expectedPeriod1, periods[1]);
@@ -250,24 +245,24 @@ namespace ntbs_service_unit_tests.Helpers
         {
             // Arrange
             var dateOfDeath = new DateTime(1999, 12, 12);
-            var treatmentEvents = new List<TreatmentEvent> {
-                new TreatmentEvent {
+            var treatmentEvents = new List<TreatmentEvent>
+            {
+                new TreatmentEvent
+                {
                     TreatmentEventType = TreatmentEventType.TreatmentOutcome,
-                    TreatmentOutcome = new TreatmentOutcome { TreatmentOutcomeType = TreatmentOutcomeType.Died },
+                    TreatmentOutcome = new TreatmentOutcome {TreatmentOutcomeType = TreatmentOutcomeType.Died},
                     EventDate = dateOfDeath
                 },
-                new TreatmentEvent {
-                    TreatmentEventType = TreatmentEventType.DiagnosisMade,
-                    EventDate = dateOfDeath.AddDays(15)
+                new TreatmentEvent
+                {
+                    TreatmentEventType = TreatmentEventType.DiagnosisMade, EventDate = dateOfDeath.AddDays(15)
                 }
             };
-            var expectedPeriod = TreatmentPeriod.CreatePeriodFromEvents(1, treatmentEvents);
-            expectedPeriod.PeriodStartDate = dateOfDeath;
-            expectedPeriod.PeriodEndDate = dateOfDeath;
-            
+            var expectedPeriod = TreatmentPeriod.CreatePeriodFromEvents(1, treatmentEvents, dateOfDeath);
+
             // Act
-            var periods = treatmentEvents.GroupEpisodesIntoPeriods(isPostMortem: true);
-            
+            var periods = treatmentEvents.GroupEpisodesIntoPeriods(isPostMortemWithCorrectEvents: true);
+
             // Assert
             Assert.Single(periods);
             AssertTreatmentPeriodMatchesExpected(expectedPeriod, periods.Single());

--- a/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
+++ b/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
@@ -75,16 +75,24 @@ namespace ntbs_service_unit_tests.Helpers
             // Assert
             Assert.Equal(5, periods.Count);
             var expectedPeriod0 = TreatmentPeriod.CreateTreatmentPeriod(1, _testTreatmentEvents[0]);
+            expectedPeriod0.PeriodStartDate = _testTreatmentEvents[0].EventDate;
             expectedPeriod0.TreatmentEvents.Add(_testTreatmentEvents[1]);
+            expectedPeriod0.PeriodEndDate = _testTreatmentEvents[1].EventDate;
 
             var expectedPeriod1 = TreatmentPeriod.CreateTransferPeriod(_testTreatmentEvents[2]);
+            expectedPeriod1.PeriodStartDate = expectedPeriod1.PeriodEndDate = _testTreatmentEvents[2].EventDate;
             var expectedPeriod2 = TreatmentPeriod.CreateTreatmentPeriod(2, _testTreatmentEvents[3]);
+            expectedPeriod2.PeriodStartDate = expectedPeriod2.PeriodEndDate = _testTreatmentEvents[3].EventDate;
 
             var expectedPeriod3 = TreatmentPeriod.CreateTreatmentPeriod(3, _testTreatmentEvents[5]);
+            expectedPeriod3.PeriodStartDate = _testTreatmentEvents[5].EventDate;
             expectedPeriod3.TreatmentEvents.Add(_testTreatmentEvents[4]);
+            expectedPeriod3.PeriodEndDate = _testTreatmentEvents[4].EventDate;
 
             var expectedPeriod4 = TreatmentPeriod.CreateTreatmentPeriod(4, _testTreatmentEvents[6]);
+            expectedPeriod4.PeriodStartDate = _testTreatmentEvents[6].EventDate;
             expectedPeriod4.TreatmentEvents.AddRange(new[] { _testTreatmentEvents[8], _testTreatmentEvents[7] });
+            expectedPeriod4.PeriodEndDate = _testTreatmentEvents[7].EventDate;
 
             AssertTreatmentPeriodMatchesExpected(expectedPeriod0, periods[0]);
             AssertTreatmentPeriodMatchesExpected(expectedPeriod1, periods[1]);
@@ -149,15 +157,22 @@ namespace ntbs_service_unit_tests.Helpers
             // Assert
             Assert.Equal(4, periods.Count);
             var expectedPeriod0 = TreatmentPeriod.CreateTreatmentPeriod(1, testTransferEvents[0]);
+            expectedPeriod0.PeriodStartDate = testTransferEvents[0].EventDate;
             expectedPeriod0.TreatmentEvents.Add(testTransferEvents[1]);
+            expectedPeriod0.PeriodEndDate = testTransferEvents[1].EventDate;
 
             var expectedPeriod1 = TreatmentPeriod.CreateTransferPeriod(testTransferEvents[2]);
+            expectedPeriod1.PeriodStartDate = expectedPeriod1.PeriodEndDate = testTransferEvents[2].EventDate;
 
             var expectedPeriod2 = TreatmentPeriod.CreateTreatmentPeriod(2, testTransferEvents[3]);
+            expectedPeriod2.PeriodStartDate = testTransferEvents[3].EventDate;
             expectedPeriod2.TreatmentEvents.AddRange(new[] { testTransferEvents[4], testTransferEvents[5] });
+            expectedPeriod2.PeriodEndDate = testTransferEvents[5].EventDate;
 
             var expectedPeriod3 = TreatmentPeriod.CreateTreatmentPeriod(3, testTransferEvents[6]);
+            expectedPeriod3.PeriodStartDate = testTransferEvents[6].EventDate;
             expectedPeriod3.TreatmentEvents.Add(testTransferEvents[7]);
+            expectedPeriod3.PeriodEndDate = testTransferEvents[7].EventDate;
 
             AssertTreatmentPeriodMatchesExpected(expectedPeriod0, periods[0]);
             AssertTreatmentPeriodMatchesExpected(expectedPeriod1, periods[1]);
@@ -230,11 +245,41 @@ namespace ntbs_service_unit_tests.Helpers
             );
         }
 
+        [Fact]
+        public void GroupEpisodesIntoPeriods_CorrectlyCreatesOnePeriodWithDeathDateForPostMortemCase()
+        {
+            // Arrange
+            var dateOfDeath = new DateTime(1999, 12, 12);
+            var treatmentEvents = new List<TreatmentEvent> {
+                new TreatmentEvent {
+                    TreatmentEventType = TreatmentEventType.TreatmentOutcome,
+                    TreatmentOutcome = new TreatmentOutcome { TreatmentOutcomeType = TreatmentOutcomeType.Died },
+                    EventDate = dateOfDeath
+                },
+                new TreatmentEvent {
+                    TreatmentEventType = TreatmentEventType.DiagnosisMade,
+                    EventDate = dateOfDeath.AddDays(15)
+                }
+            };
+            var expectedPeriod = TreatmentPeriod.CreatePeriodFromEvents(1, treatmentEvents);
+            expectedPeriod.PeriodStartDate = dateOfDeath;
+            expectedPeriod.PeriodEndDate = dateOfDeath;
+            
+            // Act
+            var periods = treatmentEvents.GroupEpisodesIntoPeriods(isPostMortem: true);
+            
+            // Assert
+            Assert.Single(periods);
+            AssertTreatmentPeriodMatchesExpected(expectedPeriod, periods.Single());
+        }
+
         private void AssertTreatmentPeriodMatchesExpected(TreatmentPeriod expected, TreatmentPeriod actual)
         {
             Assert.Equal(expected.TreatmentEvents, actual.TreatmentEvents);
             Assert.Equal(expected.PeriodNumber, actual.PeriodNumber);
             Assert.Equal(expected.IsTransfer, actual.IsTransfer);
+            Assert.Equal(expected.PeriodStartDate, actual.PeriodStartDate);
+            Assert.Equal(expected.PeriodEndDate, actual.PeriodEndDate);
         }
     }
 }

--- a/ntbs-service-unit-tests/Services/TreatmentOutcomesHelperTest.cs
+++ b/ntbs-service-unit-tests/Services/TreatmentOutcomesHelperTest.cs
@@ -538,8 +538,8 @@ namespace ntbs_service_unit_tests.Services
             Notification notification,
             TreatmentOutcomeType? expectedOutcomeAt2Years)
         {
-            var treatmentOutcomeAt1Year = TreatmentOutcomesHelper.GetTreatmentOutcomeAtXYears(notification, 2);
-            Assert.Equal(treatmentOutcomeAt1Year?.TreatmentOutcomeType, expectedOutcomeAt2Years);
+            var treatmentOutcomeAt2Years = TreatmentOutcomesHelper.GetTreatmentOutcomeAtXYears(notification, 2);
+            Assert.Equal(treatmentOutcomeAt2Years?.TreatmentOutcomeType, expectedOutcomeAt2Years);
         }
 
         [Theory, MemberData(nameof(NotificationsAndExpectedOutcomesAtYear3))]
@@ -547,8 +547,8 @@ namespace ntbs_service_unit_tests.Services
             Notification notification,
             TreatmentOutcomeType? expectedOutcomeAt3Years)
         {
-            var treatmentOutcomeAt1Year = TreatmentOutcomesHelper.GetTreatmentOutcomeAtXYears(notification, 3);
-            Assert.Equal(treatmentOutcomeAt1Year?.TreatmentOutcomeType, expectedOutcomeAt3Years);
+            var treatmentOutcomeAt3Years = TreatmentOutcomesHelper.GetTreatmentOutcomeAtXYears(notification, 3);
+            Assert.Equal(treatmentOutcomeAt3Years?.TreatmentOutcomeType, expectedOutcomeAt3Years);
         }
 
         private static Notification CreateNotificationWithNotificationEvents(int notificationId, IList<TreatmentEvent> treatmentEvents)

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -320,7 +320,7 @@ namespace ntbs_service.DataAccess
                         NotificationStatus = n.NotificationStatus,
                         DrugResistance = n.DrugResistanceProfile.DrugResistanceProfileString,
                         TreatmentEvents = n.TreatmentEvents,
-                        IsPostMortemWithCorrectEvents = (n.ClinicalDetails.IsPostMortem ?? false) && n.HasCorrectEventsForPostMortemCase
+                        IsPostMortemWithCorrectEvents = n.IsPostMortemAndHasCorrectEvents
                     })
                 .AsNoTracking()
                 .ToListAsync());

--- a/ntbs-service/DataAccess/NotificationRepository.cs
+++ b/ntbs-service/DataAccess/NotificationRepository.cs
@@ -320,6 +320,7 @@ namespace ntbs_service.DataAccess
                         NotificationStatus = n.NotificationStatus,
                         DrugResistance = n.DrugResistanceProfile.DrugResistanceProfileString,
                         TreatmentEvents = n.TreatmentEvents,
+                        IsPostMortemWithCorrectEvents = (n.ClinicalDetails.IsPostMortem ?? false) && n.HasCorrectEventsForPostMortemCase
                     })
                 .AsNoTracking()
                 .ToListAsync());

--- a/ntbs-service/Helpers/EpisodesExtensionMethods.cs
+++ b/ntbs-service/Helpers/EpisodesExtensionMethods.cs
@@ -20,15 +20,15 @@ namespace ntbs_service.Helpers
             TreatmentOutcomeType.TreatmentStopped
         };
 
-        public static List<TreatmentPeriod> GroupEpisodesIntoPeriods(this IEnumerable<TreatmentEvent> treatmentEvents, bool isPostMortem = false)
+        public static List<TreatmentPeriod> GroupEpisodesIntoPeriods(this IEnumerable<TreatmentEvent> treatmentEvents, bool isPostMortemWithCorrectEvents = false)
         {
             var treatmentPeriods = new List<TreatmentPeriod>();
             var periodNumber = 1;
 
-            if (isPostMortem)
+            if (isPostMortemWithCorrectEvents)
             {
-                var onlyPeriod = TreatmentPeriod.CreatePeriodFromEvents(periodNumber, treatmentEvents.OrderForEpisodes());
-                onlyPeriod.PeriodStartDate = onlyPeriod.PeriodEndDate = treatmentEvents.Single(te => te.TreatmentEventIsDeathEvent).EventDate;
+                var deathDate = treatmentEvents.Single(te => te.TreatmentEventIsDeathEvent).EventDate;
+                var onlyPeriod = TreatmentPeriod.CreatePeriodFromEvents(1, treatmentEvents.OrderForEpisodes(), deathDate);
                 return new List<TreatmentPeriod> { onlyPeriod };
             }
 
@@ -51,16 +51,13 @@ namespace ntbs_service.Helpers
                         periodNumber++;
                     }
 
-                    currentTreatmentPeriod.PeriodStartDate = treatmentEvent.EventDate;
-
                     treatmentPeriods.Add(currentTreatmentPeriod);
                 }
                 // Otherwise append this event to the existing period
                 else
                 {
-                    currentTreatmentPeriod.TreatmentEvents.Add(treatmentEvent);
+                    currentTreatmentPeriod.AddTreatmentEvent(treatmentEvent);
                 }
-                currentTreatmentPeriod.PeriodEndDate = treatmentEvent.EventDate;
 
                 if (treatmentEvent.IsEpisodeEndingTreatmentEvent())
                 {

--- a/ntbs-service/Helpers/NotificationErrorGenerator.cs
+++ b/ntbs-service/Helpers/NotificationErrorGenerator.cs
@@ -37,7 +37,7 @@ namespace ntbs_service.Helpers
                         case "ImmunosuppressionDetails":
                             model = typeof(ComorbidityDetails);
                             break;
-                        case "HasDeathEventForPostMortemCase":
+                        case "HasDeathEventIfPostMortemCase":
                             model = typeof(TreatmentEvent);
                             break;
                         default:

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -54,6 +54,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Has the patient started treatment?")]
         public bool? StartedTreatment { get; set; }
 
+        [AssertThat(@"IsPostMortem != true || StartedTreatment != true", ErrorMessage = ValidationMessages.IsPostMortemButStartedTreatment)]
         [Display(Name = "Was the TB diagnosis made at after death?")]
         public bool? IsPostMortem { get; set; }
 

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -54,7 +54,6 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Has the patient started treatment?")]
         public bool? StartedTreatment { get; set; }
 
-        [AssertThat(@"IsPostMortem != true || StartedTreatment != true", ErrorMessage = ValidationMessages.IsPostMortemButStartedTreatment)]
         [Display(Name = "Was the TB diagnosis made at after death?")]
         public bool? IsPostMortem { get; set; }
 

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -54,7 +54,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Has the patient started treatment?")]
         public bool? StartedTreatment { get; set; }
 
-        [Display(Name = "Was the TB diagnosis made at after death?")]
+        [Display(Name = "Was the TB diagnosis made after death?")]
         public bool? IsPostMortem { get; set; }
 
         [Display(Name = "Has the patient had a BCG vaccination?")]

--- a/ntbs-service/Models/Entities/ClinicalDetails.cs
+++ b/ntbs-service/Models/Entities/ClinicalDetails.cs
@@ -54,7 +54,7 @@ namespace ntbs_service.Models.Entities
         [Display(Name = "Has the patient started treatment?")]
         public bool? StartedTreatment { get; set; }
 
-        [Display(Name = "Was the TB diagnosis made at post-mortem?")]
+        [Display(Name = "Was the TB diagnosis made at after death?")]
         public bool? IsPostMortem { get; set; }
 
         [Display(Name = "Has the patient had a BCG vaccination?")]

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -126,8 +126,8 @@ namespace ntbs_service.Models.Entities
                                        || NotificationStatus == NotificationStatus.Closed
                                        || NotificationStatus == NotificationStatus.Legacy;
 
-        [AssertThat(@"ShouldValidateFull && HasDeathEventForPostMortemCase", ErrorMessage = ValidationMessages.DeathEventRequiredForPostMortemCase)]
-        public bool HasDeathEventForPostMortemCase =>
+        [AssertThat(@"ShouldValidateFull && HasDeathEventIfPostMortemCase", ErrorMessage = ValidationMessages.DeathEventRequiredForPostMortemCase)]
+        public bool HasDeathEventIfPostMortemCase =>
             ClinicalDetails.IsPostMortem != true
             || (TreatmentEvents != null && TreatmentEvents.Any(x => x.TreatmentEventIsDeathEvent));
 

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -126,6 +126,11 @@ namespace ntbs_service.Models.Entities
                                        || NotificationStatus == NotificationStatus.Closed
                                        || NotificationStatus == NotificationStatus.Legacy;
 
+        [AssertThat(@"ShouldValidateFull && HasDeathEventForPostMortemCase", ErrorMessage = ValidationMessages.DeathEventRequiredForPostMortemCase)]
+        public bool HasDeathEventForPostMortemCase =>
+            ClinicalDetails.IsPostMortem != true
+            || (TreatmentEvents != null && TreatmentEvents.Any(x => x.TreatmentEventIsDeathEvent));
+
         public bool HasNonPostMortemEvents => TreatmentEvents != null && TreatmentEvents
             .Any(te => te.TreatmentEventType != TreatmentEventType.DiagnosisMade && !te.TreatmentEventIsDeathEvent);
 

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -126,9 +126,7 @@ namespace ntbs_service.Models.Entities
                                        || NotificationStatus == NotificationStatus.Closed
                                        || NotificationStatus == NotificationStatus.Legacy;
 
-        [AssertThat(@"ShouldValidateFull && (ClinicalDetails.IsPostMortem != true || HasNonPostMortemEvents != true)",
-            ErrorMessage = ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch)]
-        public bool HasNonPostMortemEvents => TreatmentEvents
+        public bool HasNonPostMortemEvents => TreatmentEvents != null && TreatmentEvents
             .Any(te => te.TreatmentEventType != TreatmentEventType.DiagnosisMade && !te.TreatmentEventIsDeathEvent);
 
         public bool IsPostMortemAndHasCorrectEvents =>

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -128,11 +128,11 @@ namespace ntbs_service.Models.Entities
                                        || NotificationStatus == NotificationStatus.Legacy;
 
         [AssertThat(
-            @"ShouldValidateFull && (ClinicalDetails.IsPostMortem != true || HasCorrectEventsForPostMortemCase)",
+            @"ShouldValidateFull && (ClinicalDetails.IsPostMortem != true || IsPostMortemAndHasCorrectEvents)",
             ErrorMessage = ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch)]
-        public bool HasCorrectEventsForPostMortemCase =>
-            TreatmentEvents != null &&
-            (TreatmentEvents.Any(x => x.TreatmentEventTypeIsOutcome && x.TreatmentOutcome.TreatmentOutcomeType == TreatmentOutcomeType.Died) &&
+        public bool IsPostMortemAndHasCorrectEvents =>
+            (ClinicalDetails?.IsPostMortem ?? false) && TreatmentEvents != null &&
+            (TreatmentEvents.Any(x => x.TreatmentEventTypeIsOutcome && x.TreatmentOutcome?.TreatmentOutcomeType == TreatmentOutcomeType.Died) &&
              (TreatmentEvents.Count == 1 || (HasCorrectDiagnosisMadeEvent)));
 
         private bool HasCorrectDiagnosisMadeEvent =>

--- a/ntbs-service/Models/Entities/TreatmentEvent.cs
+++ b/ntbs-service/Models/Entities/TreatmentEvent.cs
@@ -58,7 +58,7 @@ namespace ntbs_service.Models.Entities
 
         public bool TreatmentEventTypeIsOutcome => TreatmentEventType == Enums.TreatmentEventType.TreatmentOutcome;
         public bool TreatmentEventTypeIsNotRestart => TreatmentEventType != Enums.TreatmentEventType.TreatmentRestart;
-        private bool TreatmentEventIsDeathEvent => TreatmentOutcome?.TreatmentOutcomeType == TreatmentOutcomeType.Died;
+        public bool TreatmentEventIsDeathEvent => TreatmentOutcome?.TreatmentOutcomeType == TreatmentOutcomeType.Died;
         public bool AfterNotificationDateUnlessPostMortem => EventDateAfterNotificationDate || (IsNotificationPostMortem && TreatmentEventIsDeathEvent);
         public bool EventDateAfterDob => Dob == null || EventDate >= Dob;
         private bool EventDateAfterNotificationDate => DateOfNotification == null || EventDate >= DateOfNotification;

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -67,7 +67,7 @@ namespace ntbs_service.Models
             NotificationStatusString = notification.NotificationStatus.GetDisplayName();
             NotificationDate = notification.FormattedNotificationDate;
             DrugResistance = notification.DrugResistanceProfile.DrugResistanceProfileString;
-            TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents, (notification.ClinicalDetails.IsPostMortem ?? false) && notification.HasCorrectEventsForPostMortemCase);
+            TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents, notification.IsPostMortemAndHasCorrectEvents);
             PreviousTbServiceCodes = notification.PreviousTbServices.Select(service => service.TbServiceCode);
             PreviousPhecCodes = notification.PreviousTbServices.Select(service => service.PhecCode);
             LinkedNotificationPhecCodes =

--- a/ntbs-service/Models/NotificationBannerModel.cs
+++ b/ntbs-service/Models/NotificationBannerModel.cs
@@ -67,7 +67,7 @@ namespace ntbs_service.Models
             NotificationStatusString = notification.NotificationStatus.GetDisplayName();
             NotificationDate = notification.FormattedNotificationDate;
             DrugResistance = notification.DrugResistanceProfile.DrugResistanceProfileString;
-            TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents);
+            TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents, (notification.ClinicalDetails.IsPostMortem ?? false) && notification.HasCorrectEventsForPostMortemCase);
             PreviousTbServiceCodes = notification.PreviousTbServices.Select(service => service.TbServiceCode);
             PreviousPhecCodes = notification.PreviousTbServices.Select(service => service.PhecCode);
             LinkedNotificationPhecCodes =
@@ -102,7 +102,7 @@ namespace ntbs_service.Models
             NotificationStatusString = notification.NotificationStatus.GetDisplayName();
             NotificationDate = notification.NotificationDate.ConvertToString();
             DrugResistance = notification.DrugResistance;
-            TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents);
+            TreatmentOutcome = CalculateOutcome(notification.TreatmentEvents, notification.IsPostMortemWithCorrectEvents);
             PreviousTbServiceCodes = notification.PreviousTbServiceCodes;
             PreviousPhecCodes = notification.PreviousPhecCodes;
             LinkedNotificationTbServiceCodes = notification.LinkedNotificationTbServiceCodes;
@@ -113,9 +113,11 @@ namespace ntbs_service.Models
             RedirectPath = RouteHelper.GetNotificationPath(notification.NotificationId, NotificationSubPaths.Overview);
         }
 
-        private static string CalculateOutcome(ICollection<TreatmentEvent> treatmentEvents)
+        private static string CalculateOutcome(ICollection<TreatmentEvent> treatmentEvents, bool isPostMortemWithCorrectEvents)
         {
-            return treatmentEvents.GetMostRecentTreatmentEvent()
+            return (isPostMortemWithCorrectEvents
+                    ? treatmentEvents.Single(te => te.TreatmentEventTypeIsOutcome)
+                    : treatmentEvents.GetMostRecentTreatmentEvent())
                        ?.TreatmentOutcome
                        ?.TreatmentOutcomeType.GetDisplayName() ?? "No outcome recorded";
         }

--- a/ntbs-service/Models/Projections/NotificationForBannerModel.cs
+++ b/ntbs-service/Models/Projections/NotificationForBannerModel.cs
@@ -28,6 +28,7 @@ namespace ntbs_service.Models.Projections
         public NotificationStatus NotificationStatus { get; set; }
 
         public ICollection<TreatmentEvent> TreatmentEvents { get; set; }
+        public bool IsPostMortemWithCorrectEvents { get; set; }
 
         public IEnumerable<string> PreviousTbServiceCodes { get; set; }
         public IEnumerable<string> PreviousPhecCodes { get; set; }

--- a/ntbs-service/Models/TreatmentPeriod.cs
+++ b/ntbs-service/Models/TreatmentPeriod.cs
@@ -13,7 +13,7 @@ namespace ntbs_service.Models
         public bool IsTransfer { get; }
         public List<TreatmentEvent> TreatmentEvents { get; }
         public DateTime? PeriodStartDate { get; }
-        public DateTime? PeriodEndDate { get; set; }
+        public DateTime? PeriodEndDate { get; private set; }
 
         private TreatmentPeriod(int? periodNumber, bool isTransfer, List<TreatmentEvent> treatmentEvents, DateTime? endDate = null)
         {

--- a/ntbs-service/Models/TreatmentPeriod.cs
+++ b/ntbs-service/Models/TreatmentPeriod.cs
@@ -12,14 +12,16 @@ namespace ntbs_service.Models
         public int? PeriodNumber { get; }
         public bool IsTransfer { get; }
         public List<TreatmentEvent> TreatmentEvents { get; }
-        public DateTime? PeriodStartDate { get; set; }
+        public DateTime? PeriodStartDate { get; }
         public DateTime? PeriodEndDate { get; set; }
 
-        private TreatmentPeriod(int? periodNumber, bool isTransfer, IEnumerable<TreatmentEvent> treatmentEvents)
+        private TreatmentPeriod(int? periodNumber, bool isTransfer, List<TreatmentEvent> treatmentEvents, DateTime? endDate = null)
         {
             PeriodNumber = periodNumber;
             IsTransfer = isTransfer;
-            TreatmentEvents = treatmentEvents.ToList();
+            TreatmentEvents = treatmentEvents;
+            PeriodStartDate = treatmentEvents.First().EventDate;
+            PeriodEndDate = endDate ?? treatmentEvents.Last().EventDate;
         }
 
         public static TreatmentPeriod CreateTreatmentPeriod(int? periodNumber, TreatmentEvent treatmentEvent)
@@ -32,9 +34,15 @@ namespace ntbs_service.Models
             return new TreatmentPeriod(null, true, new List<TreatmentEvent> { treatmentEvent });
         }
 
-        public static TreatmentPeriod CreatePeriodFromEvents(int? periodNumber, IEnumerable<TreatmentEvent> treatmentEvents)
+        public static TreatmentPeriod CreatePeriodFromEvents(int? periodNumber, IEnumerable<TreatmentEvent> treatmentEvents, DateTime? endDate = null)
         {
-            return new TreatmentPeriod(periodNumber, true, treatmentEvents);
+            return new TreatmentPeriod(periodNumber, false, treatmentEvents.ToList(), endDate);
+        }
+
+        public void AddTreatmentEvent(TreatmentEvent treatmentEvent)
+        {
+            TreatmentEvents.Add(treatmentEvent);
+            PeriodEndDate = treatmentEvent.EventDate;
         }
     }
 }

--- a/ntbs-service/Models/TreatmentPeriod.cs
+++ b/ntbs-service/Models/TreatmentPeriod.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 using ntbs_service.Models.Entities;
 
 namespace ntbs_service.Models
@@ -10,22 +12,29 @@ namespace ntbs_service.Models
         public int? PeriodNumber { get; }
         public bool IsTransfer { get; }
         public List<TreatmentEvent> TreatmentEvents { get; }
+        public DateTime? PeriodStartDate { get; set; }
+        public DateTime? PeriodEndDate { get; set; }
 
-        private TreatmentPeriod(int? periodNumber, bool isTransfer, TreatmentEvent treatmentEvent)
+        private TreatmentPeriod(int? periodNumber, bool isTransfer, IEnumerable<TreatmentEvent> treatmentEvents)
         {
             PeriodNumber = periodNumber;
             IsTransfer = isTransfer;
-            TreatmentEvents = new List<TreatmentEvent> { treatmentEvent };
+            TreatmentEvents = treatmentEvents.ToList();
         }
 
         public static TreatmentPeriod CreateTreatmentPeriod(int? periodNumber, TreatmentEvent treatmentEvent)
         {
-            return new TreatmentPeriod(periodNumber, false, treatmentEvent);
+            return new TreatmentPeriod(periodNumber, false, new List<TreatmentEvent> { treatmentEvent });
         }
 
         public static TreatmentPeriod CreateTransferPeriod(TreatmentEvent treatmentEvent)
         {
-            return new TreatmentPeriod(null, true, treatmentEvent);
+            return new TreatmentPeriod(null, true, new List<TreatmentEvent> { treatmentEvent });
+        }
+
+        public static TreatmentPeriod CreatePeriodFromEvents(int? periodNumber, IEnumerable<TreatmentEvent> treatmentEvents)
+        {
+            return new TreatmentPeriod(periodNumber, true, treatmentEvents);
         }
     }
 }

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -58,9 +58,9 @@
         public const string MDRCantChange = "You cannot change the value of this field because an MDR Enhanced Surveillance Questionnaire exists. Please contact NTBS@phe.gov.uk";
         public const string MDRDuration = "Please enter a whole number of months, or a range, for example, 12, 12-18 or 24+";
         public const string IsPostMortemButStartedTreatment =
-            "Unable to save value of ‘Diagnosis after death’ field due to conflicting information on the record: Started treatment is set to true";
+            "Unable to save value of 'Diagnosis after death' field due to conflicting information on the record: The patient has started treatment";
         public const string IsPostMortemButTreatmentEventsDoNotMatch =
-            "Unable to save value of ‘Diagnosis after death’ field due to conflicting information on the record: Treatment events indicate otherwise";
+            "Unable to save value of 'Diagnosis after death' field due to conflicting information on the record: When diagnosis occurs after death the only allowed treatment events are the diagnosis and the outcome";
 
         #endregion
 

--- a/ntbs-service/Models/Validations/ValidationHelper.cs
+++ b/ntbs-service/Models/Validations/ValidationHelper.cs
@@ -57,6 +57,11 @@
         public const string ValidTreatmentOptions = "Short course and MDR treatment cannot both be true";
         public const string MDRCantChange = "You cannot change the value of this field because an MDR Enhanced Surveillance Questionnaire exists. Please contact NTBS@phe.gov.uk";
         public const string MDRDuration = "Please enter a whole number of months, or a range, for example, 12, 12-18 or 24+";
+        public const string IsPostMortemButStartedTreatment =
+            "Unable to save value of ‘Diagnosis after death’ field due to conflicting information on the record: Started treatment is set to true";
+        public const string IsPostMortemButTreatmentEventsDoNotMatch =
+            "Unable to save value of ‘Diagnosis after death’ field due to conflicting information on the record: Treatment events indicate otherwise";
+
         #endregion
 
         #region Test Results

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -174,20 +174,7 @@ namespace ntbs_service.Pages.Notifications.Edit
                 ModelState.AddModelError("ClinicalDetails.IsMDRTreatment", ValidationMessages.MDRCantChange);
             }
 
-            if (Notification.NotificationStatus == NotificationStatus.Notified
-                && ClinicalDetails.IsPostMortem == true
-                && Notification.ClinicalDetails.IsPostMortem != true)
-            {
-                if (Notification.HasNonPostMortemEvents)
-                {
-                    ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch);
-                }
-
-                if (ClinicalDetails.StartedTreatment == true)
-                {
-                     ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButStartedTreatment);
-                }
-            }
+            AddPostMortemErrorsIfApplicable();
 
             if (ModelState.IsValid)
             {
@@ -197,6 +184,25 @@ namespace ntbs_service.Pages.Notifications.Edit
                 if (mdrChanged)
                 {
                     await _enhancedSurveillanceAlertsService.CreateOrDismissMdrAlert(Notification);
+                }
+            }
+        }
+
+        private void AddPostMortemErrorsIfApplicable()
+        {
+            // Only validate post mortem if a notified case is changing to post mortem, or draft is post mortem
+            if (ClinicalDetails.IsPostMortem == true
+                && (Notification.NotificationStatus == NotificationStatus.Notified && Notification.ClinicalDetails.IsPostMortem != true)
+                || Notification.NotificationStatus == NotificationStatus.Draft)
+            {
+                if (Notification.HasNonPostMortemEvents)
+                {
+                    ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch);
+                }
+
+                if (ClinicalDetails.StartedTreatment == true)
+                {
+                    ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButStartedTreatment);
                 }
             }
         }

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -174,9 +174,17 @@ namespace ntbs_service.Pages.Notifications.Edit
                 ModelState.AddModelError("ClinicalDetails.IsMDRTreatment", ValidationMessages.MDRCantChange);
             }
 
-            if (ClinicalDetails.IsPostMortem == true && Notification.HasNonPostMortemEvents)
+            if (ClinicalDetails.IsPostMortem == true && Notification.ClinicalDetails.IsPostMortem != true)
             {
-                ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch);
+                if (Notification.HasNonPostMortemEvents)
+                {
+                    ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch);
+                }
+
+                if (ClinicalDetails.StartedTreatment == true)
+                {
+                     ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButStartedTreatment);
+                }
             }
 
             if (ModelState.IsValid)

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -190,7 +190,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         private void AddPostMortemErrorsIfApplicable()
         {
-            // Only validate post mortem if a notified case is changing to post mortem, or draft is post mortem
+            // Only validate if a case is changing to post mortem
             if (ClinicalDetails.IsPostMortem == true && Notification.ClinicalDetails.IsPostMortem != true)
             {
                 if (Notification.HasNonPostMortemEvents)

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -174,17 +174,9 @@ namespace ntbs_service.Pages.Notifications.Edit
                 ModelState.AddModelError("ClinicalDetails.IsMDRTreatment", ValidationMessages.MDRCantChange);
             }
 
-            if ((ClinicalDetails.IsPostMortem ?? false))
+            if (ClinicalDetails.IsPostMortem == true && Notification.HasNonPostMortemEvents)
             {
-                if (ClinicalDetails.StartedTreatment ?? false)
-                {
-                    ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButStartedTreatment);
-                }
-
-                if (HasNonPostMortemTreatmentEvents())
-                {
-                    ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch);
-                }
+                ModelState.AddModelError("ClinicalDetails.IsPostMortem", ValidationMessages.IsPostMortemButTreatmentEventsDoNotMatch);
             }
 
             if (ModelState.IsValid)
@@ -197,13 +189,6 @@ namespace ntbs_service.Pages.Notifications.Edit
                     await _enhancedSurveillanceAlertsService.CreateOrDismissMdrAlert(Notification);
                 }
             }
-        }
-
-        private bool HasNonPostMortemTreatmentEvents()
-        {
-            return Notification.TreatmentEvents
-                .Any(te => te.TreatmentEventType != TreatmentEventType.DiagnosisMade
-                           && (!te.TreatmentEventTypeIsOutcome || te.TreatmentOutcome.TreatmentOutcomeType != TreatmentOutcomeType.Died));
         }
 
         private void SetDatesOnClinicalDetails()

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -174,7 +174,9 @@ namespace ntbs_service.Pages.Notifications.Edit
                 ModelState.AddModelError("ClinicalDetails.IsMDRTreatment", ValidationMessages.MDRCantChange);
             }
 
-            if (ClinicalDetails.IsPostMortem == true && Notification.ClinicalDetails.IsPostMortem != true)
+            if (Notification.NotificationStatus == NotificationStatus.Notified
+                && ClinicalDetails.IsPostMortem == true
+                && Notification.ClinicalDetails.IsPostMortem != true)
             {
                 if (Notification.HasNonPostMortemEvents)
                 {

--- a/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/ClinicalDetails.cshtml.cs
@@ -191,9 +191,7 @@ namespace ntbs_service.Pages.Notifications.Edit
         private void AddPostMortemErrorsIfApplicable()
         {
             // Only validate post mortem if a notified case is changing to post mortem, or draft is post mortem
-            if (ClinicalDetails.IsPostMortem == true
-                && (Notification.NotificationStatus == NotificationStatus.Notified && Notification.ClinicalDetails.IsPostMortem != true)
-                || Notification.NotificationStatus == NotificationStatus.Draft)
+            if (ClinicalDetails.IsPostMortem == true && Notification.ClinicalDetails.IsPostMortem != true)
             {
                 if (Notification.HasNonPostMortemEvents)
                 {

--- a/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_ClinicalDetailsDates.cshtml
@@ -420,7 +420,7 @@
             </nhs-fieldset>
         </nhs-form-group>
 
-    <nhs-fieldset>
+    <nhs-fieldset id="ClinicalDetails-IsPostMortem">
         <nhs-fieldset-legend nhs-legend-size="Standard">
             <h2> @Html.DisplayNameFor(m => m.ClinicalDetails.IsPostMortem) </h2>
         </nhs-fieldset-legend>

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -69,11 +69,20 @@ namespace ntbs_service.Pages.Notifications
             }
 
             CultureAndResistance = await _cultureAndResistanceService.GetCultureAndResistanceDetailsAsync(NotificationId);
-            TreatmentPeriods = Notification.TreatmentEvents.GroupEpisodesIntoPeriods();
+
+            var treatmentEvents = FilterEventsForPostMortem();
+            TreatmentPeriods = treatmentEvents.GroupEpisodesIntoPeriods();
 
             AddDenotificationEventIfDenotified();
             CalculateTreatmentOutcomes();
             return Page();
+        }
+
+        private IEnumerable<TreatmentEvent> FilterEventsForPostMortem()
+        {
+            return (Notification.ClinicalDetails.IsPostMortem ?? false) && Notification.HasCorrectEventsForPostMortemCase
+                ? Notification.TreatmentEvents.Where(te => te.TreatmentEventTypeIsOutcome && te.TreatmentOutcome.TreatmentOutcomeType == TreatmentOutcomeType.Died)
+                : Notification.TreatmentEvents;
         }
 
         private void CalculateTreatmentOutcomes()

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -80,7 +80,7 @@ namespace ntbs_service.Pages.Notifications
 
         private IEnumerable<TreatmentEvent> FilterEventsForPostMortem()
         {
-            return (Notification.ClinicalDetails.IsPostMortem ?? false) && Notification.HasCorrectEventsForPostMortemCase
+            return Notification.IsPostMortemAndHasCorrectEvents
                 ? Notification.TreatmentEvents.Where(te => te.TreatmentEventTypeIsOutcome && te.TreatmentOutcome.TreatmentOutcomeType == TreatmentOutcomeType.Died)
                 : Notification.TreatmentEvents;
         }

--- a/ntbs-service/Pages/Notifications/Overview.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Overview.cshtml.cs
@@ -70,19 +70,11 @@ namespace ntbs_service.Pages.Notifications
 
             CultureAndResistance = await _cultureAndResistanceService.GetCultureAndResistanceDetailsAsync(NotificationId);
 
-            var treatmentEvents = FilterEventsForPostMortem();
-            TreatmentPeriods = treatmentEvents.GroupEpisodesIntoPeriods();
+            TreatmentPeriods = Notification.TreatmentEvents.GroupEpisodesIntoPeriods(Notification.IsPostMortemAndHasCorrectEvents);
 
             AddDenotificationEventIfDenotified();
             CalculateTreatmentOutcomes();
             return Page();
-        }
-
-        private IEnumerable<TreatmentEvent> FilterEventsForPostMortem()
-        {
-            return Notification.IsPostMortemAndHasCorrectEvents
-                ? Notification.TreatmentEvents.Where(te => te.TreatmentEventTypeIsOutcome && te.TreatmentOutcome.TreatmentOutcomeType == TreatmentOutcomeType.Died)
-                : Notification.TreatmentEvents;
         }
 
         private void CalculateTreatmentOutcomes()

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_ClinicalDetailsOverviewPartial.cshtml
@@ -93,7 +93,7 @@
 
     <nhs-grid-row>
         <nhs-grid-column grid-column-width="OneQuarter">
-            <div class="notification-details-label"> Postmortem diagnosis </div>
+            <div class="notification-details-label"> Diagnosis after death </div>
             <div class="cell-min-height" id="@sectionId-post-mortem"> @Model.Notification.ClinicalDetails.IsPostMortemYesNo </div>
         </nhs-grid-column>
     </nhs-grid-row>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -53,11 +53,11 @@
 
                 @if (period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
                 {
-                    <span id="@sectionId-@period.PeriodNumber-dates">@period.TreatmentEvents.First().FormattedEventDate to @period.TreatmentEvents.Last().FormattedEventDate</span>
+                    <span id="@sectionId-@period.PeriodNumber-dates">@period.PeriodStartDate.ConvertToString() to @period.PeriodEndDate.ConvertToString()</span>
                 }
                 else
                 {
-                    <span id="@sectionId-@period.PeriodNumber-dates">@period.TreatmentEvents.First().FormattedEventDate to Present</span>
+                    <span id="@sectionId-@period.PeriodNumber-dates">@period.PeriodStartDate.ConvertToString() to Present</span>
                 }
             </div>
             <nhs-table classes="nhsuk-table--reduced-font" responsive>

--- a/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
+++ b/ntbs-service/Pages/Notifications/OverviewPartials/_TreatmentEventsOverviewPartial.cshtml
@@ -51,7 +51,7 @@
                     @(period.IsTransfer ? "Transfer" :  $"Treatment period {period.PeriodNumber}")
                 </h4>
 
-                @if (period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent())
+                @if (period.TreatmentEvents.Last().IsEpisodeEndingTreatmentEvent() || Model.Notification.IsPostMortemAndHasCorrectEvents)
                 {
                     <span id="@sectionId-@period.PeriodNumber-dates">@period.PeriodStartDate.ConvertToString() to @period.PeriodEndDate.ConvertToString()</span>
                 }

--- a/ntbs-service/Services/TreatmentOutcomesHelper.cs
+++ b/ntbs-service/Services/TreatmentOutcomesHelper.cs
@@ -87,6 +87,10 @@ namespace ntbs_service.Services
             Notification notification,
             int numberOfYears)
         {
+            if ((notification.ClinicalDetails.IsPostMortem ?? false) && notification.HasCorrectEventsForPostMortemCase)
+            {
+                return notification.TreatmentEvents?.Where(te => te.TreatmentEventTypeIsOutcome);
+            }
             return notification.TreatmentEvents?.Where(t =>
                 {
                     var startDate = notification.ClinicalDetails.StartingDate;

--- a/ntbs-service/Services/TreatmentOutcomesHelper.cs
+++ b/ntbs-service/Services/TreatmentOutcomesHelper.cs
@@ -87,7 +87,7 @@ namespace ntbs_service.Services
             Notification notification,
             int numberOfYears)
         {
-            if ((notification.ClinicalDetails.IsPostMortem ?? false) && notification.HasCorrectEventsForPostMortemCase)
+            if (notification.IsPostMortemAndHasCorrectEvents && numberOfYears == 1)
             {
                 return notification.TreatmentEvents?.Where(te => te.TreatmentEventTypeIsOutcome);
             }

--- a/ntbs-service/Services/TreatmentOutcomesHelper.cs
+++ b/ntbs-service/Services/TreatmentOutcomesHelper.cs
@@ -89,6 +89,7 @@ namespace ntbs_service.Services
         {
             if (notification.IsPostMortemAndHasCorrectEvents && numberOfYears == 1)
             {
+                // We're ignoring any diagnosis events that happen after death, because they shouldn't interfere with the outcome
                 return notification.TreatmentEvents?.Where(te => te.TreatmentEventTypeIsOutcome);
             }
             return notification.TreatmentEvents?.Where(t =>

--- a/ntbs-ui-tests/Steps/AssertSteps.cs
+++ b/ntbs-ui-tests/Steps/AssertSteps.cs
@@ -364,7 +364,7 @@ namespace ntbs_ui_tests.Steps
                     "Symptom onset to treatment start", "Presentation to any health service date",
                     "Symptom onset to health service presentation", "Healthcare setting", "Presentation to TB service date",
                     "Health service to TB service presentation", "Diagnosis date", "TB service presentation to diagnosis",
-                    "Treatment start date", "Diagnosis to treatment start", "Postmortem diagnosis", "Home visit",
+                    "Treatment start date", "Diagnosis to treatment start", "Diagnosis after death", "Home visit",
                     "HIV test offered", "DOT offered", "BCG vaccination", "Enhanced case management",
                     "Planned treatment regimen", "Health Protection Team reference number", "Notes"},
                 "ContactTracing" => new [] {"Number of contacts identified for screening",


### PR DESCRIPTION
## Description
Main change is removing "HasDeathEventForPostMortemCase" as a notification property and replacing it with "IsPostMortemAndHasCorrectEvents".
This is used in a few places:
- Getting treatment events for display - only passes the death event out if true
- Getting the banner outcome - displays "Died" if true
- Getting yearly outcome - will pass only the death outcome if true, so the outcome will be died (only for the 1st year).

The validation on this property means you can't save data now which isn't consistent with post mortem data - this means the clinical details page on some notifications won't be able to be saved but [NTBS-2861](https://airelogic-nis.atlassian.net/browse/NTBS-2861) has been made to tackle this.

## Checklist:
- [x] Automated tests are passing locally.
- [x] Sanity checked new EF-generated queries for performance.
- [x] If changing content for notification overview, confirmed renders okay for print in Chrome and IE
