### PR TITLE
NTBS-3112 Use github container registry for publish-dacpac image

### DIFF
--- a/.github/workflows/build-publish-dacpac-image.yml
+++ b/.github/workflows/build-publish-dacpac-image.yml
@@ -1,0 +1,26 @@
+name: Build publish-dacpac image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-publish-job:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Log in to container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io/publichealthengland
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v2
+        with:
+          context: ntbs-build/publish-dacpac-image
+          push: true
+          tags: ghcr.io/publichealthengland/ntbs-service:publish-dacpac

--- a/ntbs-build/openshift-pipelines/image-streams/ntbs-image-stream.yml
+++ b/ntbs-build/openshift-pipelines/image-streams/ntbs-image-stream.yml
@@ -58,7 +58,7 @@ spec:
     - name: publish-dacpac
       from:
         kind: DockerImage
-        name: 'ntbscontainerregistry.azurecr.io/publish-dacpac:latest'
+        name: 'ghcr.io/publichealthengland/ntbs-service:publish-dacpac'
       importPolicy:
         scheduled: true
       referencePolicy:

--- a/ntbs-build/openshift-pipelines/tasks/deploy-image.yml
+++ b/ntbs-build/openshift-pipelines/tasks/deploy-image.yml
@@ -27,7 +27,7 @@ spec:
 
         echo "Updating build image to $(inputs.params.image_tag)"
 
-        oc set image deployment/$deployment_name $deployment_name=ntbscontainerregistry.azurecr.io/ntbs-service:$(inputs.params.image_tag)
+        oc set image deployment/$deployment_name $deployment_name=ghcr.io/publichealthengland/ntbs-service:$(inputs.params.image_tag)
 
         echo "Finished updating build image"
       workingDir: /workspace/output

--- a/ntbs-build/publish-dacpac-image/Dockerfile
+++ b/ntbs-build/publish-dacpac-image/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:latest AS build
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+RUN curl -L https://go.microsoft.com/fwlink/?linkid=2157202 --output sqlpackage.zip
+RUN mkdir sqlpackage
+RUN unzip sqlpackage.zip -d sqlpackage
+RUN chmod a+x ~/sqlpackage/sqlpackage
+
+FROM ubuntu:latest
+COPY --from=build /root/sqlpackage /root/sqlpackage
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
+    libunwind8 \
+    libicu66 \
+    && rm -rf /var/lib/apt/lists/*

--- a/ntbs-build/publish-dacpac-image/README.md
+++ b/ntbs-build/publish-dacpac-image/README.md
@@ -1,0 +1,5 @@
+This Dockerfile is designed to build an image called `publish-dacpac`.
+
+The `publish-dacpac` image is consumed by the OpenShift pipelines, and used to publish a DACPAC to a database based on a publish profile.
+
+There is a github action in this repository which will build the image and push it to the github container registry. This action can be triggered manually.


### PR DESCRIPTION
Remove all refereneces to the now defunct `ntbscontainerregistry`.

Add an action to build the `publish-dacpac` image and push it to the github container registry.

Update the image stream in OpenShift so that it sources the `publish-dacpac` image from the correct location.