### PR TITLE
NTBS-3090 Move publish cron job onto volume claim template

### DIFF
--- a/ntbs-build/openshift-pipelines/cron-jobs/cleanup-run-cron.yml
+++ b/ntbs-build/openshift-pipelines/cron-jobs/cleanup-run-cron.yml
@@ -1,0 +1,21 @@
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: cleanup-runs-cron
+  namespace: ntbs-build
+spec:
+  schedule: 0 0 * * *
+  concurrencyPolicy: Allow
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: notify-event-listener
+              image: busybox
+              args:
+                - wget
+                - '--spider'
+                - 'el-tekton-cleaner-listener.ntbs-build.svc.cluster.local:8080'
+              imagePullPolicy: Always
+          restartPolicy: Never

--- a/ntbs-build/openshift-pipelines/triggers/cleanup-runs.yml
+++ b/ntbs-build/openshift-pipelines/triggers/cleanup-runs.yml
@@ -1,0 +1,40 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: TriggerTemplate
+metadata:
+  name: cleanup-runs
+  namespace: ntbs-build
+spec:
+  params:
+    - default: '10080'
+      description: >-
+        Length of time in minutes to keep PipelineRuns and TaskRuns for (default
+        1 week)
+      name: keep
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: TaskRun
+      metadata:
+        generateName: ntbs-cleanup-
+      spec:
+        params:
+          - name: keep
+            value: $(tt.params.keep)
+        serviceAccountName: tekton-cleaner
+        taskSpec:
+          params:
+            - name: keep
+          steps:
+            - image: >-
+                image-registry.openshift-image-registry.svc:5000/ntbs-build/ntbs-image-stream:tekton-cli
+              name: cleanup-pipelineruns-and-taskruns
+              script: |
+                #!/bin/sh
+                set -ex
+                # A safety check, to avoid deleting too much!
+                if [[ $(params.keep) -eq 0 || $(params.keep) == "" ]]; then
+                  echo "This task cannot be used to delete *all* resources from a cluster" >&2
+                  echo "Please specifcy a value for keep > 0"
+                  exit 1
+                fi
+                tkn pr delete -n ntbs-build --keep-since $(params.keep)
+                tkn tr delete -n ntbs-build --keep-since $(params.keep)

--- a/ntbs-build/openshift-pipelines/triggers/ntbs-publish-database-trigger.yml
+++ b/ntbs-build/openshift-pipelines/triggers/ntbs-publish-database-trigger.yml
@@ -27,5 +27,10 @@ spec:
         timeout: 15m0s
         workspaces:
           - name: shared-workspace
-            persistentVolumeClaim:
-              claimName: ntbs-build-pvc
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 1Gi

--- a/ntbs-build/openshift-pipelines/triggers/tekton-cleaner-listener.yml
+++ b/ntbs-build/openshift-pipelines/triggers/tekton-cleaner-listener.yml
@@ -1,0 +1,11 @@
+apiVersion: triggers.tekton.dev/v1alpha1
+kind: EventListener
+metadata:
+  name: tekton-cleaner-listener
+  namespace: ntbs-build
+spec:
+  serviceAccountName: tekton-cleaner
+  triggers:
+    - name: cleanup-pipelineruns-and-taskruns
+      template:
+        name: cleanup-runs

--- a/ntbs-service/ntbs-service.csproj
+++ b/ntbs-service/ntbs-service.csproj
@@ -5,6 +5,7 @@
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
     <RootNamespace>ntbs_service</RootNamespace>
     <UserSecretsId>3736039d-9d74-48f5-9007-015e53f0b2a1</UserSecretsId>
+    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <LangVersion>10.0</LangVersion>


### PR DESCRIPTION
The initial change here was to use a volume claim template, rather than an explicit PVC, in the cron job to publish databases. This is so that the cron job will continue to work even if our PVC is retired, and a new one created.

However, while testing I discovered that used PVCs will only be deleted when all pipeline/task runs referencing them have been deleted. Therefore, in order to stop the number of PVCs that are hanging around in OpenShift from getting out of control, I've added a cleanup cron job so that pipeline/task runs older than 1 week will be deleted.
