### PR TITLE
NTBS-2832: Don't show overview share message to users with no permissions

### DIFF
--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -41,6 +41,7 @@ namespace ntbs_service.Pages.Notifications
         public DataQualityDraftAlert DraftAlert { get; set; }
         public PermissionLevel PermissionLevel { get; set; }
         public string PermissionReason { get; set; }
+        public bool ShowShareMessage { get; set; }
 
         [BindProperty(SupportsGet = true)]
         public int NotificationId { get; set; }
@@ -56,6 +57,7 @@ namespace ntbs_service.Pages.Notifications
             PermissionLevel = permissionLevel;
             PermissionReason = reason;
             NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel == PermissionLevel.None);
+            ShowShareMessage = Notification.IsShared && PermissionLevel != PermissionLevel.None;
         }
 
         protected async Task<bool> TryGetLinkedNotificationsAsync()

--- a/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
@@ -33,7 +33,7 @@
                 <div class="notification-overview-details-container no-print">
                     <nhs-inset-text classes="nhs-inset-text--ntbs">
                         <span>
-                            @if (Model.Notification.IsShared)
+                            @if (Model.ShowShareMessage)
                             {
                                 var serviceHref = $"/ServiceDirectory/Region/{Model.Notification.HospitalDetails.SecondaryTBService.PHECCode}" +
                                                   $"#accordion-heading-{Model.Notification.HospitalDetails.SecondaryTBServiceCode}";


### PR DESCRIPTION

## Description
Something that came back from QA

## Checklist:
- [x] Automated tests are passing locally.
