### PR TITLE
NTBS-2919 Add config for notification range in load tests

### DIFF
--- a/load-tests/README.md
+++ b/load-tests/README.md
@@ -23,6 +23,20 @@ Before you can run tests, you first need to acquire authentication cookies. One 
  
 Then to run the tests, simply run the command `bash gradlew gatlingRun-NtbsLoadTest --rerun-tasks` from Git Bash in the [gradle](gradle) directory.
 
+### Running the tests through OpenShift
+
+To run the tests against one of the UKHSA environments (either `dev` or `uat` - they should never be run against `live`!) do the following:
+
+- Log into the UKHSA VPN and remote desktop to the dev box.
+- Log into the OpenShift portal at [https://console-openshift-console.apps.ocp-por.unix.phe.gov.uk/](https://console-openshift-console.apps.ocp-por.unix.phe.gov.uk/)
+- Go to the Pipelines page, and ensure that the `ntbs-build` project is selected
+- Select the `run-load-tests` pipeline
+- In the actions menu, select Start
+- Set values for the relevant parameters. Most of these should be self-explanatory (and most of the time you'll probably want to stick with the default parameters) except:
+  - For `token` follow the process above to get an authenticated cookie header
+  - For `shared-workspace` select PVC, and then `ntbs-build-pvc`
+- Select Start
+
 ## Using the Gatling recorder
 
 Gatling provides a "record" feature, which is a useful tool in developing new scenarios.

--- a/load-tests/gradle/src/gatling/scala/Config.scala
+++ b/load-tests/gradle/src/gatling/scala/Config.scala
@@ -2,7 +2,10 @@ import java.net.HttpCookie;
 import scala.collection.JavaConverters._
 
 object Config {
-    val urlUnderTest = "https://ntbs-load-test.e32846b1ddf0432eb63f.northeurope.aksapp.io"
+    val urlUnderTest = sys.env.getOrElse(
+        "URL_UNDER_TEST",
+        "https://ntbs-load-test.e32846b1ddf0432eb63f.northeurope.aksapp.io"
+    )
     val lengthOfTestInMinutes = sys.env.getOrElse("LOAD_TEST_DURATION_IN_MINUTES", "1").toInt
     val firstNotification = sys.env.getOrElse("FIRST_NOTIFICATION", "300001").toInt
     val numberOfNotifications = sys.env.getOrElse("NUMBER_OF_NOTIFICATIONS", "10000").toInt

--- a/load-tests/gradle/src/gatling/scala/Config.scala
+++ b/load-tests/gradle/src/gatling/scala/Config.scala
@@ -4,6 +4,8 @@ import scala.collection.JavaConverters._
 object Config {
     val urlUnderTest = "https://ntbs-load-test.e32846b1ddf0432eb63f.northeurope.aksapp.io"
     val lengthOfTestInMinutes = sys.env.getOrElse("LOAD_TEST_DURATION_IN_MINUTES", "1").toInt
+    val firstNotification = sys.env.getOrElse("FIRST_NOTIFICATION", "300001").toInt
+    val numberOfNotifications = sys.env.getOrElse("NUMBER_OF_NOTIFICATIONS", "10000").toInt
     val cookieHeader = sys.env.getOrElse(
         "COOKIE_HEADER",
         "<insert cookie here>"

--- a/load-tests/gradle/src/gatling/scala/NtbsLoadTest.scala
+++ b/load-tests/gradle/src/gatling/scala/NtbsLoadTest.scala
@@ -34,7 +34,7 @@ class NtbsLoadTest extends Simulation {
         )
     }
     val creationFeeder = Iterator.continually(newNotificationInfomation())
-    val notificationFeeder = Iterator.continually(Map("notificationId" -> (300001 + Random.nextInt(10000))))
+    val notificationFeeder = Iterator.continually(Map("notificationId" -> (Config.firstNotification + Random.nextInt(Config.numberOfNotifications))))
 
     val dashboard = DashboardScenarioBuilder.build()
     val searchByFamilyName = SearchScenarioBuilder.buildFamilyNameSearch("Test")

--- a/ntbs-build/openshift-pipelines/image-streams/ntbs-image-stream.yml
+++ b/ntbs-build/openshift-pipelines/image-streams/ntbs-image-stream.yml
@@ -23,6 +23,30 @@ spec:
         scheduled: true
       referencePolicy:
         type: Local
+    - name: gradle
+      from:
+        kind: DockerImage
+        name: 'gradle:latest'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Local
+    - name: jre
+      from:
+        kind: DockerImage
+        name: 'openjdk:8-jre'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Local
+    - name: node-alpine
+      from:
+        kind: DockerImage
+        name: 'node:16-alpine'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Local
     - name: openshift-cli
       from:
         kind: DockerImage
@@ -35,6 +59,14 @@ spec:
       from:
         kind: DockerImage
         name: 'ntbscontainerregistry.azurecr.io/publish-dacpac:latest'
+      importPolicy:
+        scheduled: true
+      referencePolicy:
+        type: Local
+    - name: ubuntu
+      from:
+        kind: DockerImage
+        name: 'ubuntu:latest'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/ntbs-build/openshift-pipelines/pipelines/run-load-tests.yml
+++ b/ntbs-build/openshift-pipelines/pipelines/run-load-tests.yml
@@ -1,0 +1,91 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: run-load-tests
+  namespace: ntbs-build
+spec:
+  params:
+    - default: live
+      description: The version of the load tests to run
+      name: branch
+      type: string
+    - default: 'https://ntbs-uat.phe.nhs.uk'
+      description: The url of the site under test
+      name: url
+      type: string
+    - description: The authenticated token used to make requests to the site under test
+      name: token
+      type: string
+    - default: '30'
+      description: The length of the test in minutes
+      name: length_in_minutes
+      type: string
+    - default: '329414'
+      description: The ID of the first notification in the range under test
+      name: first_notification
+      type: string
+    - default: '2000'
+      description: The number of notifications in the range under test
+      name: number_of_notifications
+      type: string
+  tasks:
+    - name: git-clone
+      params:
+        - name: url
+          value: 'https://github.com/publichealthengland/ntbs_Beta.git'
+        - name: revision
+          value: $(params.branch)
+        - name: submodules
+          value: 'false'
+        - name: depth
+          value: '1'
+        - name: sslVerify
+          value: 'true'
+        - name: deleteExisting
+          value: 'true'
+        - name: verbose
+          value: 'true'
+        - name: subdirectory
+          value: ntbs
+      taskRef:
+        kind: ClusterTask
+        name: git-clone
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: run-gradle
+      params:
+        - name: token
+          value: $(params.token)
+        - name: gradle_directory
+          value: ntbs/load-tests/gradle
+        - name: url
+          value: $(params.url)
+        - name: length_in_minutes
+          value: $(params.length_in_minutes)
+        - name: first_notification
+          value: $(params.first_notification)
+        - name: number_of_notifications
+          value: $(params.number_of_notifications)
+      runAfter:
+        - git-clone
+      taskRef:
+        kind: Task
+        name: run-gradle
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+    - name: parse-results
+      params:
+        - name: gradle_directory
+          value: ntbs/load-tests/gradle
+      runAfter:
+        - run-gradle
+      taskRef:
+        kind: Task
+        name: parse-gradle-results
+      workspaces:
+        - name: output
+          workspace: shared-workspace
+  workspaces:
+    - name: shared-workspace

--- a/ntbs-build/openshift-pipelines/tasks/parse-gradle-results.yml
+++ b/ntbs-build/openshift-pipelines/tasks/parse-gradle-results.yml
@@ -1,0 +1,20 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: parse-gradle-results
+  namespace: ntbs-build
+spec:
+  params:
+    - name: gradle_directory
+      type: string
+  steps:
+    - image: >-
+        image-registry.openshift-image-registry.svc:5000/ntbs-build/ntbs-image-stream:node-alpine
+      name: parse-results
+      script: |
+        cd $(workspaces.output.path)/$(params.gradle_directory)
+        export "STATS_FILE=$(find . -name 'stats.js')"
+        node result-parser/result-parser.js $STATS_FILE
+  workspaces:
+    - description: The volume storing the gradle code
+      name: output

--- a/ntbs-build/openshift-pipelines/tasks/run-gradle.yml
+++ b/ntbs-build/openshift-pipelines/tasks/run-gradle.yml
@@ -1,0 +1,46 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: run-gradle
+  namespace: ntbs-build
+spec:
+  params:
+    - description: The url of the site under test
+      name: url
+      type: string
+    - description: The authenticated token used to make requests to the site under test
+      name: token
+      type: string
+    - description: The directory in which to run gradle
+      name: gradle_directory
+      type: string
+    - description: The length of the test in minutes
+      name: length_in_minutes
+      type: string
+    - description: The ID of the first notification in the range under test
+      name: first_notification
+      type: string
+    - description: The number of notifications in the range under test
+      name: number_of_notifications
+      type: string
+  steps:
+    - env:
+        - name: COOKIE_HEADER
+          value: $(params.token)
+        - name: LOAD_TEST_DURATION_IN_MINUTES
+          value: $(params.length_in_minutes)
+        - name: FIRST_NOTIFICATION
+          value: $(params.first_notification)
+        - name: NUMBER_OF_NOTIFICATIONS
+          value: $(params.number_of_notifications)
+        - name: URL_UNDER_TEST
+          value: $(params.url)
+      image: >-
+        image-registry.openshift-image-registry.svc:5000/ntbs-build/ntbs-image-stream:jre
+      name: run-gradle
+      script: |
+        cd $(workspaces.output.path)/$(params.gradle_directory)
+        bash gradlew gatlingRun-NtbsLoadTest --rerun-tasks
+  workspaces:
+    - description: The volume storing the gradle code
+      name: output


### PR DESCRIPTION
Allow the load tests to configure the range of existing notifications
