### PR TITLE
NTBS-2982: Make some not evaluated outcomes ending events

### DIFF
--- a/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
+++ b/ntbs-service-unit-tests/Helpers/EpisodesHelperTest.cs
@@ -265,6 +265,41 @@ namespace ntbs_service_unit_tests.Helpers
             AssertTreatmentPeriodMatchesExpected(expectedPeriod, periods.Single());
         }
 
+        [Theory]
+        [InlineData(TreatmentEventType.Denotification, null, null, true)]
+        [InlineData(TreatmentEventType.TransferOut, null, null, true)]
+        [InlineData(TreatmentEventType.TransferIn, null, null, false)]
+        [InlineData(TreatmentEventType.TreatmentRestart, null, null, false)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.Completed, null, true)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.Cured, null, true)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.Died, null, true)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.Lost, null, true)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.Failed, null, true)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.TreatmentStopped, null, true)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.NotEvaluated, TreatmentOutcomeSubType.StillOnTreatment, false)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.NotEvaluated, TreatmentOutcomeSubType.Other, true)]
+        [InlineData(TreatmentEventType.TreatmentOutcome, TreatmentOutcomeType.NotEvaluated, TreatmentOutcomeSubType.TransferredAbroad, true)]
+        public void IsEpisodeEndingTreatmentEvent_CorrectlyIdentifiesEndingEvents
+            (TreatmentEventType eventType, TreatmentOutcomeType? outcomeType, TreatmentOutcomeSubType? subType, bool expectedEnding)
+        {
+            // Arrange
+            var possibleEndingEvent = new TreatmentEvent
+            {
+                TreatmentEventType = eventType,
+                TreatmentOutcome = outcomeType.HasValue
+                    ? new TreatmentOutcome {
+                        TreatmentOutcomeType = outcomeType.Value,
+                        TreatmentOutcomeSubType = subType }
+                    : null
+            };
+
+            // Act
+            var isEnding = possibleEndingEvent.IsEpisodeEndingTreatmentEvent();
+
+            // Assert
+            Assert.Equal(expectedEnding, isEnding);
+        }
+
         private void AssertTreatmentPeriodMatchesExpected(TreatmentPeriod expected, TreatmentPeriod actual)
         {
             Assert.Equal(expected.TreatmentEvents, actual.TreatmentEvents);

--- a/ntbs-service/Helpers/EpisodesExtensionMethods.cs
+++ b/ntbs-service/Helpers/EpisodesExtensionMethods.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using MoreLinq.Extensions;
 using ntbs_service.Models;
 using ntbs_service.Models.Entities;
 using ntbs_service.Models.Enums;
@@ -78,7 +77,21 @@ namespace ntbs_service.Helpers
             return treatmentEvent.TreatmentEventType == TreatmentEventType.Denotification
                    || treatmentEvent.TreatmentEventType == TreatmentEventType.TransferOut
                    || (treatmentEvent.TreatmentOutcome != null
-                       && EpisodeEndingOutcomeTypes.Contains(treatmentEvent.TreatmentOutcome.TreatmentOutcomeType));
+                       && (EpisodeEndingOutcomeTypes.Contains(treatmentEvent.TreatmentOutcome.TreatmentOutcomeType)
+                           || EventIsAnEndingNotEvaluatedOutcome(treatmentEvent))
+                       );
+        }
+
+        private static bool EventIsAnEndingNotEvaluatedOutcome(TreatmentEvent treatmentEvent)
+        {
+            var endingSubTypes = new List<TreatmentOutcomeSubType>
+            {
+                TreatmentOutcomeSubType.TransferredAbroad,
+                TreatmentOutcomeSubType.Other
+            };
+            return treatmentEvent.TreatmentOutcome.TreatmentOutcomeType == TreatmentOutcomeType.NotEvaluated
+                   && treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType.HasValue
+                   && endingSubTypes.Contains(treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType.Value);
         }
 
         public static IEnumerable<TreatmentEvent> OrderForEpisodes(this IEnumerable<TreatmentEvent> treatmentEvents)


### PR DESCRIPTION
## Description
Make not evaluated events ending if they are transferred abroad or other. Added tests.

## Checklist:
- [x] Automated tests are passing locally.
