### PR TITLE
Ntbs 2567 net 6 upgrade

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
       - name: Set build number
         id: ntbs_build_step
         run: echo '::set-output name=NTBS_BUILD::${{ format('feature-branch-build-{0}-{1}', github.run_number, github.sha) }}'

--- a/.github/workflows/ntbs-test-and-deploy.yml
+++ b/.github/workflows/ntbs-test-and-deploy.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
       - name: Set build number
         id: ntbs_build_step
         run: echo '::set-output name=NTBS_BUILD::${{ format('build-{0}-{1}', github.run_number, github.sha) }}'

--- a/.github/workflows/ntbs-test.yml
+++ b/.github/workflows/ntbs-test.yml
@@ -10,6 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
       - name: checkout
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -14,6 +14,11 @@ jobs:
   run-ui-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup .NET 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
+
       - name: Discover public IP of runner
         id: ip
         uses: haythem/public-ip@v1.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /app
 
 # restore audit lib (in a separate layer to speed up the build)
@@ -38,7 +38,7 @@ ARG RELEASE
 RUN npm run build:prod
 
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS runtime
 
 RUN apt-get update \
     && apt-get install -y krb5-user \

--- a/EFAuditer-tests/EFAuditer-tests.csproj
+++ b/EFAuditer-tests/EFAuditer-tests.csproj
@@ -8,6 +8,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />

--- a/EFAuditer-tests/EFAuditer-tests.csproj
+++ b/EFAuditer-tests/EFAuditer-tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>EFAuditer_tests</RootNamespace>
 

--- a/EFAuditer/EFAuditer.csproj
+++ b/EFAuditer/EFAuditer.csproj
@@ -5,6 +5,14 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />

--- a/EFAuditer/EFAuditer.csproj
+++ b/EFAuditer/EFAuditer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
@@ -9,13 +9,13 @@
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.11">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/load-test-data-generation/load-test-data-generation.csproj
+++ b/load-test-data-generation/load-test-data-generation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>load_test_data_generation</RootNamespace>
     <UserSecretsId>8256234F-BCDC-4B3C-9B2F-15450C83BC66</UserSecretsId>
   </PropertyGroup>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Bogus" Version="33.1.1" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -404,8 +404,8 @@ namespace ntbs_integration_tests.Helpers
 
         public static void SetServiceCodeForNotification(NtbsContext context, int notificationId, string code)
         {
-            var notification = context.Notification.Find(notificationId);
-            notification.HospitalDetails.TBServiceCode = code;
+            var hospitalDetails = context.HospitalDetails.Find(notificationId);
+            hospitalDetails.TBServiceCode = code;
             context.SaveChanges();
         }
 

--- a/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
@@ -89,14 +89,14 @@ namespace ntbs_integration_tests.NotificationPages
                                         .CreateClientWithoutRedirects())
             {
                 EditSubPaths.ForEach(subPath =>
-               {
-                   // Act
-                   var response = client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID)).Result;
+                {
+                    // Act
+                    var response = client.GetAsync(GetPathForId(subPath, Utilities.DRAFT_ID)).Result;
 
-                   _output.WriteLine("Testing subpath {0}", subPath);
-                   // Assert
-                   Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-               });
+                    _output.WriteLine("Testing subpath {0}", subPath);
+                    // Assert
+                    Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                });
             }
         }
 

--- a/ntbs-integration-tests/ntbs-integration-tests.csproj
+++ b/ntbs-integration-tests/ntbs-integration-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>ntbs_integration_tests</RootNamespace>
 
@@ -12,10 +12,10 @@
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.11" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/ntbs-integration-tests/ntbs-integration-tests.csproj
+++ b/ntbs-integration-tests/ntbs-integration-tests.csproj
@@ -8,6 +8,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.16.1" />
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />

