### PR TITLE
NTBS-1417 change back link text when page has no editable content

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/_SaveButton.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/_SaveButton.cshtml
@@ -24,6 +24,8 @@
         buttonName = "Save";
     }
 
+    var backLinkText = pageHasEditableContent ? "Cancel & go back" : "Go back";
+
     var id = ViewData.ContainsKey("id") ? ViewData["id"] : "save-button";
 }
 
@@ -46,5 +48,5 @@
 
 @if (!isDraft)
 {
-    <nhs-back-link data-ignore-form-leave-checker="true" href="@RouteHelper.GetNotificationOverviewPathWithSectionAnchor(Model.NotificationId, currentPage)">Cancel & go back</nhs-back-link>
+    <nhs-back-link data-ignore-form-leave-checker="true" href="@RouteHelper.GetNotificationOverviewPathWithSectionAnchor(Model.NotificationId, currentPage)">@backLinkText</nhs-back-link>
 }


### PR DESCRIPTION
## Description
Change back link text when page has no editable content (social context - addresses, social context - venues and treatment events pages)

## Checklist:
- [x] Automated tests are passing locally.