### PR TITLE
NTBS-3061: Only set AD groups and CMTBS for enabled users

### DIFF
--- a/ntbs-service/Services/AzureAdDirectoryService.cs
+++ b/ntbs-service/Services/AzureAdDirectoryService.cs
@@ -219,10 +219,11 @@ namespace ntbs_service.Services
             IEnumerable<TBService> tbServices,
             IEnumerable<string> groupNames)
         {
+            var accountEnabled = graphUser.AccountEnabled.HasValue && graphUser.AccountEnabled.Value;
 
-            var tbServicesMatchingGroups = tbServices
-                .Where(tb => groupNames.Contains(tb.ServiceAdGroup))
-                .ToList();
+            var tbServicesMatchingGroups = accountEnabled
+                ? tbServices.Where(tb => groupNames.Contains(tb.ServiceAdGroup)).ToList()
+                : new List<TBService>();
 
             var userName = graphUser.UserPrincipalName;
             if (IsUserExternal(graphUser))
@@ -240,9 +241,9 @@ namespace ntbs_service.Services
                 GivenName = graphUser.GivenName,
                 FamilyName = graphUser.Surname,
                 DisplayName = displayName,
-                IsActive = graphUser.AccountEnabled.HasValue && graphUser.AccountEnabled.Value,
-                AdGroups = string.Join(",", groupNames),
-                IsCaseManager = tbServicesMatchingGroups.Any()
+                IsActive = accountEnabled,
+                AdGroups = accountEnabled ? string.Join(",", groupNames) : null,
+                IsCaseManager = accountEnabled && tbServicesMatchingGroups.Any()
             };
 
             return (user, tbServicesMatchingGroups);


### PR DESCRIPTION
## Description
Only set AD groups, IsActive and any case manager TB services for enabled users. 
Do you think it's worth logging a warning that there's a user with AD group perms that isn't enabled when we find one? If we're going to have a report then it isn't hugely necessary, but it means we'd know sooner.

## Checklist:
- [x] Automated tests are passing locally.