--- a/ntbs-service-unit-tests/Pages/HomePageTests.cs
+++ b/ntbs-service-unit-tests/Pages/HomePageTests.cs
@@ -86,27 +86,9 @@ namespace ntbs_service_unit_tests.Pages
             // Arrange
             var recents = new List<Notification>
             {
-                new Notification
-                {
-                    PatientDetails = new PatientDetails{ GivenName = "Alice", FamilyName = "Adams" },
-                    NotificationStatus = NotificationStatus.Notified,
-                    CreationDate = DateTime.Parse("2021-04-01"),
-                    NotificationDate = DateTime.Parse("2021-04-01")
-                },
-                new Notification
-                {
-                    PatientDetails = new PatientDetails{ GivenName = "Bob", FamilyName = "Baker" },
-                    NotificationStatus = NotificationStatus.Notified,
-                    CreationDate = DateTime.Parse("2021-04-15"),
-                    NotificationDate = DateTime.Parse("2021-04-30")
-                },
-                new Notification
-                {
-                    PatientDetails = new PatientDetails{ GivenName = "Charlie", FamilyName = "Cook" },
-                    NotificationStatus = NotificationStatus.Notified,
-                    CreationDate = DateTime.Parse("2021-04-30"),
-                    NotificationDate = DateTime.Parse("2021-04-15")
-                }
+                CreateNotification("Alice", "Adams", NotificationStatus.Notified, "2021-04-01", "2021-04-01"),
+                CreateNotification("Bob", "Baker", NotificationStatus.Notified, "2021-04-15", "2021-04-30"),
+                CreateNotification("Charlie", "Cook", NotificationStatus.Notified, "2021-04-30", "2021-04-15")
             };
 
             await _homePageFixture.Context.AddRangeAsync(recents);
@@ -135,24 +117,9 @@ namespace ntbs_service_unit_tests.Pages
             // Arrange
             var drafts = new List<Notification>
             {
-                new Notification
-                {
-                    PatientDetails = new PatientDetails{ GivenName = "Dave", FamilyName = "Davids" },
-                    NotificationStatus = NotificationStatus.Draft,
-                    CreationDate = DateTime.Parse("2021-04-01")
-                },
-                new Notification
-                {
-                    PatientDetails = new PatientDetails{ GivenName = "Eve", FamilyName = "Smith" },
-                    NotificationStatus = NotificationStatus.Draft,
-                    CreationDate = DateTime.Parse("2021-04-30")
-                },
-                new Notification
-                {
-                    PatientDetails = new PatientDetails{ GivenName = "Frank", FamilyName = "Jones" },
-                    NotificationStatus = NotificationStatus.Draft,
-                    CreationDate = DateTime.Parse("2021-04-15")
-                }
+                CreateNotification("Dave", "Davids", NotificationStatus.Draft, "2021-04-01"),
+                CreateNotification("Eve", "Smith", NotificationStatus.Draft, "2021-04-30"),
+                CreateNotification("Frank", "Jones", NotificationStatus.Draft, "2021-04-15")
             };
 
             await _homePageFixture.Context.AddRangeAsync(drafts);
@@ -251,6 +218,25 @@ namespace ntbs_service_unit_tests.Pages
             Assert.True(phecCodes.Count() == 1);
             Assert.True(homepageKpiDetails.Count == 1);
             Assert.True(homepageKpiDetails[0] == mockHomepageKpiWithTbService);
+        }
+
+        private static Notification CreateNotification(
+            string givenName,
+            string familyName,
+            NotificationStatus status,
+            string creationDate,
+            string notificationDate = null)
+        {
+            var notification = new Notification
+            {
+                PatientDetails = new PatientDetails { GivenName = givenName, FamilyName = familyName },
+                NotificationStatus = status,
+                CreationDate = DateTime.Parse(creationDate),
+                NotificationDate = notificationDate != null ? DateTime.Parse(notificationDate) : (DateTime?)null
+            };
+            notification.DrugResistanceProfile.Species = string.Empty;
+            notification.DrugResistanceProfile.DrugResistanceProfileString = string.Empty;
+            return notification;
         }
     }
 }

--- a/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
+++ b/ntbs-service-unit-tests/Services/NtbsSearchBuilderTest.cs
@@ -345,7 +345,8 @@ namespace ntbs_service_unit_tests.Services
                             Dob = new DateTime(1990, 1, 1),
                             PostcodeToLookup = "SW12RT"
                         },
-                    HospitalDetails = new HospitalDetails {TBServiceCode = "Ashford hospital"}
+                    HospitalDetails = new HospitalDetails {TBServiceCode = "Ashford hospital"},
+                    DrugResistanceProfile = new DrugResistanceProfile { Species = string.Empty, DrugResistanceProfileString = string.Empty }
                 },
                 new Notification
                 {
@@ -365,7 +366,8 @@ namespace ntbs_service_unit_tests.Services
                             Dob = new DateTime(1991, 1, 1),
                             PostcodeToLookup = "SW294FB"
                         },
