### PR TITLE
NTBS-3095: Fix wording on social context venue page

### DIFF
--- a/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml
+++ b/ntbs-service/Pages/Notifications/Edit/SocialContextVenues.cshtml
@@ -17,7 +17,7 @@
 <h3>Regular venues visited by the patient</h3>
 <div>
     <input type="hidden" asp-for="NotificationId">
-    <p>Recording venues which the patient has regularly visited in the two years prior to TB diagnosis may help pin identifying transmissions settings.</p>
+    <p>Recording venues which the patient has regularly visited in the two years prior to TB diagnosis may help in identifying transmission settings.</p>
 
     @if(Model.SocialContextVenues.Count > 0)
     {


### PR DESCRIPTION
## Description
The original designs have the exact wording as "help pin identifying transmissions settings" here https://ntbs-uk.atlassian.net/browse/NTBS-427 so I am only 90% sure it's definitely wrong. But it must be!

## Checklist:
- [x] Automated tests are passing locally.
