### PR TITLE
NTBS-3008 Redirect to notification overview when dismissing closed alert

### DIFF
--- a/ntbs-integration-tests/Alerts/DismissAlertTests.cs
+++ b/ntbs-integration-tests/Alerts/DismissAlertTests.cs
@@ -1,0 +1,79 @@
+﻿using System.Threading.Tasks;
+using ntbs_integration_tests.Helpers;
+using ntbs_service;
+using Xunit;
+
+namespace ntbs_integration_tests.Alerts
+{
+    public class DismissAlertTests : TestRunnerBase
+    {
+        public DismissAlertTests(NtbsWebApplicationFactory<Startup> factory) : base(factory)
+        {
+        }
+
+        public static string Dismiss(int alertId) => $"Alerts/{alertId}/Dismiss?page=Overview";
+        public static string NotificationOverview(int notificationId) => $"Notifications/{notificationId}";
+
+        [Fact]
+        public async Task DismissAlert_ClosesAlertAndReturnsToNotificationOverview()
+        {
+            // Arrange
+            var alertId = Utilities.ALERT_TO_DISMISS_ID;
+            var notificationOverviewPath = NotificationOverview(Utilities.NOTIFIED_ID);
+            var initialPage = await Client.GetAsync(notificationOverviewPath);
+            var initialDocument = await GetDocumentAsync(initialPage);
+            var alertElement = initialDocument.GetElementById($"alert-{alertId}");
+            Assert.NotNull(alertElement);
+
+            // Act
+            var response = await Client.SendVerificationPostAsync(initialPage, initialDocument, Dismiss(alertId), null);
+
+            // Assert
+            response.AssertRedirectTo(notificationOverviewPath);
+            var overviewPageAfterDismissal = await Client.GetAsync(notificationOverviewPath);
+            var documentAfterDismissal = await GetDocumentAsync(overviewPageAfterDismissal);
+            var alertElementAfterDismissal = documentAfterDismissal.GetElementById($"alert-{alertId}");
+            Assert.Null(alertElementAfterDismissal);
+        }
+
+        [Fact]
+        public async Task DismissClosedAlert_RedirectsToNotificationOverview()
+        {
+            // Arrange
+            var alertId = Utilities.CLOSED_ALERT_ID;
+            var notificationOverviewPath = NotificationOverview(Utilities.NOTIFIED_ID);
+            var initialPage = await Client.GetAsync(notificationOverviewPath);
+            var initialDocument = await GetDocumentAsync(initialPage);
+            var alertElement = initialDocument.GetElementById($"alert-{alertId}");
+            Assert.Null(alertElement);
+
+            // Act
+            var response = await Client.SendVerificationPostAsync(initialPage, initialDocument, Dismiss(alertId), null);
+
+            // Assert
+            response.AssertRedirectTo(notificationOverviewPath);
+            var overviewPageAfterDismissal = await Client.GetAsync(notificationOverviewPath);
+            var documentAfterDismissal = await GetDocumentAsync(overviewPageAfterDismissal);
+            var alertElementAfterDismissal = documentAfterDismissal.GetElementById($"alert-{alertId}");
+            Assert.Null(alertElementAfterDismissal);
+        }
+
+        [Fact]
+        public async Task AttemptToDismissNonExistentAlert_RedirectsToIndexPage()
+        {
+            // Arrange
+            var notAnAlertId = 999999;
+            var notificationOverviewPath = NotificationOverview(Utilities.NOTIFIED_ID);
+            var initialPage = await Client.GetAsync(notificationOverviewPath);
+            var initialDocument = await GetDocumentAsync(initialPage);
+            var alertElement = initialDocument.GetElementById($"alert-{notAnAlertId}");
+            Assert.Null(alertElement);
+
+            // Act
+            var response = await Client.SendVerificationPostAsync(initialPage, initialDocument, Dismiss(notAnAlertId), null);
+
+            // Assert
+            response.AssertRedirectTo("/");
+        }
+    }
+}

--- a/ntbs-integration-tests/Alerts/DismissAlertTests.cs
+++ b/ntbs-integration-tests/Alerts/DismissAlertTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 using ntbs_integration_tests.Helpers;
 using ntbs_service;
 using Xunit;