-                    HospitalDetails = new HospitalDetails {TBServiceCode = "Not Ashford"}
+                    HospitalDetails = new HospitalDetails {TBServiceCode = "Not Ashford"},
+                    DrugResistanceProfile = new DrugResistanceProfile { Species = string.Empty, DrugResistanceProfileString = string.Empty }
                 }
             });
             context.SaveChanges();

--- a/ntbs-service-unit-tests/Services/UserServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/UserServiceTest.cs
@@ -141,7 +141,7 @@ namespace ntbs_service_unit_tests.Services
             var claim = new Claim("User", NationalTeam);
             SetupClaimMocking(claim);
             var mockTbServiceQuery = new List<TBService> { tbService }.AsQueryable().BuildMock();
-            _mockReferenceDataRepository.Setup(c => c.GetTbServicesQueryable())
+            _mockReferenceDataRepository.Setup(c => c.GetActiveTbServicesOrderedByNameQueryable())
                 .Returns(mockTbServiceQuery.Object);
             // Act
             var result = await _service.GetDefaultTbService(_mockUser.Object);

--- a/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
+++ b/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
@@ -8,6 +8,14 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />

--- a/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
+++ b/ntbs-service-unit-tests/ntbs-service-unit-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <RootNamespace>ntbs_service_unit_tests</RootNamespace>
 
@@ -11,10 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="6.0.0" />
     <PackageReference Include="MockQueryable.Moq" Version="5.0.1" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -37,6 +37,8 @@ namespace ntbs_service.DataAccess
         public virtual DbSet<Ethnicity> Ethnicity { get; set; }
         public virtual DbSet<TBService> TbService { get; set; }
         public virtual DbSet<Hospital> Hospital { get; set; }
+        public virtual DbSet<PatientDetails> Patients { get; set; }
+        public virtual DbSet<HospitalDetails> HospitalDetails { get; set; }
         public virtual DbSet<Notification> Notification { get; set; }
         public virtual DbSet<NotificationSite> NotificationSite { get; set; }
         public virtual DbSet<NotificationGroup> NotificationGroup { get; set; }

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-using Audit.EntityFramework;
+﻿using Audit.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using ntbs_service.Helpers;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Entities.Alerts;
@@ -252,29 +250,39 @@ namespace ntbs_service.DataAccess
                 // it would completely clog up any EF actions. We've used manually created migrations instead.
             });
 
