### PR TITLE
NTBS-2858: No longer split permissions into NHS/PHE (TB Service/Region)

### DIFF
--- a/ntbs-integration-tests/ContactDetailsPages/ContactDetailsPageTests.cs
+++ b/ntbs-integration-tests/ContactDetailsPages/ContactDetailsPageTests.cs
@@ -38,7 +38,7 @@ namespace ntbs_integration_tests.ContactDetailsPages
         [Fact]
         public async Task BreadcrumbForRegionPresentForRegionalUser()
         {
-            var user = TestUser.PheUserWithPermittedPhecCode;
+            var user = TestUser.RegionalUserWithPermittedPhecCode;
             var pageRoute = (RouteHelper.GetContactDetailsSubPath(user.Id, null));
             using (var client = Factory.WithUserAuth(user).CreateClientWithoutRedirects())
             {

--- a/ntbs-integration-tests/ContactDetailsPages/EditContactDetailsTests.cs
+++ b/ntbs-integration-tests/ContactDetailsPages/EditContactDetailsTests.cs
@@ -159,7 +159,7 @@ namespace ntbs_integration_tests.ContactDetailsPages
         [Fact]
         public async Task EditDetails_EditingOtherUser_IsForbiddenForNonAdmin()
         {
-            var user = TestUser.NhsUserWithNoTbServices;
+            var user = TestUser.ServiceUserWithNoTbServices;
             var pageRoute = (RouteHelper.GetContactDetailsSubPath(user.Id, ContactDetailsSubPaths.Edit));
             using (var client = Factory.WithUserAuth(user).CreateClientWithoutRedirects())
             {

--- a/ntbs-integration-tests/Helpers/TestUser.cs
+++ b/ntbs-integration-tests/Helpers/TestUser.cs
@@ -53,6 +53,7 @@ namespace ntbs_integration_tests.Helpers
             ServiceUserForAbingdonAndPermitted,
             ServiceUserWithNoTbServices,
             RegionalUserWithPermittedPhecCode,
+            UserWithServiceAndRegion,
             NationalTeamUser,
             AbingdonCaseManager,
             AbingdonCaseManager2,
@@ -88,6 +89,13 @@ namespace ntbs_integration_tests.Helpers
             "Permitted Phec",
             UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Admin", "App.Auth.NIS.NTBS.SoE" });
+
+        public static TestUser UserWithServiceAndRegion = new TestUser(
+            9988,
+            "user-service-and-region@phe.com",
+            "Service and Region",
+            UserType.ServiceOrRegionalUser,
+            new[] { "App.Auth.NIS.NTBS.SoE", "App.Auth.NIS.NTBS.Service_Abingdon" });
 
         public static TestUser NationalTeamUser = new TestUser(
             4567,

--- a/ntbs-integration-tests/Helpers/TestUser.cs
+++ b/ntbs-integration-tests/Helpers/TestUser.cs
@@ -67,7 +67,7 @@ namespace ntbs_integration_tests.Helpers
             1234,
             "abingdon@nhs.uk",
             "Abingdon Permitted",
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new[] { "App.Auth.NIS.NTBS.Service_Abingdon", "App.Auth.NIS.NTBS.Service_Ashford" },
             tbServiceCodes: new[]
             {
@@ -79,14 +79,14 @@ namespace ntbs_integration_tests.Helpers
             2345,
             "no-service@nhs.uk",
             "No Service",
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new string[] { });
 
         public static TestUser PheUserWithPermittedPhecCode = new TestUser(
             3456,
             "permitted-phec@phe.com",
             "Permitted Phec",
-            UserType.PheUser,
+            UserType.ServiceOrPhecUser,
             new[] { "App.Auth.NIS.NTBS.Admin", "App.Auth.NIS.NTBS.SoE" });
 
         public static TestUser NationalTeamUser = new TestUser(
@@ -100,7 +100,7 @@ namespace ntbs_integration_tests.Helpers
             5678,
             Utilities.CASEMANAGER_ABINGDON_EMAIL,
             "TestCase TestManager",
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new[] { "App.Auth.NIS.NTBS.Service_Abingdon" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID });
 
@@ -108,7 +108,7 @@ namespace ntbs_integration_tests.Helpers
             6789,
             Utilities.CASEMANAGER_ABINGDON_EMAIL2,
             "TestCase TestManager",
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new[] { "App.Auth.NIS.NTBS.Service_Abingdon" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID });
 
@@ -116,7 +116,7 @@ namespace ntbs_integration_tests.Helpers
             Utilities.CASEMANAGER_GATESHEAD_ID1,
             Utilities.CASEMANAGER_GATESHEAD_EMAIL1,
             Utilities.CASEMANAGER_GATESHEAD_DISPLAY_NAME1,
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID },
             tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID });
 
@@ -124,7 +124,7 @@ namespace ntbs_integration_tests.Helpers
             Utilities.CASEMANAGER_GATESHEAD_ID2,
             Utilities.CASEMANAGER_GATESHEAD_EMAIL2,
             Utilities.CASEMANAGER_GATESHEAD_DISPLAY_NAME2,
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new[] { "App.Auth.NIS.NTBS.Service_Gateshead" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID });
 
@@ -132,7 +132,7 @@ namespace ntbs_integration_tests.Helpers
             Utilities.CASEMANAGER_GATESHEAD_INACTIVE_ID,
             Utilities.CASEMANAGER_GATESHEAD_INACTIVE_EMAIL,
             Utilities.CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME,
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new[] { "App.Auth.NIS.NTBS.Service_Gateshead" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID },
             isActive: false);
@@ -148,7 +148,7 @@ namespace ntbs_integration_tests.Helpers
             7892,
             "ReadOnly@ntbs.phe.com",
             "ReadOnly UserGroup",
-            UserType.NhsUser,
+            UserType.ServiceOrPhecUser,
             new[] { "App.Auth.NIS.NTBS.Read_Only" },
             isReadOnly: true);
     }

--- a/ntbs-integration-tests/Helpers/TestUser.cs
+++ b/ntbs-integration-tests/Helpers/TestUser.cs
@@ -50,9 +50,9 @@ namespace ntbs_integration_tests.Helpers
 
         public static IEnumerable<TestUser> GetAll() => new[]
         {
-            NhsUserForAbingdonAndPermitted,
-            NhsUserWithNoTbServices,
-            PheUserWithPermittedPhecCode,
+            ServiceUserForAbingdonAndPermitted,
+            ServiceUserWithNoTbServices,
+            RegionalUserWithPermittedPhecCode,
             NationalTeamUser,
             AbingdonCaseManager,
             AbingdonCaseManager2,
@@ -63,7 +63,7 @@ namespace ntbs_integration_tests.Helpers
             ReadOnlyUser
         };
 
