### PR TITLE
Ntbs 3018 UI tests in uat

### DIFF
--- a/ntbs-ui-tests/Features/CreateNotifications.feature
+++ b/ntbs-ui-tests/Features/CreateNotifications.feature
@@ -75,6 +75,7 @@ Feature: Notification creation
     And I can see the value '1234' for the field 'local-patient-id' in the 'PatientDetails' overview section
 
   Scenario: Create notification with all hospital details fields
+    Given Test is skipped when using cookie override for authentication
     When I click 'Hospital details' on the navigation bar
     Then I should be on the HospitalDetails page
     When I enter 1 into 'FormattedNotificationDate_Day'
@@ -353,6 +354,7 @@ Feature: Notification creation
     And I can see the value 'Unknown' for the field 'treated' in the 'PreviousHistory' overview section
 
   Scenario: Create notification with all treatment event fields
+    Given Test is skipped when using cookie override for authentication
     When I click 'Treatment events' on the navigation bar
     Then I should be on the TreatmentEvents page
     When I click on the 'add-new-treatment-event-button' button

--- a/ntbs-ui-tests/Features/EditNotifications.feature
+++ b/ntbs-ui-tests/Features/EditNotifications.feature
@@ -41,6 +41,7 @@ Feature: Notification editing
     And I can see the value '9866698' for the field 'local-patient-id' in the 'PatientDetails' overview section
 
   Scenario: Edit notification hospital details fields
+    Given Test is skipped when using cookie override for authentication
     When I go to edit the 'HospitalDetails' section
     Then I should be on the HospitalDetails page
     When I enter 2 into 'FormattedNotificationDate_Day'
@@ -317,6 +318,7 @@ Feature: Notification editing
     And I can see the value 'Angola' for the field 'treatment-country' in the 'PreviousHistory' overview section
 
   Scenario: Edit notification treatment event fields
+    Given Test is skipped when using cookie override for authentication
     When I go to edit the 'TreatmentEvents' section
     Then I should be on the TreatmentEvents page
     When I click on the Edit link

--- a/ntbs-ui-tests/Features/ImportLegacyNotification.feature
+++ b/ntbs-ui-tests/Features/ImportLegacyNotification.feature
@@ -1,6 +1,7 @@
 Feature: Import legacy notification
 
   Scenario: Import legacy notification
+    Given Test is skipped when using cookie override for authentication
     Given I navigate to the app
     And I have logged in as BirminghamServiceUser
     And I am on the Search page

--- a/ntbs-ui-tests/Features/PageLayouts.feature
+++ b/ntbs-ui-tests/Features/PageLayouts.feature
@@ -5,6 +5,7 @@ Feature: Page layouts
     And I have logged in as BirminghamServiceUser
     
   Scenario: The homepage has correct titles for tables
+    Given Test is skipped when using cookie override for authentication
     Given I am on the Homepage
     Then I can see the correct titles for the 'alerts-table' table
     Then I can see the correct titles for the 'draft-notifications-table' table

--- a/ntbs-ui-tests/Features/ReadOnlyUser.feature
+++ b/ntbs-ui-tests/Features/ReadOnlyUser.feature
@@ -1,9 +1,10 @@
 Feature: Read only user
 
   Background: Log in as read only user
+    Given Test is skipped when using cookie override for authentication
     Given I navigate to the app
     And I have logged in as ReadOnlyUser
-    
+
   Scenario: Read only user has no edit links abd view test result link on notification overview
     Given I am on seeded 'MAXIMUM_DETAILS' notification overview page
 

--- a/ntbs-ui-tests/Features/TransferNotification.feature
+++ b/ntbs-ui-tests/Features/TransferNotification.feature
@@ -1,6 +1,7 @@
 Feature: Transfer notification
 
   Background: Create a transfer request
+    Given Test is skipped when using cookie override for authentication
     Given I navigate to the app
     And I have logged in as BirminghamServiceUser
     And I am on seeded 'MAXIMUM_DETAILS' notification overview page

--- a/ntbs-ui-tests/Hooks/TestConfig.cs
+++ b/ntbs-ui-tests/Hooks/TestConfig.cs
@@ -28,6 +28,10 @@ namespace ntbs_ui_tests.Hooks
         public string EnvironmentUnderTest { get; set; }
 
         public EnvironmentConfig EnvironmentConfig => Environments[EnvironmentUnderTest];
