### PR TITLE
NTBS-3088 Show message when a transfer is pending

### DIFF
--- a/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
+++ b/ntbs-integration-tests/NotificationPages/OverviewPageTests.cs
@@ -195,7 +195,7 @@ namespace ntbs_integration_tests.NotificationPages
                 // Assert
                 Assert.Equal(HttpStatusCode.OK, response.StatusCode);
                 var document = await GetDocumentAsync(response);
-                Assert.Contains("This record is shared with", document.Body.TextContent);
+                Assert.Contains("This notification is shared with", document.Body.TextContent);
                 var link = (IHtmlAnchorElement)document.GetElementById("shared-service-link");
                 Assert.Contains(Utilities.TBSERVICE_GATESHEAD_AND_SOUTH_TYNESIDE_NAME, link.TextContent);
                 Assert.Contains(Utilities.NORTH_EAST_PHEC_CODE_GATESHEAD, link.Href);

--- a/ntbs-service/Models/Entities/NotificationDisplay.cs
+++ b/ntbs-service/Models/Entities/NotificationDisplay.cs
@@ -62,6 +62,8 @@ namespace ntbs_service.Models.Entities
 
         public bool IsShared => HospitalDetails.SecondaryTBServiceCode != null;
 
+        public bool? HasPendingTransfer => Alerts?.Any(a => a.AlertType == AlertType.TransferRequest && a.AlertStatus == AlertStatus.Open);
+
         private string CreateSitesOfDiseaseString()
         {
             if (NotificationSites == null)

--- a/ntbs-service/Pages/Notifications/NotificationModelBase.cs
+++ b/ntbs-service/Pages/Notifications/NotificationModelBase.cs
@@ -42,6 +42,7 @@ namespace ntbs_service.Pages.Notifications
         public PermissionLevel PermissionLevel { get; set; }
         public string PermissionReason { get; set; }
         public bool ShowShareMessage { get; set; }
+        public bool ShowPendingTransferMessage { get; set; }
 
         [BindProperty(SupportsGet = true)]
         public int NotificationId { get; set; }
@@ -58,6 +59,7 @@ namespace ntbs_service.Pages.Notifications
             PermissionReason = reason;
             NotificationBannerModel = new NotificationBannerModel(Notification, PermissionLevel == PermissionLevel.None);
             ShowShareMessage = Notification.IsShared && PermissionLevel != PermissionLevel.None;
+            ShowPendingTransferMessage = Notification.HasPendingTransfer == true && PermissionLevel != PermissionLevel.None;
         }
 
         protected async Task<bool> TryGetLinkedNotificationsAsync()

--- a/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
@@ -28,35 +28,40 @@
         </nhs-grid-column>
 
         <nhs-grid-column grid-column-width="Full">
-            @if ((!string.IsNullOrEmpty(Model.PermissionReason) || Model.Notification.IsShared) && isOverviewPage)
+            @if ((!string.IsNullOrEmpty(Model.PermissionReason) || Model.Notification.IsShared || Model.Notification.HasPendingTransfer == true) && isOverviewPage)
             {
                 <div class="notification-overview-details-container no-print">
                     <nhs-inset-text classes="nhs-inset-text--ntbs">
-                        <span>
+                        <ul>
                             @if (Model.ShowShareMessage)
                             {
                                 var serviceHref = $"/ServiceDirectory/Region/{Model.Notification.HospitalDetails.SecondaryTBService.PHECCode}" +
-                                                  $"#accordion-heading-{Model.Notification.HospitalDetails.SecondaryTBServiceCode}";
-                                <span>
-                                    This record is shared with <a id="shared-service-link" href="@serviceHref">@Model.Notification.HospitalDetails.SecondaryTBService?.Name</a>.
-                                </span>
+                                                    $"#accordion-heading-{Model.Notification.HospitalDetails.SecondaryTBServiceCode}";
+                                <li>
+                                    This notification is shared with <a id="shared-service-link" href="@serviceHref">@Model.Notification.HospitalDetails.SecondaryTBService?.Name</a>.
+                                </li>
+                            }
+                            @if (Model.Notification.HasPendingTransfer == true)
+                            {
+                                <li>This notification has a pending transfer.</li>
                             }
                             @if (!string.IsNullOrEmpty(Model.PermissionReason))
                             {
-                                @Model.PermissionReason
-                                @if (Model.PermissionLevel != PermissionLevel.Edit)
-                                {
-                                    <span>
-                                        See
-                                        <a href=@(_externalLinksService.GetSharePointFaqPageWithAnchor(Model.PermissionLevel))
-                                           target="_blank"
-                                           rel="noopener noreferrer">help</a>
-                                        for more information.
-                                    </span>
-                                    <br/>
-                                }
+                                <li>
+                                    @Model.PermissionReason
+                                    @if (Model.PermissionLevel != PermissionLevel.Edit)
+                                    {
+                                        <span>
+                                            See
+                                            <a href=@(_externalLinksService.GetSharePointFaqPageWithAnchor(Model.PermissionLevel))
+                                                target="_blank"
+                                                rel="noopener noreferrer">help</a>
+                                            for more information.
+                                        </span>
+                                    }
+                                </li>
                             }
-                        </span>
+                        </ul>
                     </nhs-inset-text>
                 </div>
             }

--- a/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
+++ b/ntbs-service/Pages/Shared/_NotificationOverviewLayout.cshtml
@@ -33,6 +33,10 @@
                 <div class="notification-overview-details-container no-print">
                     <nhs-inset-text classes="nhs-inset-text--ntbs">
                         <ul>
+                            @if (Model.ShowPendingTransferMessage)
+                            {
+                                <li>This notification has a pending transfer.</li>
+                            }
                             @if (Model.ShowShareMessage)
                             {
                                 var serviceHref = $"/ServiceDirectory/Region/{Model.Notification.HospitalDetails.SecondaryTBService.PHECCode}" +
@@ -40,10 +44,6 @@
                                 <li>
                                     This notification is shared with <a id="shared-service-link" href="@serviceHref">@Model.Notification.HospitalDetails.SecondaryTBService?.Name</a>.
                                 </li>
-                            }
-                            @if (Model.Notification.HasPendingTransfer == true)
-                            {
-                                <li>This notification has a pending transfer.</li>
                             }
                             @if (!string.IsNullOrEmpty(Model.PermissionReason))
                             {

--- a/ntbs-service/wwwroot/css/notificationView.scss
+++ b/ntbs-service/wwwroot/css/notificationView.scss
@@ -101,3 +101,15 @@
     margin: 0;
   }
 }
+
+.notification-overview-details-container {
+  ul {
+    padding: 0;
+  }
+
+  li {
+    margin: 0;
+    list-style: none;
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Description
Example screenshot:
![image](https://user-images.githubusercontent.com/8667373/159495426-a6e83e94-cb4b-4db2-9a1b-b8fe89d24d98.png)

At the moment, it will show the message to all users, whenever there is a pending transfer. This means that the information can be duplicated with the alert (as in the example above) but I think this looks ok.

## Checklist:
- [x] Automated tests are passing locally.
### Accessibility testing
Features with UI components should consider items on this list
- [x] Passes automated checker (e.g. [WAVE](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh))