-        public static TestUser NhsUserForAbingdonAndPermitted = new TestUser(
+        public static TestUser ServiceUserForAbingdonAndPermitted = new TestUser(
             1234,
             "abingdon@nhs.uk",
             "Abingdon Permitted",
@@ -75,14 +75,14 @@ namespace ntbs_integration_tests.Helpers
                 Utilities.PERMITTED_SERVICE_CODE
             });
 
-        public static TestUser NhsUserWithNoTbServices = new TestUser(
+        public static TestUser ServiceUserWithNoTbServices = new TestUser(
             2345,
             "no-service@nhs.uk",
             "No Service",
             UserType.ServiceOrPhecUser,
             new string[] { });
 
-        public static TestUser PheUserWithPermittedPhecCode = new TestUser(
+        public static TestUser RegionalUserWithPermittedPhecCode = new TestUser(
             3456,
             "permitted-phec@phe.com",
             "Permitted Phec",

--- a/ntbs-integration-tests/Helpers/TestUser.cs
+++ b/ntbs-integration-tests/Helpers/TestUser.cs
@@ -67,7 +67,7 @@ namespace ntbs_integration_tests.Helpers
             1234,
             "abingdon@nhs.uk",
             "Abingdon Permitted",
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Service_Abingdon", "App.Auth.NIS.NTBS.Service_Ashford" },
             tbServiceCodes: new[]
             {
@@ -79,14 +79,14 @@ namespace ntbs_integration_tests.Helpers
             2345,
             "no-service@nhs.uk",
             "No Service",
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new string[] { });
 
         public static TestUser RegionalUserWithPermittedPhecCode = new TestUser(
             3456,
             "permitted-phec@phe.com",
             "Permitted Phec",
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Admin", "App.Auth.NIS.NTBS.SoE" });
 
         public static TestUser NationalTeamUser = new TestUser(
@@ -100,7 +100,7 @@ namespace ntbs_integration_tests.Helpers
             5678,
             Utilities.CASEMANAGER_ABINGDON_EMAIL,
             "TestCase TestManager",
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Service_Abingdon" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID });
 
@@ -108,7 +108,7 @@ namespace ntbs_integration_tests.Helpers
             6789,
             Utilities.CASEMANAGER_ABINGDON_EMAIL2,
             "TestCase TestManager",
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Service_Abingdon" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID });
 
@@ -116,7 +116,7 @@ namespace ntbs_integration_tests.Helpers
             Utilities.CASEMANAGER_GATESHEAD_ID1,
             Utilities.CASEMANAGER_GATESHEAD_EMAIL1,
             Utilities.CASEMANAGER_GATESHEAD_DISPLAY_NAME1,
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID },
             tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID });
 
@@ -124,7 +124,7 @@ namespace ntbs_integration_tests.Helpers
             Utilities.CASEMANAGER_GATESHEAD_ID2,
             Utilities.CASEMANAGER_GATESHEAD_EMAIL2,
             Utilities.CASEMANAGER_GATESHEAD_DISPLAY_NAME2,
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Service_Gateshead" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID });
 
@@ -132,7 +132,7 @@ namespace ntbs_integration_tests.Helpers
             Utilities.CASEMANAGER_GATESHEAD_INACTIVE_ID,
             Utilities.CASEMANAGER_GATESHEAD_INACTIVE_EMAIL,
             Utilities.CASEMANAGER_GATESHEAD_INACTIVE_DISPLAY_NAME,
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Service_Gateshead" },
             tbServiceCodes: new[] { Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_ID },
             isActive: false);
@@ -148,7 +148,7 @@ namespace ntbs_integration_tests.Helpers
             7892,
             "ReadOnly@ntbs.phe.com",
             "ReadOnly UserGroup",
-            UserType.ServiceOrPhecUser,
+            UserType.ServiceOrRegionalUser,
             new[] { "App.Auth.NIS.NTBS.Read_Only" },
             isReadOnly: true);
     }

--- a/ntbs-integration-tests/HomePage/HomePageTests.cs
+++ b/ntbs-integration-tests/HomePage/HomePageTests.cs
@@ -16,7 +16,7 @@ namespace ntbs_integration_tests.HomePage
         [Fact]
         public async Task DismissAlert_CorrectlyDismissesAlertAndReturnsHomePage()
         {
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .WithNotificationAndTbServiceConnected(Utilities.NOTIFIED_ID, Utilities.PERMITTED_SERVICE_CODE)
                 .CreateClientWithoutRedirects())
             {
@@ -49,9 +49,9 @@ namespace ntbs_integration_tests.HomePage
         }
 
         [Fact]
-        public async Task ShowingHomepageKpis_WhenUserIsNhsUser()
+        public async Task ShowingHomepageKpis_WhenUserIsServiceUser()
         {
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                                         .CreateClientWithoutRedirects())
             {
                 // Arrange
@@ -64,9 +64,9 @@ namespace ntbs_integration_tests.HomePage
         }
 
         [Fact]