+
+        public string AuthenticatedCookieHeader { get; set; }
+
+        public bool UseCookieOverride => !string.IsNullOrWhiteSpace(AuthenticatedCookieHeader);
     }
 
     public class EnvironmentConfig
@@ -35,8 +39,11 @@ namespace ntbs_ui_tests.Hooks
         public string ConnectionString { get; set; }
         public string MigrationConnectionString { get; set; }
         public string SpecimenConnectionString { get; set; }
-        public string RootUri { get; set; }
+        public string RootUriString { get; set; }
         public string ImportedNotificationNtbsEnvironment { get; set; }
+
+        private Uri uri;
+        public Uri RootUri => uri ??= new Uri(RootUriString);
     }
 
     public class UserConfig

--- a/ntbs-ui-tests/Steps/ActSteps.cs
+++ b/ntbs-ui-tests/Steps/ActSteps.cs
@@ -33,7 +33,7 @@ namespace ntbs_ui_tests.Steps
         {
             WithErrorLogging(() =>
             {
-                Browser.Navigate().GoToUrl($"{Settings.EnvironmentConfig.RootUri}/Notifications/{TestContext.AddedNotificationIds.Single()}");
+                Browser.Navigate().GoToUrl($"{Settings.EnvironmentConfig.RootUriString}/Notifications/{TestContext.AddedNotificationIds.Single()}");
                 // Verify that the page has loaded
                 Assert.NotNull(Browser.FindElement(By.ClassName("notification-banner-title-text")));
             });
@@ -54,7 +54,7 @@ namespace ntbs_ui_tests.Steps
         {
             WithErrorLogging(() =>
             {
-                Browser.Navigate().GoToUrl($"{Settings.EnvironmentConfig.RootUri}/Logout");
+                Browser.Navigate().GoToUrl($"{Settings.EnvironmentConfig.RootUriString}/Logout");
             });
         }
 

--- a/ntbs-ui-tests/Steps/ArrangeSteps.cs
+++ b/ntbs-ui-tests/Steps/ArrangeSteps.cs
@@ -105,6 +105,9 @@ namespace ntbs_ui_tests.Steps
                     {
                         Browser.Manage().Cookies.AddCookie(new OpenQA.Selenium.Cookie(cookie.Name, cookie.Value));
                     }
+                    var user = Settings.Users["ManuallyLoggedInUser"];
+                    user.UserId = GetUserIdFromUsername(user.Username);
+                    TestContext.LoggedInUser = user;
                 }
                 else
                 {

--- a/ntbs-ui-tests/Steps/ArrangeSteps.cs
+++ b/ntbs-ui-tests/Steps/ArrangeSteps.cs
@@ -9,6 +9,7 @@ using ntbs_ui_tests.Helpers;
 using ntbs_ui_tests.Hooks;
 using OpenQA.Selenium;
 using TechTalk.SpecFlow;
+using TechTalk.SpecFlow.UnitTestProvider;
 
 namespace ntbs_ui_tests.Steps
 {
@@ -18,12 +19,23 @@ namespace ntbs_ui_tests.Steps
         private readonly IWebDriver Browser;
         private readonly TestConfig Settings;
         private readonly TestContext TestContext;
+        private readonly IUnitTestRuntimeProvider RuntimeProvider;
 
-        public ArrangeSteps(IWebDriver driver, TestConfig settings, TestContext testContext)
+        public ArrangeSteps(IWebDriver driver, TestConfig settings, TestContext testContext, IUnitTestRuntimeProvider unitTestRuntimeProvider)
         {
             Browser = driver;
             Settings = settings;
             TestContext = testContext;
+            RuntimeProvider = unitTestRuntimeProvider;
+        }
+
+        [Given(@"Test is skipped when using cookie override for authentication")]
+        public void GivenTestIsSkippedWhenFlagIsSet()
+        {
+            if (Settings.UseCookieOverride)
+            {
+                RuntimeProvider.TestIgnore("Test skipped because it cannot be performed using cookie override for authentication.");
+            }
         }
 
         #region Navigation

--- a/ntbs-ui-tests/Steps/AssertSteps.cs
+++ b/ntbs-ui-tests/Steps/AssertSteps.cs
@@ -52,7 +52,7 @@ namespace ntbs_ui_tests.Steps
         {
             WithErrorLogging(() =>
             {
-                Assert.Equal($"{Settings.EnvironmentConfig.RootUri}/", Browser.Url);
+                Assert.Equal($"{Settings.EnvironmentConfig.RootUriString}/", Browser.Url);
             });
         }
 

--- a/ntbs-ui-tests/testSettings.json
+++ b/ntbs-ui-tests/testSettings.json
@@ -4,32 +4,40 @@
       "Username": "birmingham-uitester@aptemus.com",
       "TbServiceCode": "TBS0019"
     },
-    "LeedsServiceUser":  {
+    "LeedsServiceUser": {
       "Username": "leeds-uitester@aptemus.com",
       "TbServiceCode": "TBS0003"
     },
-    "ReadOnlyUser":  {
+    "ReadOnlyUser": {
       "Username": "readonly-uitester@aptemus.com",
       "TbServiceCode": "TBS0003"
     }
   },
   "Environments": {
     "local": {
-      "RootUri": "https://localhost:5001",
+      "RootUriString": "https://localhost:5001",
       "ConnectionString": "data source=localhost;initial catalog=ntbsDev;trusted_connection=true;MultipleActiveResultSets=true;TrustServerCertificate=true",
       "MigrationConnectionString": "data source=localhost;initial catalog=ntbs_migration;trusted_connection=true;MultipleActiveResultSets=true;TrustServerCertificate=true",
       "SpecimenConnectionString": "data source=localhost;initial catalog=specimen-matching;trusted_connection=true;MultipleActiveResultSets=true;TrustServerCertificate=true",
       "ImportedNotificationNtbsEnvironment": "Dev"
     },
     "int": {
-      "RootUri": "https://ntbs-int.e32846b1ddf0432eb63f.northeurope.aksapp.io"
+      "RootUriString": "https://ntbs-int.e32846b1ddf0432eb63f.northeurope.aksapp.io"
     },
     "test": {
-      "RootUri": "https://ntbs-test.e32846b1ddf0432eb63f.northeurope.aksapp.io"
+      "RootUriString": "https://ntbs-test.e32846b1ddf0432eb63f.northeurope.aksapp.io"
     },
     "uat": {
-      "RootUri": "https://ntbs-uat.e32846b1ddf0432eb63f.northeurope.aksapp.io"
+      "RootUriString": "https://ntbs-uat.e32846b1ddf0432eb63f.northeurope.aksapp.io"
+    },
+    "phe-uat": {
+      "RootUriString": "https://ntbs-uat-hidden.apps.ocp-por.unix.phe.gov.uk",
+      "ConnectionString": "Server=SQLClusPorDC17.phe.gov.uk\\DC17;Database=NTBS_UAT;Integrated Security=true;TrustServerCertificate=true",
+      "MigrationConnectionString": "Server=SQLClusPorDC17.phe.gov.uk\\DC17;Database=NTBS_Migration_UAT;Integrated Security=true;TrustServerCertificate=true",
+      "SpecimenConnectionString": "Server=SQLClusPorDC17.phe.gov.uk\\DC17;Database=NTBS_Specimen_Matching_UAT;Integrated Security=true;TrustServerCertificate=true",
+      "ImportedNotificationNtbsEnvironment": "UatPheMigration"
     }
   },
-  "EnvironmentUnderTest": "local"
+  "EnvironmentUnderTest": "local",
+  "AuthenticatedCookieHeader": ""
 }

--- a/ntbs-ui-tests/testSettings.json
+++ b/ntbs-ui-tests/testSettings.json
@@ -11,6 +11,10 @@
     "ReadOnlyUser": {
       "Username": "readonly-uitester@aptemus.com",
       "TbServiceCode": "TBS0003"
+    },
+    "ManuallyLoggedInUser": {
+      "Username": "",
+      "TbServiceCode": "TBS0019"
     }
   },
   "Environments": {


### PR DESCRIPTION
Allow the UI tests to run against UAT.

There are 10 tests which I've had to skip, because they don't pass under the current framework. Mostly this is because the test is relying on the name of a user that doesn't exist in the environment. I'll create a follow on ticket to try and get some of these tests working.

I'm also going to create a follow on ticket to run these tests through an OpenShift pipeline, but there's not really any point working on that yet as the pipelines aren't working.