+            modelBuilder.Entity<PatientDetails>(entity =>
+            {
+                entity.HasKey(pd => pd.NotificationId);
+
+                entity.HasOne(pd => pd.PostcodeLookup)
+                    .WithMany()
+                    .HasForeignKey(ns => ns.PostcodeToLookup);
+
+                entity.ToTable("Patients");
+            });
+
+            modelBuilder.Entity<HospitalDetails>(entity =>
+            {
+                entity.HasKey(pd => pd.NotificationId);
+
+                entity.HasOne(hd => hd.CaseManager);
+
+                entity.ToTable("HospitalDetails");
+            });
+
             modelBuilder.Entity<Notification>(entity =>
             {
                 entity.HasOne(n => n.Group)
                     .WithMany(g => g.Notifications)
                     .HasForeignKey(e => e.GroupId);
 
-                entity.OwnsOne(e => e.HospitalDetails,
-                    hospitalDetails =>
-                    {
-                        hospitalDetails.HasOne(e => e.CaseManager);
+                entity.HasOne(n => n.PatientDetails)
+                    .WithOne()
+                    .OnDelete(DeleteBehavior.Cascade);
 
-                        hospitalDetails.ToTable("HospitalDetails");
-                    });
-
-                entity.OwnsOne(e => e.PatientDetails,
-                    x =>
-                    {
-                        x.HasOne(pd => pd.PostcodeLookup)
-                            .WithMany()
-                            .HasForeignKey(ns => ns.PostcodeToLookup);
-
-                        x.ToTable("Patients");
-                    });
+                entity.HasOne(n => n.HospitalDetails)
+                    .WithOne()
+                    .OnDelete(DeleteBehavior.Cascade);
 
                 entity.OwnsOne(e => e.ClinicalDetails,
                     e =>

--- a/ntbs-service/DataAccess/NtbsContext.cs
+++ b/ntbs-service/DataAccess/NtbsContext.cs
@@ -267,7 +267,7 @@ namespace ntbs_service.DataAccess
             {
                 entity.HasKey(pd => pd.NotificationId);
 
-                entity.HasOne(hd => hd.CaseManager);
+                entity.HasOne(hd => hd.CaseManager).WithMany();
 
                 entity.ToTable("HospitalDetails");
             });

--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -24,7 +24,7 @@ namespace ntbs_service.DataAccess
         Task<IList<TBService>> GetTbServicesWithCaseManagersFromPhecCodeAsync(string phecCode);
         IQueryable<TBService> GetDefaultTbServicesForPheUserQueryable(IEnumerable<string> roles);
         IQueryable<TBService> GetDefaultTbServicesForNhsUserQueryable(IEnumerable<string> roles);
-        IQueryable<TBService> GetTbServicesQueryable();
+        IQueryable<TBService> GetActiveTbServicesOrderedByNameQueryable();
         Task<IList<PHEC>> GetAllPhecs();
         Task<PHEC> GetPhecByCode(string phecCode);
         Task<IList<User>> GetAllActiveCaseManagers();
@@ -95,7 +95,7 @@ namespace ntbs_service.DataAccess
 
         public async Task<IList<TBService>> GetAllTbServicesAsync()
         {
-            return await GetTbServicesQueryable().ToListAsync();
+            return await GetActiveTbServicesOrderedByNameQueryable().ToListAsync();
         }
 
         public async Task<TBService> GetTbServiceByCodeAsync(string code)
@@ -122,14 +122,14 @@ namespace ntbs_service.DataAccess
 
         public async Task<IList<TBService>> GetTbServicesFromPhecCodeAsync(string phecCode)
         {
-            return await GetTbServicesQueryable()
+            return await GetActiveTbServicesOrderedByNameQueryable()
                 .Where(s => s.PHECCode == phecCode)
                 .ToListAsync();
         }
 
         public async Task<IList<TBService>> GetTbServicesWithCaseManagersFromPhecCodeAsync(string phecCode)
         {
-            return await GetTbServicesQueryable()
+            return await GetActiveTbServicesOrderedByNameQueryable()
                 .Where(t => phecCode.Contains(t.PHECCode))
                 .Include(tb => tb.CaseManagerTbServices)
                 .ThenInclude(c => c.CaseManager)
@@ -138,22 +138,20 @@ namespace ntbs_service.DataAccess
 
         public IQueryable<TBService> GetDefaultTbServicesForPheUserQueryable(IEnumerable<string> roles)
         {
-            return GetTbServicesQueryable()
+            return GetActiveTbServicesOrderedByNameQueryable()
                 .Include(tb => tb.PHEC)
                 .Where(tb => roles.Contains(tb.PHEC.AdGroup));
         }
 
         public IQueryable<TBService> GetDefaultTbServicesForNhsUserQueryable(IEnumerable<string> roles)
         {
-            return GetTbServicesQueryable()
+            return GetActiveTbServicesOrderedByNameQueryable()
                 .Where(tb => roles.Contains(tb.ServiceAdGroup));
         }
 
-        public IQueryable<TBService> GetTbServicesQueryable()
+        public IQueryable<TBService> GetActiveTbServicesOrderedByNameQueryable()
         {
-            return _context.TbService
-                .Where(s => s.IsLegacy == false)
-                .OrderBy(s => s.Name);
+            return GetActiveTbServicesQueryable().OrderBy(s => s.Name);
         }
 
         public async Task<IList<PHEC>> GetAllPhecs()
@@ -198,7 +196,7 @@ namespace ntbs_service.DataAccess
 
         public async Task<IList<User>> GetActiveCaseManagersByTbServiceCodesAsync(IEnumerable<string> tbServiceCodes)
         {
-            return await GetTbServicesQueryable()
+            return await GetActiveTbServicesQueryable()
                 .Where(t => tbServiceCodes.Contains(t.Code))
                 .SelectMany(t => t.CaseManagerTbServices.Select(join => join.CaseManager))
                 .Where(user => user.IsCaseManager && user.IsActive)
@@ -246,7 +244,7 @@ namespace ntbs_service.DataAccess
 
         public async Task<List<string>> GetTbServiceCodesMatchingRolesAsync(IEnumerable<string> roles)
         {
-            return await GetTbServicesQueryable().Where(tb => roles.Contains(tb.ServiceAdGroup)).Select(tb => tb.Code).ToListAsync();
+            return await GetActiveTbServicesOrderedByNameQueryable().Where(tb => roles.Contains(tb.ServiceAdGroup)).Select(tb => tb.Code).ToListAsync();
         }
 
         public async Task<List<string>> GetPhecCodesMatchingRolesAsync(IEnumerable<string> roles)
@@ -335,6 +333,11 @@ namespace ntbs_service.DataAccess
             }
             var adGroups = adGroupsString.Split(",");
             return await _context.PHEC.Where(phec => adGroups.Contains(phec.AdGroup)).ToListAsync();
+        }
+
+        private IQueryable<TBService> GetActiveTbServicesQueryable()
+        {
+            return _context.TbService.Where(s => s.IsLegacy == false);
         }
     }
 }

