### PR TITLE
NTBS 3123 - remove references to Sentry

### DIFF
--- a/ntbs-service/package.json
+++ b/ntbs-service/package.json
@@ -18,8 +18,6 @@
   "dependencies": {
     "@babel/core": "7.17.5",
     "@babel/preset-env": "7.16.11",
-    "@sentry/browser": "6.18.1",
-    "@sentry/integrations": "6.18.1",
     "accessible-autocomplete": "2.0.4",
     "axios": "0.26.0",
     "babel-loader": "8.2.3",
@@ -36,7 +34,6 @@
     "vue-accessible-modal": "0.4.0"
   },
   "devDependencies": {
-    "@sentry/webpack-plugin": "1.18.8",
     "@types/node": "17.0.21",
     "@types/webpack-env": "1.16.3",
     "css-loader": "6.6.0",

--- a/ntbs-service/webpack.prod.js
+++ b/ntbs-service/webpack.prod.js
@@ -1,14 +1,14 @@
 const merge = require('webpack-merge').merge;
 const webpack = require('webpack');
 const common = require('./webpack.common.js');
-const SentryWebpackPlugin = require('@sentry/webpack-plugin');
+//const SentryWebpackPlugin = require('@sentry/webpack-plugin');
 
 const plugins = [
     new webpack.NormalModuleReplacementPlugin(/(.*)-APP_TARGET(\.*)/, function (resource) {
         resource.request = resource.request.replace(/-APP_TARGET/, `-production`);
     })
 ];
-
+/*
 if (process.env.RELEASE && process.env.SENTRY_AUTH_TOKEN) {
     plugins.push(new SentryWebpackPlugin({
         release: process.env.RELEASE,
@@ -19,7 +19,7 @@ if (process.env.RELEASE && process.env.SENTRY_AUTH_TOKEN) {
 } else {
     console.warn(  "Cannot publish sentry release, make sure RELEASE and SENTRY_AUTH_TOKEN env variables are set")
 }
-
+*/
 module.exports = merge(common, {
     mode: 'production',
     devtool: 'source-map',

--- a/ntbs-service/webpack.prod.js
+++ b/ntbs-service/webpack.prod.js
@@ -1,25 +1,13 @@
 const merge = require('webpack-merge').merge;
 const webpack = require('webpack');
 const common = require('./webpack.common.js');
-//const SentryWebpackPlugin = require('@sentry/webpack-plugin');
 
 const plugins = [
     new webpack.NormalModuleReplacementPlugin(/(.*)-APP_TARGET(\.*)/, function (resource) {
         resource.request = resource.request.replace(/-APP_TARGET/, `-production`);
     })
 ];
-/*
-if (process.env.RELEASE && process.env.SENTRY_AUTH_TOKEN) {
-    plugins.push(new SentryWebpackPlugin({
-        release: process.env.RELEASE,
-        include: '.',
-        ignoreFile: '.sentrycliignore',
-        ignore: ['node_modules', 'webpack.config.js']
-    }));
-} else {
-    console.warn(  "Cannot publish sentry release, make sure RELEASE and SENTRY_AUTH_TOKEN env variables are set")
-}
-*/
+
 module.exports = merge(common, {
     mode: 'production',
     devtool: 'source-map',

--- a/ntbs-service/wwwroot/source/app.ts
+++ b/ntbs-service/wwwroot/source/app.ts
@@ -53,14 +53,6 @@ import SingleSubmitForm from "./Components/SingleSubmitForm";
 require("es6-promise").polyfill();
 require("./Polyfills/ArrayFromPolyfill");
 
-/*
-if (config.env === "production") {
-    Sentry.init({
-        dsn: 'https://83b245064a684fa7ac86658bf38d2ad3@sentry.io/2862017', // identifies the sentry project
-        integrations: [new SentryIntegrations.Vue({Vue, attachProps: true, logErrors: true})],
-    });
-}
-*/
 Vue.use(VueAccessibleModal, { transition: "fade" });
 // register Vue components
 Vue.component("date-input", DateInput);

--- a/ntbs-service/wwwroot/source/app.ts
+++ b/ntbs-service/wwwroot/source/app.ts
@@ -8,8 +8,8 @@ import "../css/site.scss"
 import config from "./config/config-APP_TARGET";
 import Vue from "vue";
 import {initAll as govUkJsInitAll} from "govuk-frontend";
-import * as Sentry from '@sentry/browser';
-import * as SentryIntegrations from '@sentry/integrations';
+//import * as Sentry from '@sentry/browser';
+//import * as SentryIntegrations from '@sentry/integrations';
 // @ts-ignore
 import Details from '../../node_modules/nhsuk-frontend/packages/components/details/details';
 // @ts-ignore
@@ -53,13 +53,14 @@ import SingleSubmitForm from "./Components/SingleSubmitForm";
 require("es6-promise").polyfill();
 require("./Polyfills/ArrayFromPolyfill");
 
+/*
 if (config.env === "production") {
     Sentry.init({
         dsn: 'https://83b245064a684fa7ac86658bf38d2ad3@sentry.io/2862017', // identifies the sentry project
         integrations: [new SentryIntegrations.Vue({Vue, attachProps: true, logErrors: true})],
     });
 }
-
+*/
 Vue.use(VueAccessibleModal, { transition: "fade" });
 // register Vue components
 Vue.component("date-input", DateInput);


### PR DESCRIPTION
The build was failing because the Sentry project no longer exists

## Description
Removed references to Sentry from build code

Tested by deploying to dev and then performing action which would have previously resulted in a Sentry alert - no issues observed.
