### PR TITLE
NTBS-2918 Cron job for redeploying UAT databases at 12 on Sunday

### DIFF
--- a/ntbs-build/openshift-pipelines/cron-jobs/publish-uat-databases-cron.yml
+++ b/ntbs-build/openshift-pipelines/cron-jobs/publish-uat-databases-cron.yml
@@ -1,0 +1,21 @@
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: publish-uat-databases-cron
+  namespace: ntbs-build
+spec:
+  schedule: 0 12 * * 0
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: notify-event-listener
+              image: busybox
+              args:
+                - wget
+                - '--spider'
+                - >-
+                  el-ntbs-publish-database-listener.ntbs-build.svc.cluster.local:8080
+          restartPolicy: Never

--- a/ntbs-build/openshift-pipelines/triggers/ntbs-publish-database-listener.yml
+++ b/ntbs-build/openshift-pipelines/triggers/ntbs-publish-database-listener.yml
@@ -1,0 +1,11 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: ntbs-publish-database-listener
+  namespace: ntbs-build
+spec:
+  serviceAccountName: pipeline
+  triggers:
+    - name: publish-uat-databases
+      template:
+        name: ntbs-publish-database-trigger

--- a/ntbs-build/openshift-pipelines/triggers/ntbs-publish-database-trigger.yml
+++ b/ntbs-build/openshift-pipelines/triggers/ntbs-publish-database-trigger.yml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: ntbs-publish-database-trigger
+  namespace: ntbs-build
+spec:
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        generateName: ntbs-publish-database-
+      spec:
+        params:
+          - name: deploy-migration
+            value: 'yes'
+          - name: deploy-specimen-matching
+            value: 'yes'
+          - name: deploy-reporting
+            value: 'no'
+          - name: environment
+            value: uat
+          - name: branch
+            value: live
+        pipelineRef:
+          name: ntbs-publish-database
+        serviceAccountName: pipeline
+        timeout: 15m0s
+        workspaces:
+          - name: shared-workspace
+            persistentVolumeClaim:
+              claimName: ntbs-build-pvc


### PR DESCRIPTION
As with all our openshift files, these are just here for reference, and in case we need to restore them to the cluster at some point.