--- a/ntbs-service/Migrations/20211223145732_UpgradeToDotNet6.Designer.cs
+++ b/ntbs-service/Migrations/20211223145732_UpgradeToDotNet6.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ntbs_service.DataAccess;
 
@@ -11,9 +12,10 @@ using ntbs_service.DataAccess;
 namespace ntbs_service.Migrations
 {
     [DbContext(typeof(NtbsContext))]
-    partial class NtbsContextModelSnapshot : ModelSnapshot
+    [Migration("20211223145732_UpgradeToDotNet6")]
+    partial class UpgradeToDotNet6
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ntbs-service/Migrations/20211223145732_UpgradeToDotNet6.cs
+++ b/ntbs-service/Migrations/20211223145732_UpgradeToDotNet6.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ntbs_service.Migrations
+{
+    public partial class UpgradeToDotNet6 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/ntbs-service/Models/Entities/HospitalDetails.cs
+++ b/ntbs-service/Models/Entities/HospitalDetails.cs
@@ -4,16 +4,16 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using EFAuditer;
 using ExpressiveAnnotations.Attributes;
-using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Models.Validations;
 
 namespace ntbs_service.Models.Entities
 {
-    [Owned]
     [Display(Name = "Hospital details")]
     public partial class HospitalDetails : ModelBase, IOwnedEntityForAuditing
     {
+        public int NotificationId { get; set; }
+
         [MaxLength(200)]
         [RegularExpression(ValidationRegexes.CharacterValidationAsciiBasic, ErrorMessage = ValidationMessages.InvalidCharacter)]
         [Display(Name = "Consultant")]

--- a/ntbs-service/Models/Entities/PatientDetails.cs
+++ b/ntbs-service/Models/Entities/PatientDetails.cs
@@ -2,17 +2,17 @@
 using System.ComponentModel.DataAnnotations;
 using EFAuditer;
 using ExpressiveAnnotations.Attributes;
-using Microsoft.EntityFrameworkCore;
 using ntbs_service.Models.Interfaces;
 using ntbs_service.Models.ReferenceEntities;
 using ntbs_service.Models.Validations;
 
 namespace ntbs_service.Models.Entities
 {
-    [Owned]
     [Display(Name = "Personal details")]
     public partial class PatientDetails : ModelBase, IHasPostcode, IOwnedEntityForAuditing
     {
+        public int NotificationId { get; set; }
+
         [RequiredIf(@"ShouldValidateFull", ErrorMessage = ValidationMessages.FieldRequired)]
         [StringLength(35)]
         [RegularExpression(ValidationRegexes.CharacterValidation, ErrorMessage = ValidationMessages.StandardStringFormat)]

--- a/ntbs-service/Models/Entities/PatientDetailsDisplay.cs
+++ b/ntbs-service/Models/Entities/PatientDetailsDisplay.cs
@@ -44,5 +44,10 @@ namespace ntbs_service.Models.Entities
 
         public string LocalAuthorityName => PostcodeLookup?.LocalAuthority?.Name;
         public string ResidencePHECName => PostcodeLookup?.LocalAuthority?.LocalAuthorityToPHEC?.PHEC?.Name;
+
+        internal PatientDetails Clone()
+        {
+            return (PatientDetails)MemberwiseClone();
+        }
     }
 }

--- a/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/HospitalDetails.cshtml.cs
@@ -160,6 +160,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         private async Task SetValuesForValidation()
         {
+            HospitalDetails.NotificationId = NotificationId;
             HospitalDetails.ExistingCaseManagerId = Notification.HospitalDetails.CaseManagerId;
             HospitalDetails.SetValidationContext(Notification);
             ValidationService.TrySetFormattedDate(Notification, "Notification", nameof(Notification.NotificationDate), FormattedNotificationDate);

--- a/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
+++ b/ntbs-service/Pages/Notifications/Edit/PatientDetails.cshtml.cs
@@ -136,6 +136,7 @@ namespace ntbs_service.Pages.Notifications.Edit
 
         protected override async Task ValidateAndSave()
         {
+            PatientDetails.NotificationId = NotificationId;
             await Service.UpdatePatientFlagsAsync(PatientDetails);
             // Remove already invalidated states from modelState as rely
             // on changes made in UpdatePatientFlags

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -342,8 +342,10 @@ namespace ntbs_service.Services
         public async Task<Notification> CreateLinkedNotificationAsync(Notification notification, ClaimsPrincipal user)
         {
             var linkedNotification = await CreateNewNotificationForUserAsync(user);
+            var defaultPatientDetails = notification.PatientDetails.Clone();
+            defaultPatientDetails.NotificationId = linkedNotification.NotificationId;
             _context.Attach(linkedNotification);
-            _context.SetValues(linkedNotification.PatientDetails, notification.PatientDetails);
+            _context.SetValues(linkedNotification.PatientDetails, defaultPatientDetails);
             await _notificationRepository.SaveChangesAsync();
 
             if (notification.GroupId != null)

--- a/ntbs-service/Services/UserService.cs
+++ b/ntbs-service/Services/UserService.cs
@@ -140,7 +140,7 @@ namespace ntbs_service.Services
             switch (type)
             {
                 case UserType.NationalTeam:
-                    return _referenceDataRepository.GetTbServicesQueryable();
+                    return _referenceDataRepository.GetActiveTbServicesOrderedByNameQueryable();
                 case UserType.NhsUser:
                     return _referenceDataRepository.GetDefaultTbServicesForNhsUserQueryable(roles);
                 default:

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>ntbs_service</RootNamespace>
@@ -18,22 +18,22 @@
     <PackageReference Include="Markdig" Version="0.26.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.Profiler.AspNetCore" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="5.0.11" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.WsFederation" Version="6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="6.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.RazorPages" Version="2.2.5" />
     <PackageReference Include="Microsoft.AspNetCore.Session" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.11">
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="5.0.11" />
-    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="5.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.SqlServer" Version="6.0.1" />
     <PackageReference Include="Microsoft.Graph" Version="4.11.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.5" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.39.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.1" />
     <PackageReference Include="morelinq" Version="3.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NHSUK.FrontEndLibrary.TagHelpers-fork" Version="1.1.4-alpha" />

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -6,6 +6,12 @@
     <RootNamespace>ntbs_service</RootNamespace>
     <UserSecretsId>3736039d-9d74-48f5-9007-015e53f0b2a1</UserSecretsId>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />
     <PackageReference Include="Dapper" Version="2.0.123" />

--- a/ntbs-ui-tests/ntbs-ui-tests.csproj
+++ b/ntbs-ui-tests/ntbs-ui-tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>ntbs_ui_tests</RootNamespace>
     <IsPackable>false</IsPackable>
     <UserSecretsId>62C1600C-4252-429E-980B-0153542954A7</UserSecretsId>
@@ -11,10 +11,10 @@
     <PackageReference Include="Audit.EntityFramework.Core" Version="19.0.1" />
     <PackageReference Include="DotNetSeleniumExtras.WaitHelpers" Version="3.11.0" />
     <PackageReference Include="Lindhart.Analyser.MissingAwaitWarning" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.11" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.11" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.11" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="Selenium.Support" Version="4.1.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.1.0" />


### PR DESCRIPTION
## Description
Upgrade to .NET 6. The most difficult thing here is that EF Core 6 did not play nicely with our data model (I'm about ~99% sure this is a bug in EF Core, rather than documented behaviour). The problem involved navigation properties on owned entities. Consequently, I've updated the context we're using so that the Hospital and Patient details are no longer owned by the Notification.

(We've experienced problems with ownership before, and it's something we want to move away from in general - see NTBS-2525 - so this is a step in the right direction).

## Checklist:
- [x] Automated tests are passing locally.
- [x] UI tests passing