-        public async Task ShowingHomepageKpis_WhenUserIsPheUser()
+        public async Task ShowingHomepageKpis_WhenUserIsRegionalUser()
         {
-            using (var client = Factory.WithUserAuth(TestUser.PheUserWithPermittedPhecCode)
+            using (var client = Factory.WithUserAuth(TestUser.RegionalUserWithPermittedPhecCode)
                                         .CreateClientWithoutRedirects())
             {
                 // Arrange

--- a/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
+++ b/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
@@ -164,6 +164,37 @@ namespace ntbs_integration_tests.LabResultsPage
         }
 
         [Fact]
+        public async Task ServiceAndRegionalUser_CanViewSpecimensAccordingToPermissions()
+        {
+            using (var client = Factory.WithUserAuth(TestUser.UserWithServiceAndRegion)
+                .CreateClientWithoutRedirects())
+            {
+                // Arrange
+                var expectedLabReferenceNumbers = new List<string>
+                {
+                    MockSpecimenService.MockUnmatchedSpecimenForPhec.ReferenceLaboratoryNumber,
+                    MockSpecimenService.MockUnmatchedSpecimenForTbService.ReferenceLaboratoryNumber
+                };
+
+                //Act
+                var response = await client.GetAsync(PageRoute);
+                var document = await GetDocumentAsync(response);
+
+                // Assert
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var specimenDetailsSections = document.QuerySelectorAll(".nhsuk-card--care--specimen");
+                Assert.Equal(expectedLabReferenceNumbers.Count, specimenDetailsSections.Length);
+
+                foreach (var expectedLabReferenceNumber in expectedLabReferenceNumbers)
+                {
+                    var header = document.QuerySelector($"#specimen-{expectedLabReferenceNumber}");
+                    Assert.NotNull(header);
+                }
+            }
+        }
+
+        [Fact]
         public async Task NationalTeam_CanViewSpecimensAccordingToPermissions()
         {
             using (var client = Factory.WithUserAuth(TestUser.NationalTeamUser)

--- a/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
+++ b/ntbs-integration-tests/LabResultsPage/LabResultsPageTests.cs
@@ -66,9 +66,9 @@ namespace ntbs_integration_tests.LabResultsPage
         }
 
         [Fact]
-        public async Task NhsUser_CanViewSpecimensAccordingToPermissions()
+        public async Task ServiceUser_CanViewSpecimensAccordingToPermissions()
         {
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .CreateClientWithoutRedirects())
             {
                 // Arrange
@@ -106,9 +106,9 @@ namespace ntbs_integration_tests.LabResultsPage
         }
 
         [Fact]
-        public async Task NhsUser_ShowsNoSpecimensIfNoPermissionForTbServices()
+        public async Task ServiceUser_ShowsNoSpecimensIfNoPermissionForTbServices()
         {
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserWithNoTbServices)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserWithNoTbServices)
                 .CreateClientWithoutRedirects())
             {
                 //Act
@@ -124,9 +124,9 @@ namespace ntbs_integration_tests.LabResultsPage
         }
 
         [Fact]
-        public async Task PheUser_CanViewSpecimensAccordingToPermissions()
+        public async Task RegionalUser_CanViewSpecimensAccordingToPermissions()
         {
-            using (var client = Factory.WithUserAuth(TestUser.PheUserWithPermittedPhecCode)
+            using (var client = Factory.WithUserAuth(TestUser.RegionalUserWithPermittedPhecCode)
                 .CreateClientWithoutRedirects())
             {
                 // Arrange

--- a/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/BasicEditPageTests.cs
@@ -41,10 +41,10 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public void Get_ReturnsOk_ForNhsUserWithPermission()
+        public void Get_ReturnsOk_ForServiceUserWithPermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                                         .WithNotificationAndTbServiceConnected(Utilities.DRAFT_ID, Utilities.PERMITTED_SERVICE_CODE)
                                         .CreateClientWithoutRedirects())
             {
@@ -61,10 +61,10 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public void Get_ReturnsRedirect_ForNhsUserWithoutPermission()
+        public void Get_ReturnsRedirect_ForServiceUserWithoutPermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                                         .WithNotificationAndTbServiceConnected(Utilities.DRAFT_ID, Utilities.UNPERMITTED_SERVICE_CODE)
                                         .CreateClientWithoutRedirects())
             {
@@ -81,10 +81,10 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public void Get_ReturnsOk_ForPheUserWithMatchingServicePermission()
+        public void Get_ReturnsOk_ForRegionalUserWithMatchingServicePermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.PheUserWithPermittedPhecCode)
+            using (var client = Factory.WithUserAuth(TestUser.RegionalUserWithPermittedPhecCode)
                                         .WithNotificationAndTbServiceConnected(Utilities.DRAFT_ID, Utilities.PERMITTED_SERVICE_CODE)
                                         .CreateClientWithoutRedirects())
             {
@@ -101,10 +101,10 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public void Get_ReturnsRedirectToOverview_ForPheUserWithMatchingPostcodePermission()
+        public void Get_ReturnsRedirectToOverview_ForRegionalUserWithMatchingPostcodePermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.PheUserWithPermittedPhecCode)
+            using (var client = Factory.WithUserAuth(TestUser.RegionalUserWithPermittedPhecCode)
                                         .WithNotificationAndPostcodeConnected(Utilities.DRAFT_ID, Utilities.PERMITTED_POSTCODE)
                                         .CreateClientWithoutRedirects())
             {
@@ -162,10 +162,10 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public void Get_ReturnsRedirect_ForPheUserWithoutMatchingServicePermission()
+        public void Get_ReturnsRedirect_ForRegionalUserWithoutMatchingServicePermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.PheUserWithPermittedPhecCode)
+            using (var client = Factory.WithUserAuth(TestUser.RegionalUserWithPermittedPhecCode)
                                         .WithNotificationAndTbServiceConnected(Utilities.DRAFT_ID, Utilities.UNPERMITTED_SERVICE_CODE)
                                         .CreateClientWithoutRedirects())
             {
@@ -182,10 +182,10 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public void Get_ReturnsRedirect_ForPheUserWithoutMatchingPostcodePermission()
+        public void Get_ReturnsRedirect_ForRegionalUserWithoutMatchingPostcodePermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.PheUserWithPermittedPhecCode)
+            using (var client = Factory.WithUserAuth(TestUser.RegionalUserWithPermittedPhecCode)
                                         .WithNotificationAndPostcodeConnected(Utilities.DRAFT_ID, Utilities.UNPERMITTED_POSTCODE)
                                         .CreateClientWithoutRedirects())
             {

--- a/ntbs-integration-tests/NotificationPages/ChangesPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/ChangesPageTests.cs
@@ -20,7 +20,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             using (var client = Factory
-                .WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+                .WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .WithNotificationAndTbServiceConnected(Utilities.NOTIFIED_ID, Utilities.PERMITTED_SERVICE_CODE)
                 .CreateClientWithoutRedirects())
             {
@@ -38,7 +38,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             using (var client = Factory
-                .WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+                .WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .WithNotificationAndTbServiceConnected(Utilities.LINKED_NOTIFICATION_ABINGDON_TB_SERVICE, Utilities.PERMITTED_SERVICE_CODE)
                 .CreateClientWithoutRedirects())
             {
@@ -62,7 +62,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             using (var client = Factory
-                .WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+                .WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .WithNotificationAndTbServiceConnected(Utilities.NOTIFIED_ID, Utilities.UNPERMITTED_SERVICE_CODE)
                 .CreateClientWithoutRedirects())
             {

--- a/ntbs-integration-tests/NotificationPages/CreatePageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/CreatePageTests.cs
@@ -20,7 +20,7 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetCreate_ReturnsRedirect()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .CreateClientWithoutRedirects())
             {
                 // Act
@@ -50,7 +50,7 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetCreate_ReturnsNotification_WithDefaultDrugResistanceProfile()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .CreateClientWithoutRedirects())
             {
                 // Act

--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -110,7 +110,7 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Get_ReturnsOverviewPage_ForUserWithPermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                                         .WithNotificationAndTbServiceConnected(Utilities.NOTIFIED_ID, Utilities.PERMITTED_SERVICE_CODE)
                                         .CreateClientWithoutRedirects())
             {
@@ -130,7 +130,7 @@ namespace ntbs_integration_tests.NotificationPages
         {
             // Arrange
             using (var client = Factory
-                .WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+                .WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .WithNotificationAndTbServiceConnected(Utilities.LINKED_NOTIFICATION_ABINGDON_TB_SERVICE, Utilities.PERMITTED_SERVICE_CODE)
                 .CreateClientWithoutRedirects())
             {
@@ -153,7 +153,7 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Get_ShowsWarning_ForUserWithoutPermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                                         .WithNotificationAndTbServiceConnected(Utilities.NOTIFIED_ID, Utilities.UNPERMITTED_SERVICE_CODE)
                                         .CreateClientWithoutRedirects())
             {
@@ -185,9 +185,9 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task Get_ReturnsOverviewPageReadOnlyVersion_ForUserWithReadOnlyPermissionFromLinkedNotification()
         {
             // Arrange
-            // NhsUserForAbingdonAndPermitted has been set up to have access to Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID
+            // ServiceUserForAbingdonAndPermitted has been set up to have access to Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID
             // which belong to the same Notification group as LINK_NOTIFICATION_ROYAL_FREE_LONDON_TB_SERVICE
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .CreateClientWithoutRedirects())
             {
                 // Act
@@ -202,10 +202,10 @@ namespace ntbs_integration_tests.NotificationPages
         }
 
         [Fact]
-        public async Task OverviewPageReturnsReadOnlyVersion_ForPheUserWithMatchingPostcodePermission()
+        public async Task OverviewPageReturnsReadOnlyVersion_ForRegionalUserWithMatchingPostcodePermission()
         {
             // Arrange
-            using (var client = Factory.WithUserAuth(TestUser.PheUserWithPermittedPhecCode)
+            using (var client = Factory.WithUserAuth(TestUser.RegionalUserWithPermittedPhecCode)
                 .WithNotificationAndPostcodeConnected(Utilities.NOTIFIED_ID, Utilities.PERMITTED_POSTCODE)
                 .CreateClientWithoutRedirects())
             {
@@ -224,9 +224,9 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task OverviewPageReturnsReadOnlyVersion_ForUserWhoHadEditPermissionsBeforeATransfer()
         {
             // Arrange
-            // NhsUserForAbingdonAndPermitted has been set up to have access to Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID
+            // ServiceUserForAbingdonAndPermitted has been set up to have access to Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID
             // which belong to the notification has previously been assigned to
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .CreateClientWithoutRedirects())
             {
                 // Act
@@ -244,9 +244,9 @@ namespace ntbs_integration_tests.NotificationPages
         public async Task GetOnClosedNotification_ReturnsOverviewPageReadOnlyVersion_ForUserWithEditPermission()
         {
             // Arrange
-            // NhsUserForAbingdonAndPermitted has been set up to have access to Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID
+            // ServiceUserForAbingdonAndPermitted has been set up to have access to Utilities.TBSERVICE_ABINGDON_COMMUNITY_HOSPITAL_ID
             // which belong to the same Notification group as LINK_NOTIFICATION_ROYAL_FREE_LONDON_TB_SERVICE
-            using (var client = Factory.WithUserAuth(TestUser.NhsUserForAbingdonAndPermitted)
+            using (var client = Factory.WithUserAuth(TestUser.ServiceUserForAbingdonAndPermitted)
                 .CreateClientWithoutRedirects())
             {
                 // Act

--- a/ntbs-service-unit-tests/Pages/HomePageTests.cs
+++ b/ntbs-service-unit-tests/Pages/HomePageTests.cs
@@ -175,7 +175,7 @@ namespace ntbs_service_unit_tests.Pages
         }
 
         [Fact]
-        public async Task OnGetAsync_PopulatesHomepageKpisDetailsWithPhecCodes_WhenUserIsPheUser()
+        public async Task OnGetAsync_PopulatesHomepageKpisDetailsWithPhecCodes_WhenUserIsRegionalUser()
         {
             // Arrange
             _mockUserService.Setup(s => s.GetUserPermissionsFilterAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(
@@ -204,7 +204,7 @@ namespace ntbs_service_unit_tests.Pages
         }
 
         [Fact]
-        public async Task OnGetAsync_PopulatesHomepageKpisDetailsWithTbServiceCodes_WhenUserIsNhsUser()
+        public async Task OnGetAsync_PopulatesHomepageKpisDetailsWithTbServiceCodes_WhenUserIsServiceUser()
         {
             // Arrange
             _mockUserService.Setup(s => s.GetUserPermissionsFilterAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(

--- a/ntbs-service-unit-tests/Pages/HomePageTests.cs
+++ b/ntbs-service-unit-tests/Pages/HomePageTests.cs
@@ -84,7 +84,7 @@ namespace ntbs_service_unit_tests.Pages
         {
             // Arrange
             _mockUserService.Setup(s => s.GetUserPermissionsFilterAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(
-                new UserPermissionsFilter { Type = UserType.ServiceOrPhecUser });
+                new UserPermissionsFilter { Type = UserType.ServiceOrRegionalUser });
 
             var recents = new List<Notification>
             {
@@ -118,7 +118,7 @@ namespace ntbs_service_unit_tests.Pages
         {
             // Arrange
             _mockUserService.Setup(s => s.GetUserPermissionsFilterAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(
-                new UserPermissionsFilter { Type = UserType.ServiceOrPhecUser });
+                new UserPermissionsFilter { Type = UserType.ServiceOrRegionalUser });
 
             var drafts = new List<Notification>
             {
@@ -154,9 +154,9 @@ namespace ntbs_service_unit_tests.Pages
             var alerts = new List<AlertWithTbServiceForDisplay> { new AlertWithTbServiceForDisplay { AlertId = 101 } };
             _mockAlertRepository.Setup(s => s.GetOpenAlertsByTbServiceCodesAsync(It.IsAny<IEnumerable<string>>()))
                 .Returns(Task.FromResult(alerts));
-            _mockUserService.Setup(s => s.GetUserType(It.IsAny<ClaimsPrincipal>())).Returns(UserType.ServiceOrPhecUser);
+            _mockUserService.Setup(s => s.GetUserType(It.IsAny<ClaimsPrincipal>())).Returns(UserType.ServiceOrRegionalUser);
             _mockUserService.Setup(s => s.GetUserPermissionsFilterAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(
-                new UserPermissionsFilter { Type = UserType.ServiceOrPhecUser });
+                new UserPermissionsFilter { Type = UserType.ServiceOrRegionalUser });
 
             var pageModel = new IndexModel(_notificationRepository,
                 _mockAlertRepository.Object,
@@ -181,7 +181,7 @@ namespace ntbs_service_unit_tests.Pages
             _mockUserService.Setup(s => s.GetUserPermissionsFilterAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(
                 new UserPermissionsFilter
                 {
-                    Type = UserType.ServiceOrPhecUser,
+                    Type = UserType.ServiceOrRegionalUser,
                     IncludedPHECCodes = new List<string> { "PHEC001" }
                 });
 
@@ -210,7 +210,7 @@ namespace ntbs_service_unit_tests.Pages
             _mockUserService.Setup(s => s.GetUserPermissionsFilterAsync(It.IsAny<ClaimsPrincipal>())).ReturnsAsync(
                 new UserPermissionsFilter
                 {
-                    Type = UserType.ServiceOrPhecUser,
+                    Type = UserType.ServiceOrRegionalUser,
                     IncludedTBServiceCodes = new List<string> { "TB001" }
                 });
 

--- a/ntbs-service-unit-tests/Pages/HomePageTests.cs
+++ b/ntbs-service-unit-tests/Pages/HomePageTests.cs
@@ -66,9 +66,6 @@ namespace ntbs_service_unit_tests.Pages
                 .Setup(s => s.FilterNotificationsByUserAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IQueryable<Notification>>()))
                 .Returns((ClaimsPrincipal user, IQueryable<Notification> notifications) => Task.FromResult(notifications));
             _mockAuthorizationService
-                .Setup(s => s.FilterNotificationsByUserAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IQueryable<Notification>>()))
-                .Returns((ClaimsPrincipal user, IQueryable<Notification> notifications) => Task.FromResult(notifications));
-            _mockAuthorizationService
                 .Setup(s => s.FilterAlertsForUserAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<IList<AlertWithTbServiceForDisplay>>()))
                 .Returns((ClaimsPrincipal user, IList<AlertWithTbServiceForDisplay> alerts) => Task.FromResult(alerts));
 

--- a/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
@@ -142,7 +142,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Theory]
-        [InlineData(UserType.ServiceOrPhecUser)]
+        [InlineData(UserType.ServiceOrRegionalUser)]
         [InlineData(UserType.NationalTeam)]
         public async Task FilterAlertsForUser_FiltersByTheUsersTbServicesForAllUserTypes(UserType userType)
         {
@@ -207,7 +207,7 @@ namespace ntbs_service_unit_tests.Services
             _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
                 .Returns(Task.FromResult((new List<TBService> {tbService}).AsEnumerable()));
             _mockUserService.Setup(us => us.GetUserType(It.IsAny<ClaimsPrincipal>()))
-                .Returns(UserType.ServiceOrPhecUser);
+                .Returns(UserType.ServiceOrRegionalUser);
 
             // Act
             var result = await _authorizationService.FilterAlertsForUserAsync(testUser, alertsToExpect);

--- a/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
@@ -175,7 +175,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Fact]
-        public async Task FilterAlertsForUser_DoesNotFilterAnyAlertsForPheUser()
+        public async Task FilterAlertsForUser_DoesNotFilterAnyAlertsForRegionalUser()
         {
             // Arrange
             var testUser = new ClaimsPrincipal(new ClaimsIdentity("TestDev"));

--- a/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/AuthorizationServiceTest.cs
@@ -142,8 +142,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Theory]
-        [InlineData(UserType.NhsUser)]
-        [InlineData(UserType.PheUser)]
+        [InlineData(UserType.ServiceOrPhecUser)]
         [InlineData(UserType.NationalTeam)]
         public async Task FilterAlertsForUser_FiltersByTheUsersTbServicesForAllUserTypes(UserType userType)
         {
@@ -208,7 +207,7 @@ namespace ntbs_service_unit_tests.Services
             _mockUserService.Setup(us => us.GetTbServicesAsync(It.IsAny<ClaimsPrincipal>()))
                 .Returns(Task.FromResult((new List<TBService> {tbService}).AsEnumerable()));
             _mockUserService.Setup(us => us.GetUserType(It.IsAny<ClaimsPrincipal>()))
-                .Returns(UserType.PheUser);
+                .Returns(UserType.ServiceOrPhecUser);
 
             // Act
             var result = await _authorizationService.FilterAlertsForUserAsync(testUser, alertsToExpect);

--- a/ntbs-service-unit-tests/Services/UserServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/UserServiceTest.cs
@@ -60,7 +60,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Fact]
-        public async Task GetUserPermissionsFilter_ReturnsExpectedFilter_ForNhsUser()
+        public async Task GetUserPermissionsFilter_ReturnsExpectedFilter_ForServiceUser()
         {
             // Arrange
             const string serviceAdGroup = ServicePrefix + "Ashford";
@@ -85,7 +85,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Fact]
-        public async Task GetUserPermissionsFilter_ReturnsExpectedFilter_ForPheUser()
+        public async Task GetUserPermissionsFilter_ReturnsExpectedFilter_ForRegionalUser()
         {
             // Arrange
             const string adGroup = "SoE";
@@ -129,7 +129,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Fact]
-        public async Task GetDefaultTbService_ReturnsMatchingService_ForNhsUser()
+        public async Task GetDefaultTbService_ReturnsMatchingService_ForServiceUser()
         {
             // Arrange
             const string serviceAdGroup = ServicePrefix + "Ashford";
@@ -149,7 +149,7 @@ namespace ntbs_service_unit_tests.Services
         }
 
         [Fact]
-        public async Task GetDefaultTbService_ReturnsMatchingService_ForPheUser()
+        public async Task GetDefaultTbService_ReturnsMatchingService_ForRegionalUser()
         {
             // Arrange
             const string adGroup = "SoE";

--- a/ntbs-service-unit-tests/Services/UserServiceTest.cs
+++ b/ntbs-service-unit-tests/Services/UserServiceTest.cs
@@ -81,7 +81,7 @@ namespace ntbs_service_unit_tests.Services
             Assert.Empty(result.IncludedPHECCodes);
             Assert.Single(result.IncludedTBServiceCodes);
             Assert.Equal(code, result.IncludedTBServiceCodes.First());
-            Assert.Equal(UserType.ServiceOrPhecUser, result.Type);
+            Assert.Equal(UserType.ServiceOrRegionalUser, result.Type);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace ntbs_service_unit_tests.Services
             Assert.Empty(result.IncludedTBServiceCodes);
             Assert.Single(result.IncludedPHECCodes);
             Assert.Equal(code, result.IncludedPHECCodes.First());
-            Assert.Equal(UserType.ServiceOrPhecUser, result.Type);
+            Assert.Equal(UserType.ServiceOrRegionalUser, result.Type);
         }
 
         [Fact]

--- a/ntbs-service/DataAccess/ReferenceDataRepository.cs
+++ b/ntbs-service/DataAccess/ReferenceDataRepository.cs
@@ -22,9 +22,8 @@ namespace ntbs_service.DataAccess
         Task<IList<TBService>> GetTbServicesFromHospitalIdsAsync(IEnumerable<Guid> hospitalIds);
         Task<IList<TBService>> GetTbServicesFromPhecCodeAsync(string phecCode);
         Task<IList<TBService>> GetTbServicesWithCaseManagersFromPhecCodeAsync(string phecCode);
-        IQueryable<TBService> GetDefaultTbServicesForPheUserQueryable(IEnumerable<string> roles);
-        IQueryable<TBService> GetDefaultTbServicesForNhsUserQueryable(IEnumerable<string> roles);
         IQueryable<TBService> GetActiveTbServicesOrderedByNameQueryable();
+        IQueryable<TBService> GetDefaultTbServicesForUserQueryable(IEnumerable<string> roles);
         Task<IList<PHEC>> GetAllPhecs();
         Task<PHEC> GetPhecByCode(string phecCode);
         Task<IList<User>> GetAllActiveCaseManagers();
@@ -136,17 +135,11 @@ namespace ntbs_service.DataAccess
                 .ToListAsync();
         }
 
-        public IQueryable<TBService> GetDefaultTbServicesForPheUserQueryable(IEnumerable<string> roles)
+        public IQueryable<TBService> GetDefaultTbServicesForUserQueryable(IEnumerable<string> roles)
         {
             return GetActiveTbServicesOrderedByNameQueryable()
                 .Include(tb => tb.PHEC)
-                .Where(tb => roles.Contains(tb.PHEC.AdGroup));
-        }
-
-        public IQueryable<TBService> GetDefaultTbServicesForNhsUserQueryable(IEnumerable<string> roles)
-        {
-            return GetActiveTbServicesOrderedByNameQueryable()
-                .Where(tb => roles.Contains(tb.ServiceAdGroup));
+                .Where(tb => roles.Contains(tb.PHEC.AdGroup) || roles.Contains(tb.ServiceAdGroup));
         }
 
         public IQueryable<TBService> GetActiveTbServicesOrderedByNameQueryable()

--- a/ntbs-service/Models/Enums/UserType.cs
+++ b/ntbs-service/Models/Enums/UserType.cs
@@ -5,6 +5,6 @@ namespace ntbs_service.Models.Enums
         /** Members of the national team with access to all regions */
         NationalTeam,
         /** Members of PHECs, regions associated with multiple TB services */
-        ServiceOrPhecUser
+        ServiceOrRegionalUser
     }
 }

--- a/ntbs-service/Models/Enums/UserType.cs
+++ b/ntbs-service/Models/Enums/UserType.cs
@@ -5,8 +5,6 @@ namespace ntbs_service.Models.Enums
         /** Members of the national team with access to all regions */
         NationalTeam,
         /** Members of PHECs, regions associated with multiple TB services */
-        PheUser,
-        /** Clinical staff, members of particular TB services */
-        NhsUser
+        ServiceOrPhecUser
     }
 }

--- a/ntbs-service/Models/UserPermissionsFilter.cs
+++ b/ntbs-service/Models/UserPermissionsFilter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 using ntbs_service.Models.Enums;
 
 namespace ntbs_service.Models
@@ -11,7 +12,6 @@ namespace ntbs_service.Models
         public List<string> IncludedPHECCodes { get; set; } = new List<string>();
         public UserType Type { get; set; }
 
-        public bool FilterByTBService => Type == UserType.NhsUser;
-        public bool FilterByPHEC => Type == UserType.PheUser;
+        public bool IsInAtLeastOneRegion => IncludedPHECCodes.Any();
     }
 }

--- a/ntbs-service/Models/UserPermissionsFilter.cs
+++ b/ntbs-service/Models/UserPermissionsFilter.cs
@@ -13,5 +13,15 @@ namespace ntbs_service.Models
         public UserType Type { get; set; }
 
         public bool IsInAtLeastOneRegion => IncludedPHECCodes.Any();
+
+        public bool UserBelongsToTbService(string tbServiceCode)
+        {
+            return IncludedTBServiceCodes.Contains(tbServiceCode);
+        }
+
+        public bool UserBelongsToPHEC(string phecCode)
+        {
+            return IncludedPHECCodes.Contains(phecCode);
+        }
     }
 }

--- a/ntbs-service/Pages/Index.cshtml.cs
+++ b/ntbs-service/Pages/Index.cshtml.cs
@@ -55,19 +55,13 @@ namespace ntbs_service.Pages
 
         private async Task SetHomepageKpiDetails()
         {
-            var userType = _userService.GetUserType(User);
-            if (userType == UserType.NhsUser)
-            {
-                var tbServiceCodes = (await _userService.GetTbServicesAsync(User))
-                    .Select(x => x.Code)
-                    .ToList();
-                HomepageKpiDetails = await _homepageKpiService.GetKpiForTbService(tbServiceCodes);
-            }
-            else
-            {
-                var phecCodes = (await _userService.GetPhecCodesAsync(User)).ToList();
-                HomepageKpiDetails = await _homepageKpiService.GetKpiForPhec(phecCodes);
-            }
+            var userPermissionsFilter = await _userService.GetUserPermissionsFilterAsync(User);
+
+            HomepageKpiDetails =
+                userPermissionsFilter.Type == UserType.NationalTeam || userPermissionsFilter.IsInAtLeastOneRegion
+                ? await _homepageKpiService.GetKpiForPhec(userPermissionsFilter.IncludedPHECCodes)
+                : await _homepageKpiService.GetKpiForTbService(userPermissionsFilter.IncludedTBServiceCodes);
+
             KpiFilter = new SelectList(HomepageKpiDetails.OrderBy(x => x.Name), nameof(HomepageKpi.Code), nameof(HomepageKpi.Name));
         }
 

--- a/ntbs-service/Pages/Index.cshtml.cs
+++ b/ntbs-service/Pages/Index.cshtml.cs
@@ -57,10 +57,18 @@ namespace ntbs_service.Pages
         {
             var userPermissionsFilter = await _userService.GetUserPermissionsFilterAsync(User);
 
-            HomepageKpiDetails =
-                userPermissionsFilter.Type == UserType.NationalTeam || userPermissionsFilter.IsInAtLeastOneRegion
-                ? await _homepageKpiService.GetKpiForPhec(userPermissionsFilter.IncludedPHECCodes)
-                : await _homepageKpiService.GetKpiForTbService(userPermissionsFilter.IncludedTBServiceCodes);
+            if (userPermissionsFilter.Type == UserType.NationalTeam)
+            {
+                HomepageKpiDetails = await _homepageKpiService.GetKpiForAllPhec();
+            }
+            else if (userPermissionsFilter.IsInAtLeastOneRegion)
+            {
+                HomepageKpiDetails = await _homepageKpiService.GetKpiForPhec(userPermissionsFilter.IncludedPHECCodes);
+            }
+            else
+            {
+                HomepageKpiDetails = await _homepageKpiService.GetKpiForTbService(userPermissionsFilter.IncludedTBServiceCodes);
+            }
 
             KpiFilter = new SelectList(HomepageKpiDetails.OrderBy(x => x.Name), nameof(HomepageKpi.Code), nameof(HomepageKpi.Name));
         }

--- a/ntbs-service/Pages/LabResults/Index.cshtml.cs
+++ b/ntbs-service/Pages/LabResults/Index.cshtml.cs
@@ -178,14 +178,15 @@ namespace ntbs_service.Pages.LabResults
             if (permissionsFilter.Type == UserType.NationalTeam)
             {
                 UnmatchedSpecimens = await _specimenService.GetAllUnmatchedSpecimensAsync();
-                return;
             }
-
-            var specimensFromServices = await _specimenService.GetUnmatchedSpecimensDetailsForTbServicesAsync(
-                permissionsFilter.IncludedTBServiceCodes);
-            var specimensFromPhecs = await _specimenService.GetUnmatchedSpecimensDetailsForPhecsAsync(
-                permissionsFilter.IncludedPHECCodes);
-            UnmatchedSpecimens = specimensFromServices.Concat(specimensFromPhecs);
+            else
+            {
+                var specimensFromServices = await _specimenService.GetUnmatchedSpecimensDetailsForTbServicesAsync(
+                    permissionsFilter.IncludedTBServiceCodes);
+                var specimensFromPhecs = await _specimenService.GetUnmatchedSpecimensDetailsForPhecsAsync(
+                    permissionsFilter.IncludedPHECCodes);
+                UnmatchedSpecimens = specimensFromServices.Concat(specimensFromPhecs);
+            }
         }
 
         private void AddTempDataForSuccessfulMessage(int notificationId, string laboratoryReferenceNumber)

--- a/ntbs-service/Pages/LabResults/Index.cshtml.cs
+++ b/ntbs-service/Pages/LabResults/Index.cshtml.cs
@@ -174,20 +174,18 @@ namespace ntbs_service.Pages.LabResults
         private async Task FetchUnmatchedSpecimensAsync()
         {
             var permissionsFilter = await _userService.GetUserPermissionsFilterAsync(User);
+
             if (permissionsFilter.Type == UserType.NationalTeam)
             {
                 UnmatchedSpecimens = await _specimenService.GetAllUnmatchedSpecimensAsync();
+                return;
             }
-            else if (permissionsFilter.FilterByTBService)
-            {
-                UnmatchedSpecimens = await _specimenService.GetUnmatchedSpecimensDetailsForTbServicesAsync(
-                    permissionsFilter.IncludedTBServiceCodes);
-            }
-            else if (permissionsFilter.FilterByPHEC)
-            {
-                UnmatchedSpecimens = await _specimenService.GetUnmatchedSpecimensDetailsForPhecsAsync(
-                    permissionsFilter.IncludedPHECCodes);
-            }
+
+            var specimensFromServices = await _specimenService.GetUnmatchedSpecimensDetailsForTbServicesAsync(
+                permissionsFilter.IncludedTBServiceCodes);
+            var specimensFromPhecs = await _specimenService.GetUnmatchedSpecimensDetailsForPhecsAsync(
+                permissionsFilter.IncludedPHECCodes);
+            UnmatchedSpecimens = specimensFromServices.Concat(specimensFromPhecs);
         }
 
         private void AddTempDataForSuccessfulMessage(int notificationId, string laboratoryReferenceNumber)

--- a/ntbs-service/Services/AuthorizationService.cs
+++ b/ntbs-service/Services/AuthorizationService.cs
@@ -130,13 +130,13 @@ namespace ntbs_service.Services
             }
 
             return _userPermissionsFilter.Type == UserType.NationalTeam
-                   || UserBelongsToTbService(notificationBannerModel.TbServiceCode)
-                   || UserBelongsToPhec(notificationBannerModel.TbServicePHECCode)
-                   || UserBelongsToPhec(notificationBannerModel.LocationPHECCode)
-                   || notificationBannerModel.LinkedNotificationPhecCodes.Any(UserBelongsToPhec)
-                   || notificationBannerModel.LinkedNotificationTbServiceCodes.Any(UserBelongsToTbService)
-                   || notificationBannerModel.PreviousTbServiceCodes.Any(UserBelongsToTbService)
-                   || notificationBannerModel.PreviousPhecCodes.Any(UserBelongsToPhec);
+                   || _userPermissionsFilter.UserBelongsToTbService(notificationBannerModel.TbServiceCode)
+                   || _userPermissionsFilter.UserBelongsToPHEC(notificationBannerModel.TbServicePHECCode)
+                   || _userPermissionsFilter.UserBelongsToPHEC(notificationBannerModel.LocationPHECCode)
+                   || notificationBannerModel.LinkedNotificationPhecCodes.Any(_userPermissionsFilter.UserBelongsToPHEC)
+                   || notificationBannerModel.LinkedNotificationTbServiceCodes.Any(_userPermissionsFilter.UserBelongsToTbService)
+                   || notificationBannerModel.PreviousTbServiceCodes.Any(_userPermissionsFilter.UserBelongsToTbService)
+                   || notificationBannerModel.PreviousPhecCodes.Any(_userPermissionsFilter.UserBelongsToPHEC);
         }
 
         private bool UserHasDirectRelationToLinkedNotification(Notification notification)
@@ -149,7 +149,8 @@ namespace ntbs_service.Services
         {
             foreach (var previousTbService in notification.PreviousTbServices)
             {
-                if (UserBelongsToTbService(previousTbService.TbServiceCode) || UserBelongsToPhec(previousTbService.PhecCode))
+                if (_userPermissionsFilter.UserBelongsToTbService(previousTbService.TbServiceCode)
+                    || _userPermissionsFilter.UserBelongsToPHEC(previousTbService.PhecCode))
                 {
                     return true;
                 }
@@ -159,24 +160,14 @@ namespace ntbs_service.Services
 
         private bool UserHasDirectRelationToNotification(Notification notification)
         {
-            return UserBelongsToTbService(notification.HospitalDetails.TBServiceCode) || UserBelongsToPhec(notification.HospitalDetails.TBService?.PHECCode);
-        }
-
-        private bool UserBelongsToTbService(string tbServiceCode)
-        {
-            return _userPermissionsFilter.IncludedTBServiceCodes.Contains(tbServiceCode);
-        }
-
-        private bool UserBelongsToPhec(string phecCode)
-        {
-            return _userPermissionsFilter.IncludedPHECCodes.Contains(phecCode);
+            return _userPermissionsFilter.UserBelongsToTbService(notification.HospitalDetails.TBServiceCode)
+                   || _userPermissionsFilter.UserBelongsToPHEC(notification.HospitalDetails.TBService?.PHECCode);
         }
 
         private bool UserBelongsToResidencePhecOfNotification(Notification notification)
         {
             var phecCode = notification.PatientDetails.PostcodeLookup?.LocalAuthority?.LocalAuthorityToPHEC?.PHECCode;
-            return _userPermissionsFilter.IsInAtLeastOneRegion
-                   && _userPermissionsFilter.IncludedPHECCodes.Contains(phecCode);
+            return _userPermissionsFilter.UserBelongsToPHEC(phecCode);
         }
 
         public async Task<IQueryable<Notification>> FilterNotificationsByUserAsync(ClaimsPrincipal user,
@@ -187,19 +178,19 @@ namespace ntbs_service.Services
                 _userPermissionsFilter = await GetUserPermissionsFilterAsync(user);
             }
 
-            notifications = notifications.Where(n =>
-                _userPermissionsFilter.IncludedTBServiceCodes.Contains(n.HospitalDetails.TBServiceCode)
-                // Having a method in LINQ clause breaks IQueryable abstraction. We have to use inline expression over methods
-                || (n.HospitalDetails.TBService != null
-                    && _userPermissionsFilter.IncludedPHECCodes.Contains(n.HospitalDetails.TBService.PHECCode))
-                || (_userPermissionsFilter.IsInAtLeastOneRegion
-                    && n.PatientDetails.PostcodeLookup != null
-                    && n.PatientDetails.PostcodeLookup.LocalAuthority != null
-                    && n.PatientDetails.PostcodeLookup.LocalAuthority.LocalAuthorityToPHEC != null
-                    && _userPermissionsFilter.IncludedPHECCodes.Contains(n.PatientDetails.PostcodeLookup.LocalAuthority.LocalAuthorityToPHEC.PHECCode))
+            return _userPermissionsFilter.Type == UserType.NationalTeam
+                ? notifications
+                : notifications.Where(n =>
+                    _userPermissionsFilter.IncludedTBServiceCodes.Contains(n.HospitalDetails.TBServiceCode)
+                    // Having a method in LINQ clause breaks IQueryable abstraction. We have to use inline expression over methods
+                    || (n.HospitalDetails.TBService != null
+                        && _userPermissionsFilter.IncludedPHECCodes.Contains(n.HospitalDetails.TBService.PHECCode))
+                    || (_userPermissionsFilter.IsInAtLeastOneRegion
+                        && n.PatientDetails.PostcodeLookup != null
+                        && n.PatientDetails.PostcodeLookup.LocalAuthority != null
+                        && n.PatientDetails.PostcodeLookup.LocalAuthority.LocalAuthorityToPHEC != null
+                        && _userPermissionsFilter.IncludedPHECCodes.Contains(n.PatientDetails.PostcodeLookup.LocalAuthority.LocalAuthorityToPHEC.PHECCode))
                 );
-
-            return notifications;
         }
 
         public async Task<IList<AlertWithTbServiceForDisplay>> FilterAlertsForUserAsync(ClaimsPrincipal user, IList<AlertWithTbServiceForDisplay> alerts)

--- a/ntbs-service/Services/HomepageKpiService.cs
+++ b/ntbs-service/Services/HomepageKpiService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using Microsoft.Extensions.Configuration;
+using ntbs_service.DataAccess;
 using ntbs_service.Helpers;
 using ntbs_service.Models.Entities;
 
@@ -13,15 +14,18 @@ namespace ntbs_service.Services
     {
         Task<IEnumerable<HomepageKpi>> GetKpiForPhec(IEnumerable<string> phecCodes);
         Task<IEnumerable<HomepageKpi>> GetKpiForTbService(IEnumerable<string> tbServiceCodes);
+        Task<IEnumerable<HomepageKpi>> GetKpiForAllPhec();
     }
 
     public class HomepageKpiService : IHomepageKpiService
     {
         private readonly string _connectionString;
+        private readonly IReferenceDataRepository _referenceDataRepository;
 
-        public HomepageKpiService(IConfiguration configuration)
+        public HomepageKpiService(IConfiguration configuration, IReferenceDataRepository referenceDataRepository)
         {
             _connectionString = configuration.GetConnectionString(Constants.DbConnectionStringReporting);
+            _referenceDataRepository = referenceDataRepository;
         }
 
         public async Task<IEnumerable<HomepageKpi>> GetKpiForPhec(IEnumerable<string> phecCodes)
@@ -40,6 +44,12 @@ namespace ntbs_service.Services
 
             var homepageKpiResults = await ExecuteGetKpiQuery(query, formattedServiceCodes);
             return homepageKpiResults;
+        }
+
+        public async Task<IEnumerable<HomepageKpi>> GetKpiForAllPhec()
+        {
+            var allPhecs = (await _referenceDataRepository.GetAllPhecs()).Select(p => p.Code);
+            return await GetKpiForPhec(allPhecs);
         }
 
         private async Task<IEnumerable<HomepageKpi>> ExecuteGetKpiQuery(string query, string param = null)
@@ -64,6 +74,12 @@ namespace ntbs_service.Services
         {
             var homepageKpiDetails = tbServiceCodes.Select(x => new HomepageKpi { Code = x, Name = x });
             return Task.FromResult(homepageKpiDetails);
+        }
+
+        public Task<IEnumerable<HomepageKpi>> GetKpiForAllPhec()
+        {
+            var homepageKpiDetails = new List<HomepageKpi> { new HomepageKpi {Code = "x", Name = "x"} };
+            return Task.FromResult<IEnumerable<HomepageKpi>>(homepageKpiDetails);
         }
     }
 }

--- a/ntbs-service/Services/UserService.cs
+++ b/ntbs-service/Services/UserService.cs
@@ -83,7 +83,7 @@ namespace ntbs_service.Services
                 return UserType.NationalTeam;
             }
 
-            return UserType.ServiceOrPhecUser;
+            return UserType.ServiceOrRegionalUser;
         }
 
         public async Task RecordUserLoginAsync(string username)


### PR DESCRIPTION
## Description
I think there are probably some tests still to be written for when a user is both a TB service member and a regional user.
The main changes are that in GetUserPermissionsFilter we now no longer check if they have a service and then just get all the services - we get all services and regions regardless. Then there were a few changes to make with what used this permissions filter - eg in lab results we now concatenate together the lab results from TB service and regional membership. In the other places like homepage notifications, we could just bring 2 linq where statements together.

## Checklist:
- [x] Automated tests are passing locally.
