### PR TITLE
NTBS-3000: Add diagnosis made event for post mortem cases

### DIFF
--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -262,14 +262,14 @@ namespace ntbs_service_unit_tests.DataMigration
             var notification = await GetSingleNotification(legacyId);
 
             // Assert
-            Assert.Single(notification.TreatmentEvents);
+            var deathEvent = notification.TreatmentEvents.Single(te => te.TreatmentEventIsDeathEvent);
             Assert.True(notification.ClinicalDetails.IsPostMortem);
             Assert.Equal(NotificationStatus.Closed, notification.NotificationStatus);
-            // For post mortem cases with no death event we *only* want to create the single death event so outcomes reporting is correct
+            // For post mortem cases with no death event we want to a death event and a diagnosis event
             Assert.Collection(notification.TreatmentEvents,
-                te => Assert.Equal(TreatmentOutcomeType.Died, te.TreatmentOutcome.TreatmentOutcomeType));
-            Assert.Collection(notification.TreatmentEvents,
-                te => Assert.Equal(TreatmentOutcomeUnknownDeathId, te.TreatmentOutcome.TreatmentOutcomeId));
+                te => Assert.Equal(TreatmentOutcomeType.Died, te.TreatmentOutcome.TreatmentOutcomeType),
+                te => Assert.Equal(TreatmentEventType.DiagnosisMade, te.TreatmentEventType));
+             Assert.Equal(TreatmentOutcomeUnknownDeathId, deathEvent.TreatmentOutcome.TreatmentOutcomeId);
         }
 
         // This is based on NTBS-2869
@@ -284,8 +284,9 @@ namespace ntbs_service_unit_tests.DataMigration
             var notification = await GetSingleNotification(legacyId);
 
             // Assert
-            Assert.Single(notification.TreatmentEvents);
-            var deathEvent = notification.TreatmentEvents.Single();
+            var diagnosisEvent = notification.TreatmentEvents.SingleOrDefault(te => te.TreatmentEventType == TreatmentEventType.DiagnosisMade);
+            Assert.NotNull(diagnosisEvent);
+            var deathEvent = notification.TreatmentEvents.Single(te => te.TreatmentEventIsDeathEvent);
             Assert.True(notification.ClinicalDetails.IsPostMortem);
             // For post mortem cases we *only* want to import the single death event so outcomes reporting is correct
             Assert.Equal(TreatmentOutcomeType.Died, deathEvent.TreatmentOutcome.TreatmentOutcomeType);

--- a/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
+++ b/ntbs-service-unit-tests/DataMigration/NotificationMapperTest.cs
@@ -262,10 +262,11 @@ namespace ntbs_service_unit_tests.DataMigration
             var notification = await GetSingleNotification(legacyId);
 
             // Assert
+            Assert.Single(notification.TreatmentEvents.Where(te => te.TreatmentEventIsDeathEvent));
             var deathEvent = notification.TreatmentEvents.Single(te => te.TreatmentEventIsDeathEvent);
             Assert.True(notification.ClinicalDetails.IsPostMortem);
             Assert.Equal(NotificationStatus.Closed, notification.NotificationStatus);
-            // For post mortem cases with no death event we want to a death event and a diagnosis event
+            // For post mortem cases with no death event we want a death event and a diagnosis event
             Assert.Collection(notification.TreatmentEvents,
                 te => Assert.Equal(TreatmentOutcomeType.Died, te.TreatmentOutcome.TreatmentOutcomeType),
                 te => Assert.Equal(TreatmentEventType.DiagnosisMade, te.TreatmentEventType));

--- a/ntbs-service-unit-tests/Models/Entities/NotificationTest.cs
+++ b/ntbs-service-unit-tests/Models/Entities/NotificationTest.cs
@@ -47,12 +47,13 @@ namespace ntbs_service_unit_tests.Models.Entities
 
         [Theory]
         [MemberData(nameof(ShouldBeClosedTestData))]
