### PR TITLE
NTBS-3112 Add kerberos to container

### DIFF
--- a/ntbs-build/publish-dacpac-image/Dockerfile
+++ b/ntbs-build/publish-dacpac-image/Dockerfile
@@ -16,4 +16,6 @@ COPY --from=build /root/sqlpackage /root/sqlpackage
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y --no-install-recommends \
     libunwind8 \
     libicu66 \
+    krb5-user \
+    procps \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I've added a dependency that was somehow missing from the previous Dockerfile.

I've tested this by re-deploying to UAT and it's definitely working now.