### PR TITLE
NTBS-3051: Allow dismiss on transfer rejection to only be clicked once

### DIFF
--- a/ntbs-service/Pages/Alerts/TransferRejected.cshtml
+++ b/ntbs-service/Pages/Alerts/TransferRejected.cshtml
@@ -21,15 +21,17 @@
 
     <div class="rejection-note"> @Model.TransferRejectedAlert.RejectionReason </div>
 
-    <form method="post" autocomplete="off">
-        <div class="flex-container">
-            <button nhs-button-type="Standard" id="cancel-transfer-button" classes="ntbsuk-button--primary confirm-transfer-button">
-                Dismiss
-            </button>
-            <nhs-back-link href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.Overview)" 
-                classes="transfer-request-back-link">
-                Go back
-            </nhs-back-link>
-        </div>
-    </form>
+    <single-submit-form inline-template>
+        <form method="post" autocomplete="off" v-on:submit="disableButton">
+            <div class="flex-container">
+                <button nhs-button-type="Standard" ref="submitButton" id="cancel-transfer-button" classes="ntbsuk-button--primary confirm-transfer-button">
+                    Dismiss
+                </button>
+                <nhs-back-link href="@RouteHelper.GetNotificationPath(Model.NotificationId, NotificationSubPaths.Overview)" 
+                               classes="transfer-request-back-link">
+                    Go back
+                </nhs-back-link>
+            </div>
+        </form>
+    </single-submit-form>
 </nhs-width-container>

--- a/ntbs-service/Pages/Search/Index.cshtml
+++ b/ntbs-service/Pages/Search/Index.cshtml
@@ -260,7 +260,7 @@
                           class="dismiss-alert-button--overview-view create-notification-button-container"
                           v-on:submit="disableButton">
                         <button nhs-button-type="Standard" type="submit" classes="ntbsuk-button--primary create-notification-button--right"
-                                id="search-button" aria-label="Create notification" ref="submitButton">
+                                id="create-button" aria-label="Create notification" ref="submitButton">
                             Create Notification
                         </button>
                     </form>
@@ -297,7 +297,7 @@
                           action="/Notifications/Create"
                           v-on:submit="disableButton">
                         <button nhs-button-type="Standard" type="submit" classes="ntbsuk-button--primary"
-                                id="search-button" aria-label="Create notification" ref="submitButton">
+                                aria-label="Create notification" ref="submitButton">
                             Create Notification
                         </button>
                     </form>


### PR DESCRIPTION
## Description
Another button which needed to disable multiple clicks - the dismiss button on the page which tells you about a rejected transfer.

## Checklist:
- [x] Automated tests are passing locally.
