### PR TITLE
Ntbs-2989: Add link to service directory on request transfer page

### DIFF
--- a/ntbs-integration-tests/TransferPages/TransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/TransferPageTests.cs
@@ -79,11 +79,11 @@ namespace ntbs_integration_tests.TransferPages
             const int id = Utilities.NOTIFIED_WITH_TBSERVICE;
             var url = GetCurrentPathForId(id);
             var document = await GetDocumentForUrlAsync(url);
-            var directoryLinkText = document.QuerySelectorAll("h3")
-                .FirstOrDefault(e => e.InnerHtml.Contains("You can search for TB services and case managers"));
+            var directoryLinkText = document.QuerySelector("#ntbs-service-directory-hint");
             
             // Assert
             Assert.NotNull(directoryLinkText);
+            Assert.Contains("You can search for TB services and case managers", directoryLinkText.InnerHtml);
         }
 
         [Fact]
@@ -92,14 +92,13 @@ namespace ntbs_integration_tests.TransferPages
             // Arrange
             const int id = Utilities.NOTIFIED_WITH_TBSERVICE;
             var url = GetCurrentPathForId(id);
-            var initialDocument = await GetDocumentForUrlAsync(url);
-            var directoryLink = initialDocument.QuerySelectorAll("h3 > a")
-                .SingleOrDefault(
-                    e => e.Attributes.GetNamedItem("href")?.Value == "/ServiceDirectory" 
-                         && e.InnerHtml.Contains("NTBS service directory"));
-            
+            var document = await GetDocumentForUrlAsync(url);
+            var directoryLink = document.QuerySelector("#ntbs-service-directory-hint > a");
+
             //Assert
             Assert.NotNull(directoryLink);
+            Assert.Contains("NTBS service directory", directoryLink.InnerHtml);
+            Assert.Equal("/ServiceDirectory", directoryLink.GetAttribute("href"));
         }
     }
 }

--- a/ntbs-integration-tests/TransferPages/TransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/TransferPageTests.cs
@@ -1,8 +1,6 @@
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
-using ntbs_integration_tests.TestServices;
 using ntbs_service;
 using ntbs_service.Helpers;
 using ntbs_service.Models.Enums;
@@ -65,7 +63,7 @@ namespace ntbs_integration_tests.TransferPages
         public async Task NavigatingToPendingTransfer_ReturnsReadOnlyPartial_WhenTransferAlertAlreadyExists()
         {
             // Arrange
-            const int id = Utilities.NOTIFIED_ID_2;
+            const int id = Utilities.NOTIFIED_ID;
             var url = GetCurrentPathForId(id);
             var initialDocument = await GetDocumentForUrlAsync(url);
 

--- a/ntbs-integration-tests/TransferPages/TransferPageTests.cs
+++ b/ntbs-integration-tests/TransferPages/TransferPageTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
+using ntbs_integration_tests.TestServices;
 using ntbs_service;
 using ntbs_service.Helpers;
 using ntbs_service.Models.Enums;
@@ -63,11 +65,41 @@ namespace ntbs_integration_tests.TransferPages
         public async Task NavigatingToPendingTransfer_ReturnsReadOnlyPartial_WhenTransferAlertAlreadyExists()
         {
             // Arrange
-            const int id = Utilities.NOTIFIED_ID;
+            const int id = Utilities.NOTIFIED_ID_2;
             var url = GetCurrentPathForId(id);
             var initialDocument = await GetDocumentForUrlAsync(url);
 
             Assert.NotNull(initialDocument.QuerySelector("#cancel-transfer-button"));
+        }
+
+        [Fact]
+        public async Task TransferPageDisplaysServiceDirectoryLink()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_WITH_TBSERVICE;
+            var url = GetCurrentPathForId(id);
+            var document = await GetDocumentForUrlAsync(url);
+            var directoryLinkText = document.QuerySelectorAll("h3")
+                .FirstOrDefault(e => e.InnerHtml.Contains("You can search for TB services and case managers"));
+            
+            // Assert
+            Assert.NotNull(directoryLinkText);
+        }
+
+        [Fact]
+        public async Task NTBSServiceDirectoryLink_LinksToServiceDirectoryPage()
+        {
+            // Arrange
+            const int id = Utilities.NOTIFIED_WITH_TBSERVICE;
+            var url = GetCurrentPathForId(id);
+            var initialDocument = await GetDocumentForUrlAsync(url);
+            var directoryLink = initialDocument.QuerySelectorAll("h3 > a")
+                .SingleOrDefault(
+                    e => e.Attributes.GetNamedItem("href")?.Value == "/ServiceDirectory" 
+                         && e.InnerHtml.Contains("NTBS service directory"));
+            
+            //Assert
+            Assert.NotNull(directoryLink);
         }
     }
 }

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml
@@ -14,7 +14,9 @@
 <nhs-width-container container-width="Standard">
     <form method="post" autocomplete="off">
         <h2> You are about to transfer this notification </h2>
-        <h3> You can search for TB services and case managers in the <a href=/ServiceDirectory>NTBS service directory</a> if you are not sure of the TB service name</h3>
+        <nhs-hint nhs-hint-type="Standard" id="ntbs-service-directory-hint">
+            You can search for TB services and case managers in the <a class="nhsuk-action-link" href=/ServiceDirectory>NTBS service directory</a> if you are not sure of the TB service name
+        </nhs-hint> <br>
         <div>
             <filtered-dropdown filter-handler-path="FilteredCaseManagersListByTbServiceCode" :filtering-refs="['caseManagers']" :should-filter-on-load="true" inline-template>
                 <div>

--- a/ntbs-service/Pages/Alerts/TransferRequest.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRequest.cshtml
@@ -14,6 +14,7 @@
 <nhs-width-container container-width="Standard">
     <form method="post" autocomplete="off">
         <h2> You are about to transfer this notification </h2>
+        <h3> You can search for TB services and case managers in the <a href=/ServiceDirectory>NTBS service directory</a> if you are not sure of the TB service name</h3>
         <div>
             <filtered-dropdown filter-handler-path="FilteredCaseManagersListByTbServiceCode" :filtering-refs="['caseManagers']" :should-filter-on-load="true" inline-template>
                 <div>


### PR DESCRIPTION
## Description

On the Request Transfer screen, below the title but above the TB service search box, a line of text appears which says 'You can search for TB services and case managers in the NTBS service directory if you are not sure of the TB service name'.  The words 'NTBS service directory' act as a link to the top level Service Directory page for the given environment.

The text has been added as an NHS-hint component and the link is an a tag with a href.

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Test functionality without javascript
- [x] Test in small window (imitating small screen)
- [ ] Check the feature looks and works correctly in IE11
- [x] Zoom page to 400% - content still visible?
- [x] Test feature works with keyboard only operation
- [ ] Test with one screen reader (e.g. [NVDA](https://www.nvaccess.org/): see [getting started](https://webaim.org/articles/nvda/)) - logical flow, no unexpected content. 
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