@@ -73,7 +74,7 @@ namespace ntbs_integration_tests.Alerts
             var response = await Client.SendVerificationPostAsync(initialPage, initialDocument, Dismiss(notAnAlertId), null);
 
             // Assert
-            response.AssertRedirectTo("/");
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         }
     }
 }

--- a/ntbs-integration-tests/Helpers/Utilities.cs
+++ b/ntbs-integration-tests/Helpers/Utilities.cs
@@ -113,6 +113,8 @@ namespace ntbs_integration_tests.Helpers
         public const int TRANSFER_ALERT_ID_TO_ACCEPT_2 = 20006;
 
         public const int DRAFT_DATA_QUALITY_ALERT = 20007;
+        public const int ALERT_TO_DISMISS_ID = 20008;
+        public const int CLOSED_ALERT_ID = 20009;
 
         public const int PATIENT_NOTIFICATION_GROUP_ID = 30001;
 
@@ -398,6 +400,18 @@ namespace ntbs_integration_tests.Helpers
                     AlertId = TRANSFER_REJECTED_ID,
                     NotificationId = NOTIFIED_ID,
                     AlertStatus = AlertStatus.Open
+                },
+                new DataQualityTreatmentOutcome12
+                {
+                    AlertId = ALERT_TO_DISMISS_ID,
+                    NotificationId = NOTIFIED_ID,
+                    AlertStatus = AlertStatus.Open
+                },
+                new DataQualityTreatmentOutcome12
+                {
+                    AlertId = CLOSED_ALERT_ID,
+                    NotificationId = NOTIFIED_ID,
+                    AlertStatus = AlertStatus.Closed
                 }
             };
         }