-        public void NotificationSetsShouldBeClosedCorrectly(DateTime treatmentOutcomeDate, DateTime? treatmentOtherDate, NotificationStatus status, bool expectedValue)
+        public void SetsShouldBeClosedCorrectlyForNonPostMortemNotification(DateTime treatmentOutcomeDate, DateTime? treatmentOtherDate, NotificationStatus status, bool expectedValue)
         {
             // Arrange
             var notification = new Notification
             {
                 NotificationStatus = status,
+                ClinicalDetails = new ClinicalDetails{ IsPostMortem = false },
                 TreatmentEvents = new List<TreatmentEvent> {
                     new TreatmentEvent
                     {
@@ -71,6 +72,34 @@ namespace ntbs_service_unit_tests.Models.Entities
 
             // Assert
             Assert.Equal(expectedValue, notification.ShouldBeClosed());
+        }
+
+        [Fact]
+        public void SetsShouldBeClosedCorrectlyForPostMortemNotification()
+        {
+            // Arrange
+            var notification = new Notification
+            {
+                NotificationStatus = NotificationStatus.Notified,
+                ClinicalDetails = new ClinicalDetails{ IsPostMortem = true },
+                TreatmentEvents = new List<TreatmentEvent> {
+                    new TreatmentEvent
+                    {
+                        TreatmentEventType = TreatmentEventType.TreatmentOutcome,
+                        TreatmentOutcomeId = 7,
+                        TreatmentOutcome = new TreatmentOutcome{ TreatmentOutcomeType = TreatmentOutcomeType.Died, TreatmentOutcomeSubType = TreatmentOutcomeSubType.TbCausedDeath },
+                        EventDate = new DateTime(2017, 1, 1)
+                    },
+                    new TreatmentEvent
+                    {
+                        TreatmentEventType = TreatmentEventType.DiagnosisMade,
+                        EventDate = new DateTime(2017, 2, 2)
+                    }
+                }
+            };
+
+            // Assert
+            Assert.True(notification.ShouldBeClosed());
         }
 
         [Fact]

--- a/ntbs-service/DataAccess/TreatmentEventRepository.cs
+++ b/ntbs-service/DataAccess/TreatmentEventRepository.cs
@@ -31,7 +31,7 @@ namespace ntbs_service.DataAccess
             var startingEvent = notification.TreatmentEvents.SingleOrDefault(t => t.IsStartingEvent);
             if (startingEvent != null)
             {
-                NotificationHelper.SetStartingEventDate(startingEvent, clinicalDetails);
+                NotificationHelper.SetStartingEventDateAndType(startingEvent, clinicalDetails);
                 await UpdateAsync(notification, startingEvent);
             }
         }

--- a/ntbs-service/Helpers/EpisodesExtensionMethods.cs
+++ b/ntbs-service/Helpers/EpisodesExtensionMethods.cs
@@ -9,15 +9,6 @@ namespace ntbs_service.Helpers
 {
     public static class EpisodesExtensionMethods
     {
-        private static readonly List<TreatmentOutcomeType> EpisodeEndingOutcomeTypes = new List<TreatmentOutcomeType>
-        {
-            TreatmentOutcomeType.Completed,
-            TreatmentOutcomeType.Cured,
-            TreatmentOutcomeType.Died,
-            TreatmentOutcomeType.Lost,
-            TreatmentOutcomeType.Failed,
-            TreatmentOutcomeType.TreatmentStopped
-        };
 
         public static List<TreatmentPeriod> GroupEpisodesIntoPeriods(this IEnumerable<TreatmentEvent> treatmentEvents, bool isPostMortemWithCorrectEvents = false)
         {
@@ -77,21 +68,7 @@ namespace ntbs_service.Helpers
             return treatmentEvent.TreatmentEventType == TreatmentEventType.Denotification
                    || treatmentEvent.TreatmentEventType == TreatmentEventType.TransferOut
                    || (treatmentEvent.TreatmentOutcome != null
-                       && (EpisodeEndingOutcomeTypes.Contains(treatmentEvent.TreatmentOutcome.TreatmentOutcomeType)
-                           || EventIsAnEndingNotEvaluatedOutcome(treatmentEvent))
-                       );
-        }
-
-        private static bool EventIsAnEndingNotEvaluatedOutcome(TreatmentEvent treatmentEvent)
-        {
-            var endingSubTypes = new List<TreatmentOutcomeSubType>
-            {
-                TreatmentOutcomeSubType.TransferredAbroad,
-                TreatmentOutcomeSubType.Other
-            };
-            return treatmentEvent.TreatmentOutcome.TreatmentOutcomeType == TreatmentOutcomeType.NotEvaluated
-                   && treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType.HasValue
-                   && endingSubTypes.Contains(treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType.Value);
+                       && treatmentEvent.TreatmentOutcome.TreatmentOutcomeSubType != TreatmentOutcomeSubType.StillOnTreatment);
         }
 
         public static IEnumerable<TreatmentEvent> OrderForEpisodes(this IEnumerable<TreatmentEvent> treatmentEvents)

--- a/ntbs-service/Helpers/NotificationHelper.cs
+++ b/ntbs-service/Helpers/NotificationHelper.cs
@@ -39,7 +39,7 @@ namespace ntbs_service.Helpers
                 CaseManagerId = caseManagerId,
                 TbServiceCode = tbServiceCode
             };
-            SetStartingEventDate(treatmentStartEvent, notification.ClinicalDetails);
+            SetStartingEventDateAndType(treatmentStartEvent, notification.ClinicalDetails);
             return treatmentStartEvent;
         }
 
@@ -47,7 +47,7 @@ namespace ntbs_service.Helpers
         // "starting event" when no treatment start is recorded.
         // We need two distinct types so the labels are correct though!
         // We don't want both events in, since we want the outcome dates to be based off of treatment start
-        public static void SetStartingEventDate(TreatmentEvent treatmentStartEvent, ClinicalDetails clinicalDetails)
+        public static void SetStartingEventDateAndType(TreatmentEvent treatmentStartEvent, ClinicalDetails clinicalDetails)
         {
             treatmentStartEvent.EventDate = clinicalDetails.StartingDate;
             treatmentStartEvent.TreatmentEventType = clinicalDetails.TreatmentStartDate != null

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -151,18 +151,28 @@ namespace ntbs_service.Models.Entities
             var mostRecentTreatmentEvent = TreatmentEvents.GetMostRecentTreatmentEvent();
 
             return NotificationStatus == NotificationStatus.Notified 
-                   && mostRecentTreatmentEvent?.TreatmentOutcomeId != null 
-                   && mostRecentTreatmentEvent.TreatmentEventTypeIsOutcome
-                   && NotStillOnTreatmentAndOlderThanOneYear(mostRecentTreatmentEvent);
+                   && (EventIsOutcomeAndNotStillOnTreatmentAndOlderThanOneYear(mostRecentTreatmentEvent)
+                       || IsPostMortemAndOlderThanOneYear());
 
-            bool NotStillOnTreatmentAndOlderThanOneYear(TreatmentEvent treatmentEvent)
+            bool EventIsOutcomeAndNotStillOnTreatmentAndOlderThanOneYear(TreatmentEvent treatmentEvent)
             {
+                if (mostRecentTreatmentEvent?.TreatmentOutcomeId == null ||
+                    !mostRecentTreatmentEvent.TreatmentEventTypeIsOutcome)
+                {
+                    return false;
+                }
+
                 var treatmentOutcome = treatmentEvent.TreatmentOutcome
                                        ?? SeedData.TreatmentOutcomes.GetTreatmentOutcomes()
                                            .Single(oc => oc.TreatmentOutcomeId == treatmentEvent.TreatmentOutcomeId);
 
                 return treatmentOutcome.TreatmentOutcomeSubType != TreatmentOutcomeSubType.StillOnTreatment 
                        && treatmentEvent.EventDate < DateTime.Today.AddYears(-1);
+            }
+
+            bool IsPostMortemAndOlderThanOneYear()
+            {
+                return IsPostMortemAndHasCorrectEvents && TreatmentEvents.Single(te => te.TreatmentEventIsDeathEvent).EventDate < DateTime.Today.AddYears(-1);
             }
         }
 

--- a/ntbs-service/Models/Entities/Notification.cs
+++ b/ntbs-service/Models/Entities/Notification.cs
@@ -151,10 +151,10 @@ namespace ntbs_service.Models.Entities
             var mostRecentTreatmentEvent = TreatmentEvents.GetMostRecentTreatmentEvent();
 
             return NotificationStatus == NotificationStatus.Notified 
-                   && (EventIsOutcomeAndNotStillOnTreatmentAndOlderThanOneYear(mostRecentTreatmentEvent)
+                   && (EventIsEndingAndOlderThanOneYear(mostRecentTreatmentEvent)
                        || IsPostMortemAndOlderThanOneYear());
 
-            bool EventIsOutcomeAndNotStillOnTreatmentAndOlderThanOneYear(TreatmentEvent treatmentEvent)
+            bool EventIsEndingAndOlderThanOneYear(TreatmentEvent treatmentEvent)
             {
                 if (mostRecentTreatmentEvent?.TreatmentOutcomeId == null ||
                     !mostRecentTreatmentEvent.TreatmentEventTypeIsOutcome)
@@ -166,7 +166,7 @@ namespace ntbs_service.Models.Entities
                                        ?? SeedData.TreatmentOutcomes.GetTreatmentOutcomes()
                                            .Single(oc => oc.TreatmentOutcomeId == treatmentEvent.TreatmentOutcomeId);
 
-                return treatmentOutcome.TreatmentOutcomeSubType != TreatmentOutcomeSubType.StillOnTreatment 
+                return treatmentOutcome.TreatmentOutcomeSubType != TreatmentOutcomeSubType.StillOnTreatment
                        && treatmentEvent.EventDate < DateTime.Today.AddYears(-1);
             }
 

--- a/ntbs-service/Services/NotificationService.cs
+++ b/ntbs-service/Services/NotificationService.cs
@@ -327,10 +327,8 @@ namespace ntbs_service.Services
             notification.SubmissionDate = DateTime.UtcNow;
 
             await _notificationRepository.SaveChangesAsync(NotificationAuditType.Notified);
-            if (notification.ClinicalDetails.IsPostMortem != true)
-            {
-                await CreateTreatmentEventNotificationStart(notification);
-            }
+            await CreateTreatmentEventNotificationStart(notification);
+
             await _alertService.AutoDismissAlertAsync<DataQualityDraftAlert>(notification);
         }
 


### PR DESCRIPTION
## Description
Always generate the starting event when a notification is submitted. 
Always generate the starting event when a notification is imported.
Fixed a bug with `ShouldBeClosed` where a post mortem notification wasn't being seen as having an outcome (as the diagnosis made event would be the last recorded event)

## Checklist:
- [x] Automated tests are passing locally.
