### PR TITLE
NTBS-3039 Move temporarily unavailable image to github container registry

### DIFF
--- a/scripts/publishTemporarilyUnavailablePageImage.ps1
+++ b/scripts/publishTemporarilyUnavailablePageImage.ps1
@@ -1,3 +1,5 @@
 # Rough script for quick build-and-release to a particular env
+# Follow the instructions in temporarily-unavailable/README.md to generate a personal access token and add it as an environment variable
+echo $env:GITHUB_TOKEN | docker login ghcr.io -u USERNAME --password-stdin
 docker build -t ghcr.io/publichealthengland/ntbs-service:temporarily-unavailable ./temporarily-unavailable/
 docker push ghcr.io/publichealthengland/ntbs-service:temporarily-unavailable

--- a/scripts/publishTemporarilyUnavailablePageImage.ps1
+++ b/scripts/publishTemporarilyUnavailablePageImage.ps1
@@ -1,3 +1,3 @@
 # Rough script for quick build-and-release to a particular env
-docker build -t ntbscontainerregistry.azurecr.io/temporarily-unavailable ./temporarily-unavailable/
-docker push ntbscontainerregistry.azurecr.io/temporarily-unavailable
+docker build -t ghcr.io/publichealthengland/ntbs-service:temporarily-unavailable ./temporarily-unavailable/
+docker push ghcr.io/publichealthengland/ntbs-service:temporarily-unavailable

--- a/temporarily-unavailable/README.md
+++ b/temporarily-unavailable/README.md
@@ -9,6 +9,14 @@ versioning system is used for the images.
 We use the same repository for the image as the main app - see `publishTemporarilyUnavailablePageImage.ps1` script for publishing
 the image.
 
+Before running the above script you must authenticate to the github container registry (information taken from https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+* Navigate to https://github.com/settings/tokens/new?scopes=write:packages to generate a new personal access token with write:packages enabled.
+* In powershell navigate to the ntbs_Beta folder.
+* Run `$env:CR_PAT='YOUR_TOKEN'`
+* Run `echo $env:CR_PAT | docker login ghcr.io -u USERNAME --password-stdin`
+* Run `scripts\publishTemporarilyUnavailablePageImage.ps1`
+
+
 ## Deploying
 The kubernetes definition files for the PHE environment include a set of resources to deploy the app. See comments in
 those files for choosing which app (temporarily-unavailable or ntbs-service) are being exposed on which url.

--- a/temporarily-unavailable/README.md
+++ b/temporarily-unavailable/README.md
@@ -12,10 +12,8 @@ the image.
 Before running the above script you must authenticate to the github container registry (information taken from https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
 * Navigate to https://github.com/settings/tokens/new?scopes=write:packages to generate a new personal access token with write:packages enabled.
 * In powershell navigate to the ntbs_Beta folder.
-* Run `$env:CR_PAT='YOUR_TOKEN'`
-* Run `echo $env:CR_PAT | docker login ghcr.io -u USERNAME --password-stdin`
+* Run `$env:GITHUB_TOKEN='YOUR_TOKEN'`
 * Run `scripts\publishTemporarilyUnavailablePageImage.ps1`
-
 
 ## Deploying
 The kubernetes definition files for the PHE environment include a set of resources to deploy the app. See comments in


### PR DESCRIPTION
## Description
Move temporarily unavailable image to github container registry

I have also updated the image source in the coming-soon deployment YAML file on openshift from 'ntbscontainerregistry.azurecr.io/temporarily-unavailable' to 'ghcr.io/publichealthengland/ntbs-service:temporarily-unavailable'