--- a/ntbs-service/DataAccess/AlertRepository.cs
+++ b/ntbs-service/DataAccess/AlertRepository.cs
@@ -10,6 +10,7 @@ namespace ntbs_service.DataAccess
 {
     public interface IAlertRepository
     {
+        Task<Alert> GetAlertByIdAsync(int alertId);
         Task<Alert> GetOpenAlertByIdAsync(int? alertId);
         Task<T> GetAlertByNotificationIdAndTypeAsync<T>(int notificationId) where T : Alert;
         Task<UnmatchedLabResultAlert> GetUnmatchedLabResultAlertForNotificationAndSpecimenAsync(int notificationId,
@@ -41,6 +42,11 @@ namespace ntbs_service.DataAccess
         public AlertRepository(NtbsContext context)
         {
             _context = context;
+        }
+
+        public async Task<Alert> GetAlertByIdAsync(int alertId)
+        {
+            return await _context.Alert.SingleOrDefaultAsync(m => m.AlertId == alertId);
         }
 
         public async Task<Alert> GetOpenAlertByIdAsync(int? alertId)

--- a/ntbs-service/Pages/Alerts/Dismiss.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/Dismiss.cshtml.cs
@@ -1,5 +1,4 @@
-﻿using System.Net;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ntbs_service.DataAccess;
@@ -29,13 +28,17 @@ namespace ntbs_service.Pages.Alerts
         {
             var alertToDismiss = await alertRepository.GetAlertByIdAsync(AlertId);
 
-            if (alertToDismiss is not null
-                && await authorizationService.IsUserAuthorizedToManageAlert(User, alertToDismiss))
+            if (alertToDismiss is null)
+            {
+                return BadRequest();
+            }
+
+            if (await authorizationService.IsUserAuthorizedToManageAlert(User, alertToDismiss))
             {
                 await alertService.DismissAlertAsync(AlertId, User.Username());
             }
 
-            if (Request.Query["page"] == "Overview" && alertToDismiss is not null)
+            if (Request.Query["page"] == "Overview")
             {
                 return RedirectToPage("/Notifications/Overview", new { alertToDismiss.NotificationId });
             }

--- a/ntbs-service/Pages/Alerts/Dismiss.cshtml.cs
+++ b/ntbs-service/Pages/Alerts/Dismiss.cshtml.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using ntbs_service.DataAccess;
@@ -26,14 +27,15 @@ namespace ntbs_service.Pages.Alerts
 
         public async Task<IActionResult> OnPostAsync()
         {
-            var alertToDismiss = await alertRepository.GetOpenAlertByIdAsync(AlertId);
+            var alertToDismiss = await alertRepository.GetAlertByIdAsync(AlertId);
 
-            if (await authorizationService.IsUserAuthorizedToManageAlert(User, alertToDismiss))
+            if (alertToDismiss is not null
+                && await authorizationService.IsUserAuthorizedToManageAlert(User, alertToDismiss))
             {
                 await alertService.DismissAlertAsync(AlertId, User.Username());
             }
 
-            if (Request.Query["page"] == "Overview")
+            if (Request.Query["page"] == "Overview" && alertToDismiss is not null)
             {
                 return RedirectToPage("/Notifications/Overview", new { alertToDismiss.NotificationId });
             }

--- a/ntbs-service/Pages/Errors/400.cshtml
+++ b/ntbs-service/Pages/Errors/400.cshtml
@@ -1,0 +1,27 @@
+﻿@page
+@using ntbs_service.Pages
+@model ErrorModel
+@{
+    ViewData["Title"] = "Bad Request";
+}
+
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Bad Request</h1>
+        <p class="govuk-body">
+          The request could not be processed because it contains invalid data.
+        </p>
+        <p class="govuk-body">
+          @if (Model.ShowRequestId)
+          {
+              <p>
+                  If error persists, contact helpdesk and quote <strong>Request ID:</strong> <code>@Model.RequestId</code>
+              </p>
+          }
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/ntbs-service/Pages/Index.cshtml
+++ b/ntbs-service/Pages/Index.cshtml
@@ -86,12 +86,18 @@
                                 <nhs-table-item heading-text="Dismiss">
                                     @if (!item.NotDismissable)
                                     {
-                                        <form method="post" action="@RouteHelper.GetAlertPath(@item.AlertId, AlertSubPaths.Dismiss)">
-                                            @Html.AntiForgeryToken()
-                                            <button class="button-link nhsuk-link govuk-link--no-visited-state govuk-link" aria-label="Dismiss alert">
-                                                X
-                                            </button>
-                                        </form>
+                                        <single-submit-form inline-template>
+                                            <form method="post"
+                                                  action="@RouteHelper.GetAlertPath(@item.AlertId, AlertSubPaths.Dismiss)"
+                                                  v-on:submit="disableButton">
+                                                @Html.AntiForgeryToken()
+                                                <button class="button-link nhsuk-link govuk-link--no-visited-state govuk-link"
+                                                        aria-label="Dismiss alert"
+                                                        ref="submitButton">
+                                                    X
+                                                </button>
+                                            </form>
+                                        </single-submit-form>
                                     }
                                 </nhs-table-item>
                             </nhs-table-body-row>

--- a/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
+++ b/ntbs-service/Pages/Shared/_AlertsAndActions.cshtml
@@ -32,14 +32,19 @@
                                 }
                                 @if (!alert.NotDismissable)
                                 {
-                                    <form method="post" action="@RouteHelper.GetAlertPath(@alert.AlertId, AlertSubPaths.Dismiss)?page=Overview"
-                                          class="dismiss-alert-button--overview-view">
-                                        @Html.AntiForgeryToken()
-                                        <button class="button-link nhsuk-link govuk-link--no-visited-state govuk-link"
-                                                aria-label="Dismiss alert">
-                                            X
-                                        </button>
-                                    </form>
+                                    <single-submit-form inline-template>
+                                        <form method="post"
+                                              action="@RouteHelper.GetAlertPath(@alert.AlertId, AlertSubPaths.Dismiss)?page=Overview"
+                                              class="dismiss-alert-button--overview-view"
+                                              v-on:submit="disableButton">
+                                            @Html.AntiForgeryToken()
+                                            <button class="button-link nhsuk-link govuk-link--no-visited-state govuk-link"
+                                                    aria-label="Dismiss alert"
+                                                    ref="submitButton">
+                                                X
+                                            </button>
+                                        </form>
+                                    </single-submit-form>
                                 }
                             </div>
                         }


### PR DESCRIPTION
When a request is made to dismiss an alert which is already closed, we allow the request to succeed, with a redirect to the notification overview page. (This is the same behaviour as if the alert was previously open).

The previous behaviour was that a null reference exception occurred and an Internal Server Error response was given. We believe that this was happening if the user clicked on the "Dismiss" link twice in quick succession.

## Checklist:
- [x] Automated tests are passing locally.